### PR TITLE
Mint an invite code into the caller's own organization, not one they name

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -33940,7 +33940,7 @@
     },
     "/api/v1/employee/web/joinOrganization/userId/{userId}/organizationId/{orgId}": {
       "post": {
-        "description": "Creates an employee record linking the given user to the given organization, with the employment details supplied in the request body.",
+        "description": "Creates an employee record linking the given user to the organization named in the path, which must be the organization the caller's session is scoped to. Uses the employment details supplied in the request body.",
         "operationId": "joinOrganization",
         "parameters": [
           {
@@ -34011,7 +34011,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or named an organization that is not it"
           },
           "404": {
             "content": {
@@ -55702,7 +55702,7 @@
     },
     "/api/v1/invitation/web/generateCode/organizationId/{organizationId}": {
       "post": {
-        "description": "Generates a new invite code for the given organization.",
+        "description": "Generates a new invite code for the organization named in the path, which must be the organization the caller's session is scoped to.",
         "operationId": "createInviteCode",
         "parameters": [
           {
@@ -55764,7 +55764,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or named an organization that is not it"
           },
           "404": {
             "content": {
@@ -55825,7 +55825,7 @@
     },
     "/api/v1/invitation/web/organizationId/{organizationId}": {
       "get": {
-        "description": "Returns every invite code generated for the given organization.",
+        "description": "Returns every invite code generated for the organization named in the path, which must be the organization the caller's session is scoped to.",
         "operationId": "readAllInviteCodes",
         "parameters": [
           {
@@ -55880,7 +55880,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or named an organization that is not it"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
@@ -189,6 +189,37 @@ public class OrganizationSecurityService {
         return currentUserId != null && currentUserId.equals(userId);
     }
 
+    /**
+     * Checks that the organization the caller named is the one their session is scoped to.
+     *
+     * <p>For the endpoints that take an organization id from the caller and then load an
+     * {@code Organization} by it. That load is the one place tenant isolation cannot help:
+     * {@code Organization} is the tenant root, so it is not a {@code TenantScopedEntity},
+     * carries no {@code orgFilter}, and {@code TenantIsolationLoadListener} returns on its
+     * first line for anything that is not tenant-scoped. A caller-supplied id therefore
+     * resolves to any organization in the deployment unless a guard says otherwise.
+     *
+     * <p>Comparing against {@code TenantContext} is what makes it a check rather than a
+     * formality: {@code TenantFilter} only ever sets the current organization to one the
+     * caller holds an {@code ORG_MEMBER_} authority for, so equality with it establishes
+     * entitlement. Pair it with a role check, which answers what the caller may do; this
+     * answers where.
+     *
+     * <p>Usage in {@code @PreAuthorize}:
+     * {@code @orgSecurity.isCurrentTenant(#organizationId) and @orgSecurity.hasAnyOrgRoleForCurrentTenant('hr-admin')}
+     *
+     * @param organizationId the organization named by the caller
+     * @return true if it is the organization in force for this request
+     */
+    public boolean isCurrentTenant(Long organizationId) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        boolean result = orgId != null && orgId.equals(organizationId);
+        if (!result) {
+            log.debug("Current-tenant check refused organization {} against tenant {}", organizationId, orgId);
+        }
+        return result;
+    }
+
     public boolean isMemberOfCurrentTenant() {
         Long orgId = TenantContext.getCurrentOrgId();
         if (orgId == null) {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -59,16 +59,18 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} with the created employee's DTO and HTTP status 201 (Created).
      */
     @PostMapping("/joinOrganization/userId/{userId}/organizationId/{orgId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isCurrentTenant(#orgId)"
+            + " and @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Add a user to an organization as an employee",
-            description = "Creates an employee record linking the given user to the given organization, "
-                    + "with the employment details supplied in the request body."
+            description = "Creates an employee record linking the given user to the organization named "
+                    + "in the path, which must be the organization the caller's session is scoped to. "
+                    + "Uses the employment details supplied in the request body."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Employee record created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or named an organization that is not it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user or organization with the given id")
     })
     public ResponseEntity<EmployeeDto> joinOrganization(@PathVariable Long userId, @PathVariable Long orgId, @Valid @RequestBody EmployeeJoinOrgDto employeeJoinOrgDto) {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -108,8 +108,20 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
     @Query("SELECT e FROM Employee e JOIN e.orgRoles r WHERE e.organization.id = :orgId AND r = :role")
     List<Employee> findByOrganizationIdAndOrgRole(Long orgId, OrgRole role);
 
-    @Query("SELECT CASE WHEN COUNT(e) > 0 THEN true ELSE false END FROM Employee e JOIN e.orgRoles r WHERE e.id = :employeeId AND r IN :roles")
-    boolean existsByIdAndOrgRolesIn(@Param("employeeId") Long employeeId, @Param("roles") Set<OrgRole> roles);
+    /**
+     * Whether the employee holds one of the given roles <em>in the given organization</em>.
+     *
+     * <p>The organization predicate is written out rather than left to the {@code orgFilter}.
+     * The filter does cover this query, but a caller reading the method name has no way to
+     * know that, and the one call site refuses a manager with a message that claims an
+     * organization was checked. Saying it in the query makes the claim true wherever the
+     * method is used next, including anywhere the filter is bypassed or absent.
+     */
+    @Query("SELECT CASE WHEN COUNT(e) > 0 THEN true ELSE false END FROM Employee e JOIN e.orgRoles r "
+            + "WHERE e.id = :employeeId AND e.organization.id = :organizationId AND r IN :roles")
+    boolean existsByIdAndOrganization_IdAndOrgRolesIn(@Param("employeeId") Long employeeId,
+                                                     @Param("organizationId") Long organizationId,
+                                                     @Param("roles") Set<OrgRole> roles);
 
     boolean existsByIdAndOrganization_Id(Long id, Long organizationId);
 

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
@@ -47,40 +47,50 @@ public class ProjectInviteCodeController {
     }
 
     @GetMapping("/organizationId/{organizationId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isCurrentTenant(#organizationId)"
+            + " and @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "List invite codes for an organization",
-            description = "Returns every invite code generated for the given organization."
+            description = "Returns every invite code generated for the organization named in the path, "
+                    + "which must be the organization the caller's session is scoped to."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Invite codes returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or named an organization that is not it")
     })
     public ResponseEntity<List<ProjectInviteCodeDto>> readAllInviteCodes(@PathVariable Long organizationId) {
-        return ResponseEntity.status(HttpStatus.OK).body(projectInviteCodeService.readAllProjectInviteCodes(organizationId));
+        return ResponseEntity.status(HttpStatus.OK).body(projectInviteCodeService.readAllProjectInviteCodes());
     }
 
     /**
-     * Creates a new invite code for an organization.
+     * Creates a new invite code for the caller's organization.
+     *
+     * <p>The organization is named in the path for the sake of the published route, and the
+     * guard is what makes that name binding: it must be the organization this session is
+     * scoped to. The code itself is minted against the session's organization rather than
+     * against the path segment, so the two cannot drift apart.
      *
      * @param inviteCodeGenerationDto DTO containing the details for generating the invite code.
+     * @param organizationId          The organization named by the caller, read by the guard.
      * @return A {@link ResponseEntity} with the created invite code DTO and HTTP status 201 (Created).
      */
     @PostMapping("/generateCode/organizationId/{organizationId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isCurrentTenant(#organizationId)"
+            + " and @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Generate an invite code",
-            description = "Generates a new invite code for the given organization."
+            description = "Generates a new invite code for the organization named in the path, which "
+                    + "must be the organization the caller's session is scoped to."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Invite code created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or named an organization that is not it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
     })
     public ResponseEntity<ProjectInviteCodeDto> createInviteCode(@Valid @RequestBody InviteCodeGenerationDto inviteCodeGenerationDto,
                                                                  @PathVariable Long organizationId) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(projectInviteCodeService.generateInviteCode(inviteCodeGenerationDto,organizationId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(projectInviteCodeService.generateInviteCode(inviteCodeGenerationDto));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeService.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeService.java
@@ -9,6 +9,7 @@ import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.InvalidInviteCodeException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.exception.TenantIdMissingException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -72,20 +73,36 @@ public class ProjectInviteCodeService {
     }
 
     /**
-     * Generates a new invite code for an organization.
+     * Generates a new invite code for the caller's organization.
      * The code is created with specified validity, usage limits, and default employee details.
+     *
+     * <p>The organization comes from the session and never from the caller. An invite code is a
+     * credential for whichever organization it is bound to, and {@code Organization} is the one
+     * entity tenant isolation cannot cover: as the tenant root it is not a
+     * {@code TenantScopedEntity}, so it carries no {@code orgFilter} and
+     * {@code TenantIsolationLoadListener} returns before looking at it. A caller-supplied id
+     * reaching {@code findById} here would therefore mint a working code into any organization
+     * in the deployment, which is what #687 was. Reading the same key the guard checked is what
+     * keeps the two from drifting apart.
      *
      * @param inviteCodeGenerationDto DTO containing the details for generating the invite code.
      * @return A DTO of the newly created invite code.
+     * @throws TenantIdMissingException if the request carries no organization.
      * @throws ResourceNotFoundException if the organization is not found.
      * @throws DatabaseOperationException if the invite code cannot be saved.
      */
     @Transactional
-    public ProjectInviteCodeDto generateInviteCode(InviteCodeGenerationDto inviteCodeGenerationDto,Long organizationId) {
+    public ProjectInviteCodeDto generateInviteCode(InviteCodeGenerationDto inviteCodeGenerationDto) {
+        Long organizationId = TenantContext.getCurrentOrgId();
+        if (organizationId == null) {
+            throw new TenantIdMissingException(
+                    "No organization in context. An invite code is minted into the caller's own organization.");
+        }
         Organization organization = organizationRepository.findById(organizationId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + organizationId + " was not found"));
         if (inviteCodeGenerationDto.getManagerId() != null) {
-            if (!employeeRepository.existsByIdAndOrgRolesIn(inviteCodeGenerationDto.getManagerId(), OrgRole.getManagerRoles())) {
+            if (!employeeRepository.existsByIdAndOrganization_IdAndOrgRolesIn(
+                    inviteCodeGenerationDto.getManagerId(), organizationId, OrgRole.getManagerRoles())) {
                 throw new ResourceNotFoundException("Manager with ID " + inviteCodeGenerationDto.getManagerId() + " was not found with a manager role in this organization");
             }
         }
@@ -201,8 +218,25 @@ public class ProjectInviteCodeService {
         return projectInviteCodeMapper.toDto(updatedInviteCode);
     }
 
+    /**
+     * Lists the invite codes of the caller's organization.
+     *
+     * <p>Keyed on the session for the same reason as generation. The listing hands back the code
+     * values, so a caller-supplied key here decides who may read a credential; that the
+     * {@code orgFilter} on {@link ProjectInviteCode} would have turned a foreign key into an
+     * empty list is a property of the entity, not of this method, and it is not what should be
+     * carrying the decision.
+     *
+     * @return the organization's invite codes.
+     * @throws TenantIdMissingException if the request carries no organization.
+     */
     @Transactional(readOnly = true)
-    public List<ProjectInviteCodeDto> readAllProjectInviteCodes(Long organizationId) {
+    public List<ProjectInviteCodeDto> readAllProjectInviteCodes() {
+        Long organizationId = TenantContext.getCurrentOrgId();
+        if (organizationId == null) {
+            throw new TenantIdMissingException(
+                    "No organization in context. Invite codes are listed for the caller's own organization.");
+        }
         return inviteCodeRepository.findByOrganization_Id(organizationId)
                 .stream()
                 .map(projectInviteCodeMapper::toDto)

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationIT.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.category.CategoryRepository;
 import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
 import org.tornotron.echno_backend.common.exception.UnscopedTenantAccessException;
 import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +41,9 @@ class TenantIsolationIT extends AbstractIntegrationTest {
 
     @Autowired
     private CategoryRepository categoryRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -128,6 +132,22 @@ class TenantIsolationIT extends AbstractIntegrationTest {
             TenantContext.setCurrentOrgId(orgBId);
             assertThat(categoryRepository.findById(categoryId)).isPresent();
         }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void findById_onTheTenantRootItself_isNotCoveredByEitherMechanism() {
+        // Organization is the one entity neither defence reaches, and necessarily so: it is
+        // the tenant root, so it implements no TenantScopedEntity, carries no orgFilter, and
+        // the load listener returns on its first line for it. Another organization therefore
+        // loads by id under any tenant, as this proves against a real database.
+        //
+        // That is not a defect to fix in the mechanism, since the root cannot scope itself.
+        // It is the reason an endpoint that takes an organization id from the caller and
+        // resolves it here has to establish entitlement in its own guard, having nothing
+        // underneath to fall back on. #687 was such an endpoint.
+        TenantContext.setCurrentOrgId(orgAId);
+
+        assertThat(organizationRepository.findById(orgBId)).isPresent();
     }
 
     private Organization persistOrganization(String name) {

--- a/src/test/java/org/tornotron/echno_backend/common/service/OrganizationSecurityServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/OrganizationSecurityServiceTest.java
@@ -181,4 +181,25 @@ class OrganizationSecurityServiceTest {
         authWith("ORG_MEMBER_5");
         assertThat(svc.isSelfOrHasAnyOrgRole(7L, "hr-admin")).isFalse();
     }
+
+    @Test
+    void isCurrentTenant_trueOnlyForTheOrganizationInForce() {
+        TenantContext.setCurrentOrgId(5L);
+        assertThat(svc.isCurrentTenant(5L)).isTrue();
+        assertThat(svc.isCurrentTenant(6L)).isFalse();
+    }
+
+    @Test
+    void isCurrentTenant_falseWhenNoTenantIsInForce() {
+        // Fail closed. A null tenant is a request that never established one, so there is
+        // nothing to compare the named organization against and nothing to allow.
+        assertThat(svc.isCurrentTenant(5L)).isFalse();
+    }
+
+    @Test
+    void isCurrentTenant_falseForANullOrganization() {
+        // A route that binds no id at all must not read as "matches whatever is in force".
+        TenantContext.setCurrentOrgId(5L);
+        assertThat(svc.isCurrentTenant(null)).isFalse();
+    }
 }

--- a/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeServiceTest.java
@@ -11,6 +11,7 @@ import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.InvalidInviteCodeException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.exception.TenantIdMissingException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -28,6 +29,7 @@ import org.tornotron.echno_backend.projectInviteCode.mapper.ProjectInviteCodeMap
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -108,20 +110,20 @@ class ProjectInviteCodeServiceTest {
         when(organizationRepository.findById(ORG)).thenReturn(Optional.empty());
 
         assertThatExceptionOfType(ResourceNotFoundException.class)
-                .isThrownBy(() -> service.generateInviteCode(generationDto(), ORG));
+                .isThrownBy(() -> service.generateInviteCode(generationDto()));
         verify(inviteCodeRepository, never()).save(any());
     }
 
     @Test
     void generateInviteCode_managerWithoutManagerRole_throwsNotFound() {
         when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
-        when(employeeRepository.existsByIdAndOrgRolesIn(eq(MANAGER_ID), any())).thenReturn(false);
+        when(employeeRepository.existsByIdAndOrganization_IdAndOrgRolesIn(eq(MANAGER_ID), eq(ORG), any())).thenReturn(false);
 
         InviteCodeGenerationDto dto = generationDto();
         dto.setManagerId(MANAGER_ID);
 
         assertThatExceptionOfType(ResourceNotFoundException.class)
-                .isThrownBy(() -> service.generateInviteCode(dto, ORG));
+                .isThrownBy(() -> service.generateInviteCode(dto));
         verify(inviteCodeRepository, never()).save(any());
     }
 
@@ -139,7 +141,7 @@ class ProjectInviteCodeServiceTest {
         dto.setMaxUses(4);
         dto.setValidityDays(10);
 
-        service.generateInviteCode(dto, ORG);
+        service.generateInviteCode(dto);
 
         ArgumentCaptor<ProjectInviteCode> captor = ArgumentCaptor.forClass(ProjectInviteCode.class);
         verify(inviteCodeRepository).save(captor.capture());
@@ -170,7 +172,7 @@ class ProjectInviteCodeServiceTest {
         InviteCodeGenerationDto dto = generationDto();
         dto.setShiftTimingId(shiftId);
 
-        service.generateInviteCode(dto, ORG);
+        service.generateInviteCode(dto);
 
         ArgumentCaptor<ProjectInviteCode> captor = ArgumentCaptor.forClass(ProjectInviteCode.class);
         verify(inviteCodeRepository).save(captor.capture());
@@ -189,7 +191,7 @@ class ProjectInviteCodeServiceTest {
         dto.setShiftTimingId(shiftId);
 
         assertThatExceptionOfType(ResourceNotFoundException.class)
-                .isThrownBy(() -> service.generateInviteCode(dto, ORG));
+                .isThrownBy(() -> service.generateInviteCode(dto));
         verify(inviteCodeRepository, never()).save(any());
     }
 
@@ -200,7 +202,7 @@ class ProjectInviteCodeServiceTest {
         when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> inv.getArgument(0));
 
         assertThatExceptionOfType(DatabaseOperationException.class)
-                .isThrownBy(() -> service.generateInviteCode(generationDto(), ORG));
+                .isThrownBy(() -> service.generateInviteCode(generationDto()));
     }
 
     private ProjectInviteCode storedCode(boolean active, LocalDateTime expiry, int maxUses, int currentUses) {
@@ -337,7 +339,7 @@ class ProjectInviteCodeServiceTest {
     void generateInviteCode_checksManagerRolesSet() {
         when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
         Set<OrgRole> managerRoles = OrgRole.getManagerRoles();
-        lenient().when(employeeRepository.existsByIdAndOrgRolesIn(MANAGER_ID, managerRoles)).thenReturn(true);
+        lenient().when(employeeRepository.existsByIdAndOrganization_IdAndOrgRolesIn(MANAGER_ID, ORG, managerRoles)).thenReturn(true);
         when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> {
             ProjectInviteCode saved = inv.getArgument(0);
             saved.setId(INVITE_ID);
@@ -348,8 +350,76 @@ class ProjectInviteCodeServiceTest {
         InviteCodeGenerationDto dto = generationDto();
         dto.setManagerId(MANAGER_ID);
 
-        service.generateInviteCode(dto, ORG);
+        service.generateInviteCode(dto);
 
-        verify(employeeRepository).existsByIdAndOrgRolesIn(MANAGER_ID, managerRoles);
+        verify(employeeRepository).existsByIdAndOrganization_IdAndOrgRolesIn(MANAGER_ID, ORG, managerRoles);
+    }
+
+    // --- The organization an invite code is bound to comes from the session (#687) ---
+
+    @Test
+    void generateInviteCode_bindsTheCodeToTheSessionOrganization() {
+        // The method takes no organization argument at all, so there is no second key for a
+        // caller-supplied id to travel on. This asserts the one that remains is the session's.
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> {
+            ProjectInviteCode saved = inv.getArgument(0);
+            saved.setId(INVITE_ID);
+            return saved;
+        });
+        when(projectInviteCodeMapper.toDto(any())).thenReturn(new ProjectInviteCodeDto());
+
+        service.generateInviteCode(generationDto());
+
+        ArgumentCaptor<ProjectInviteCode> captor = ArgumentCaptor.forClass(ProjectInviteCode.class);
+        verify(inviteCodeRepository).save(captor.capture());
+        assertThat(captor.getValue().getOrganization().getId()).isEqualTo(ORG);
+        verify(organizationRepository).findById(ORG);
+    }
+
+    @Test
+    void generateInviteCode_withNoTenantInContext_mintsNothing() {
+        TenantContext.clear();
+
+        assertThatExceptionOfType(TenantIdMissingException.class)
+                .isThrownBy(() -> service.generateInviteCode(generationDto()));
+        verify(organizationRepository, never()).findById(any());
+        verify(inviteCodeRepository, never()).save(any());
+    }
+
+    @Test
+    void generateInviteCode_checksTheManagerWithinTheSessionOrganization() {
+        // The refusal message claims the manager was looked for in this organization. Before
+        // this it was looked for anywhere, and the claim rested on the Hibernate filter
+        // happening to be enabled rather than on the query.
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        when(employeeRepository.existsByIdAndOrganization_IdAndOrgRolesIn(
+                eq(MANAGER_ID), eq(ORG), any())).thenReturn(false);
+
+        InviteCodeGenerationDto dto = generationDto();
+        dto.setManagerId(MANAGER_ID);
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.generateInviteCode(dto));
+        verify(employeeRepository).existsByIdAndOrganization_IdAndOrgRolesIn(
+                eq(MANAGER_ID), eq(ORG), any());
+    }
+
+    @Test
+    void readAllProjectInviteCodes_readsTheSessionOrganization() {
+        when(inviteCodeRepository.findByOrganization_Id(ORG)).thenReturn(List.of());
+
+        service.readAllProjectInviteCodes();
+
+        verify(inviteCodeRepository).findByOrganization_Id(ORG);
+    }
+
+    @Test
+    void readAllProjectInviteCodes_withNoTenantInContext_readsNothing() {
+        TenantContext.clear();
+
+        assertThatExceptionOfType(TenantIdMissingException.class)
+                .isThrownBy(() -> service.readAllProjectInviteCodes());
+        verify(inviteCodeRepository, never()).findByOrganization_Id(any());
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeTenantGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeTenantGuardTest.java
@@ -1,0 +1,129 @@
+package org.tornotron.echno_backend.projectInviteCode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Proves that the invite-code endpoints refuse an organization the caller is not entitled to.
+ *
+ * <p>Both handlers name an organization in the path. A role check alone answers a different
+ * question: whether the caller holds the role in the organization their own session is scoped
+ * to. An hr-admin of one organization satisfies that while naming another, and generation is a
+ * write whose product is a credential for whichever organization was named.
+ *
+ * <p>Nothing underneath catches it. {@code Organization} is the tenant root, so it implements
+ * neither {@code TenantScopedEntity} nor carries the {@code orgFilter}, and
+ * {@code TenantIsolationLoadListener} returns on its first line for anything that is not
+ * tenant-scoped. Both defences are absent at exactly the point where a caller names an
+ * organization by id, so the guard has to ask the question itself.
+ *
+ * <p>{@code @orgSecurity} is mocked so the branches are exercised without building JWT group
+ * claims, and it is stubbed to behave as it would for a real hr-admin of organization
+ * {@link #OWN_ORG}: entitled to their own organization, not to {@link #FOREIGN_ORG}, and
+ * holding the role in the tenant their session is scoped to. The service is mocked and its
+ * return value is irrelevant here; what matters is whether the request reaches it at all.
+ */
+@WebMvcTest(ProjectInviteCodeController.class)
+@Import(ProjectInviteCodeTenantGuardTest.TestSecurityConfig.class)
+class ProjectInviteCodeTenantGuardTest {
+
+    private static final long OWN_ORG = 100L;
+    private static final long FOREIGN_ORG = 200L;
+
+    private static final String VALID_BODY = """
+            {"designation":"Engineer","department":"Civil","status":"ACTIVE","maxUses":1,"validityDays":5}
+            """;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProjectInviteCodeService projectInviteCodeService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @BeforeEach
+    void callerIsAnHrAdminOfTheirOwnOrganizationOnly() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(OWN_ORG)).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(FOREIGN_ORG)).thenReturn(false);
+    }
+
+    @Test
+    void generate_forAnotherOrganization_isForbiddenAndNeverReachesTheService() throws Exception {
+        mockMvc.perform(post("/api/v1/invitation/web/generateCode/organizationId/" + FOREIGN_ORG)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isForbidden());
+
+        // The refusal has to land before the code is minted. A 403 over a persisted invite
+        // would leave the credential in place for the listing to hand back.
+        verifyNoInteractions(projectInviteCodeService);
+    }
+
+    @Test
+    void generate_forTheCallersOwnOrganization_isStillAllowed() throws Exception {
+        mockMvc.perform(post("/api/v1/invitation/web/generateCode/organizationId/" + OWN_ORG)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void list_forAnotherOrganization_isForbiddenAndNeverReachesTheService() throws Exception {
+        mockMvc.perform(get("/api/v1/invitation/web/organizationId/" + FOREIGN_ORG).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(projectInviteCodeService);
+    }
+
+    @Test
+    void list_forTheCallersOwnOrganization_isStillAllowed() throws Exception {
+        mockMvc.perform(get("/api/v1/invitation/web/organizationId/" + OWN_ORG).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Closes #687.

## The defect

`POST /api/v1/invitation/web/generateCode/organizationId/{organizationId}` took the organization from the path. Its guard, `@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')`, establishes that the caller holds a role in the organization **their session is scoped to**, and never reads `#organizationId`. Those are different questions, and the second one was never asked. The service then resolved the named organization and bound a working invite code to it, returning the code value in the 201 body.

## Why nothing underneath caught it

Confirmed against the current code, since the fix only makes sense if this is right.

Tenant isolation here is a Hibernate `@Filter(name = "orgFilter")` on entities implementing `TenantScopedEntity`, enabled per `@Transactional` method by `HibernateFilterConfig` whenever `TenantContext.getCurrentOrgId()` is set, plus `TenantIsolationLoadListener`, which fail-closes on any loaded tenant-scoped row belonging to another organization. That pairing is why the other findings from the same sweep degrade to an empty list rather than a leak.

`Organization` sits outside both, and necessarily so, because it is the tenant root:

- it does not implement `TenantScopedEntity` and carries no `@Filter`, so `findById` resolves any organization in the deployment;
- `TenantIsolationLoadListener.onPostLoad` returns on its first line for anything that is not a `TenantScopedEntity`.

Both defences are therefore absent at exactly the point where a caller names an organization by id. This is a class of endpoint that has to check entitlement itself, not an annotation someone forgot. `TenantIsolationIT` now asserts that property against a real database, beside the cases that are covered, so the reasoning is checked rather than asserted in a comment.

## The fix

**A guard that establishes entitlement.** New `@orgSecurity.isCurrentTenant(organizationId)` compares the named organization against `TenantContext`. That is a real check rather than a restatement: `TenantFilter` only ever sets the current organization to one the caller holds an `ORG_MEMBER_` authority for, refusing the request outright otherwise. It fails closed on a null tenant and on a null argument. Paired with the existing role check, one answers where and the other answers what.

**A service that reads the same key.** `generateInviteCode` and `readAllProjectInviteCodes` drop their organization parameter and read `TenantContext`. The recurring shape in this repository is a guard checking one id while the service loads by another, so leaving the parameter in place would have left the next edit free to reintroduce it. The route keeps its path segment, so `echno-core` call sites are unchanged; the segment is now binding rather than decorative.

The listing moves for its own reason, not by symmetry: it hands back code values, so it decides who may read a credential, and that decision should not be resting on the entity's filter happening to cover it.

## Two more of the same shape

- `POST /api/v1/employee/web/joinOrganization/userId/{userId}/organizationId/{orgId}` carried the identical guard over an identical caller-supplied id, and its write is the worse one: it creates the employee row and adds the user to the Keycloak group for the named organization, which is the `ORG_MEMBER_` authority the whole tenant layer is built on. Same guard fix, applied here.
- The manager check inside generation refused with a message claiming the manager was looked for "in this organization" while the query carried no organization predicate. It now carries one, so the message is true wherever the method is used next rather than only where the Hibernate filter happens to be enabled.

The mobile twin of `joinOrganization` is guarded by a bare realm authority bound to no organization at all. Tightening it needs a decision about the mobile onboarding contract, so it is filed rather than changed here.

## Returning the code value

Kept, deliberately. The listing endpoint already returns code values to the same role, so withholding it from the 201 removes nothing an entitled caller cannot read a second later, while breaking the console flow that shows an admin the code they just created. The weaker part of this credential is its shape rather than where it is returned, and that is filed separately since changing it is a contract change across `echno-core` and the mobile app.

## Tests

| Test | What it holds | Red before the fix |
|---|---|---|
| `ProjectInviteCodeTenantGuardTest.generate_forAnotherOrganization_isForbiddenAndNeverReachesTheService` | a role holder naming another organization is refused, before the service runs | **measured** (was 201) |
| `ProjectInviteCodeTenantGuardTest.list_forAnotherOrganization_isForbiddenAndNeverReachesTheService` | same for the listing | **measured** (was 200) |
| `ProjectInviteCodeTenantGuardTest.generate_forTheCallersOwnOrganization_isStillAllowed` | the ordinary case is unaffected | passed before and after, by design |
| `ProjectInviteCodeTenantGuardTest.list_forTheCallersOwnOrganization_isStillAllowed` | same for the listing | passed before and after, by design |
| `OrganizationSecurityServiceTest.isCurrentTenant_*` (3 cases) | matches only the organization in force; fails closed on a null tenant and a null argument | new surface, nothing to measure |
| `ProjectInviteCodeServiceTest.generateInviteCode_bindsTheCodeToTheSessionOrganization` | the persisted code carries the session's organization | reasoned; does not compile against the old signature |
| `ProjectInviteCodeServiceTest.generateInviteCode_withNoTenantInContext_mintsNothing` | no tenant means no organization load and no save | reasoned, same reason |
| `ProjectInviteCodeServiceTest.readAllProjectInviteCodes_*` (2 cases) | the listing is keyed on the session and refuses without one | reasoned, same reason |
| `ProjectInviteCodeServiceTest.generateInviteCode_checksTheManagerWithinTheSessionOrganization` | the manager query carries the organization its message claims | reasoned, same reason |
| `TenantIsolationIT.findById_onTheTenantRootItself_isNotCoveredByEitherMechanism` | the tenant root loads across organizations, against a real database | documents the mechanism; passes either way |

The two measured reds were run against the unmodified controller with only the new `isCurrentTenant` helper added, so the test file as committed is the one that was measured. The remaining service cases cannot compile against the old two-argument signature and are not counted as measured.

`TenantIsolationIT` needs Testcontainers, which this workstation has no Docker for; CI runs it.

## OpenAPI

Only three operation descriptions and their 403 descriptions changed, and no structure. There is no Docker here to run `openApiSnapshot`, so the three blocks in `docs/openapi.json` were edited in place to the exact strings the annotations now produce, leaving the canonical form untouched. CI re-verifies against the served document.
