### PR TITLE
Give the attendance approvers somewhere to find what is waiting on them

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -25237,6 +25237,217 @@
         ]
       }
     },
+    "/api/v1/attendance/pending-approvals": {
+      "get": {
+        "description": "Returns the attendance days held for a geofence decision that the signed-in caller may decide: the days that name them as approver, and, for a holder of the attendance record-management roles, every other held day in the tenant, which is how the days no approver could be resolved for are reached. A caller's own days are never in it, because nobody approves their own absence from site whatever roles they hold. Newest day first, up to a fixed ceiling; the response carries X-Total-Count with the true number waiting, and X-Result-Capped when there were more than one response can hold.",
+        "operationId": "getPendingApprovals_3",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AttendanceResponseDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Records waiting on the caller returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to serve"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List the attendance days waiting on you",
+        "tags": [
+          "Attendance"
+        ]
+      }
+    },
+    "/api/v1/attendance/pending-approvals/count": {
+      "get": {
+        "description": "Returns how many attendance days are awaiting a decision from the signed-in caller, for the badge a client draws on the menu. Counted over the same set the listing serves.",
+        "operationId": "getPendingApprovalCount_3",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "additionalProperties": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Count returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to count"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Count the attendance days waiting on you",
+        "tags": [
+          "Attendance"
+        ]
+      }
+    },
     "/api/v1/attendance/project/{projectId}": {
       "get": {
         "description": "Returns a page of attendance records for a project on a given date, optionally filtered by status or a search term against the employee name, sorted by employee name.",
@@ -26055,6 +26266,217 @@
           }
         },
         "summary": "Mark an employee absent",
+        "tags": [
+          "Attendance (Web)"
+        ]
+      }
+    },
+    "/api/v1/attendance/web/pending-approvals": {
+      "get": {
+        "description": "Returns the attendance days held for a geofence decision that the signed-in caller may decide: the days that name them as approver, and, for a holder of the attendance record-management roles, every other held day in the tenant, which is how the days no approver could be resolved for are reached. A caller's own days are never in it, because nobody approves their own absence from site whatever roles they hold. Newest day first, up to a fixed ceiling; the response carries X-Total-Count with the true number waiting, and X-Result-Capped when there were more than one response can hold.",
+        "operationId": "getPendingApprovals_2",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AttendanceResponseDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Records waiting on the caller returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to serve"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List the attendance days waiting on you",
+        "tags": [
+          "Attendance (Web)"
+        ]
+      }
+    },
+    "/api/v1/attendance/web/pending-approvals/count": {
+      "get": {
+        "description": "Returns how many attendance days are awaiting a decision from the signed-in caller, for the badge a client draws on the menu. Counted over the same set the listing serves.",
+        "operationId": "getPendingApprovalCount_2",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "additionalProperties": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Count returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to count"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Count the attendance days waiting on you",
         "tags": [
           "Attendance (Web)"
         ]

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceApprovalQueueSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceApprovalQueueSpecifications.java
@@ -1,0 +1,108 @@
+package org.tornotron.echno_backend.attendance;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The attendance days waiting on one caller's decision, as a JPA {@link Specification}.
+ *
+ * <p>Written for issue #692. Since #681 a punch taken outside the project's geofence is held for a
+ * named person, and the decision worked from the first day: {@code AttendanceService.approve}
+ * accepts it, {@code AttendanceSecurityService.canDecideApproval} says who may take it. What was
+ * missing was any way to find the record. The two listings are a project on one required date and
+ * one employee over a range, so an approver could only reach a held day by already knowing it was
+ * there.
+ *
+ * <p>The predicate is written once and used by both the listing and its count, the way the
+ * regularization register's is, so the badge and the list it labels cannot come to disagree. The
+ * count is a real count query rather than a page total, so it stays right past the first page.
+ *
+ * <h2>Why the queue is the geofence exceptions rather than everything pending</h2>
+ *
+ * <p>{@code approvalStatus} starts at {@code PENDING} on every record ever created:
+ * {@code checkIn} builds it that way and nothing moves it until somebody decides the day. Pending
+ * is therefore the resting state of an ordinary attendance record, not a request for attention, and
+ * a queue of every pending record a caller may decide would hand an HR admin every attendance row
+ * in the organization. {@code requiresGeofenceApproval} is the flag that separates a day held for a
+ * decision from a day nobody has looked at, which is what the field was added for and what the
+ * entity documents it as.
+ *
+ * <p>So the queue is narrower than the set {@code canDecideApproval} accepts, and deliberately: it
+ * only ever offers records the approve endpoint would take, never one it would refuse.
+ *
+ * <h2>How it agrees with the two rules on the write path</h2>
+ *
+ * <p>{@code AttendanceService.requireActorMayApprove} refuses a self-approval on a flagged record
+ * before it looks at any role, then defers to {@code canDecideApproval}, which is the
+ * record-management roles plus the approver the record names. Read in that order:
+ *
+ * <ul>
+ *   <li>The employee's own held days are excluded outright, for every caller. A project manager
+ *       who marked from off site is refused their own record by the approve endpoint whatever
+ *       roles they hold, so offering it in their queue would draw a button the server answers
+ *       with a 403.</li>
+ *   <li>A caller holding the record-management roles sees every other held day in the tenant,
+ *       which is what carries the records {@code resolveApprover} could name nobody for. A null
+ *       {@code geofenceApproverId} widens who decides rather than stranding the record, and the
+ *       reporting-manager field is set on a small minority of employees today, so that is the
+ *       common case rather than the edge.</li>
+ *   <li>Any other caller sees the days that name them. The id is the one the server resolved and
+ *       stored at the time of the punch; the chain behind it is not walked again here, so the
+ *       queue cannot drift from the record.</li>
+ * </ul>
+ *
+ * <p>Organization scoping is deliberately absent, as it is on the regularization register: it
+ * comes from the Hibernate {@code orgFilter} enabled per request against {@link Attendance}, which
+ * is fail-closed since issue #507. It applies to the count query for the same reason it applies to
+ * the row query, both being criteria queries over the same filtered entity.
+ */
+public final class AttendanceApprovalQueueSpecifications {
+
+    /**
+     * The order the queue is read in.
+     *
+     * <p>Most recent day first, because that is the one an approver is most likely to be asked
+     * about, and the same order the regularization register settled on. The id breaks the tie
+     * between two days that fall on the same date, and being the primary key it is unique, so no
+     * two rows compare equal and no page boundary can fall inside a run of ties. Without a total
+     * order a page walk can hand back one record twice and never reach another, which on a queue
+     * means a held day nobody sees.
+     */
+    public static final Sort QUEUE_ORDER =
+            Sort.by(Sort.Order.desc("attendanceDate"), Sort.Order.desc("id"));
+
+    private AttendanceApprovalQueueSpecifications() {
+    }
+
+    /**
+     * The days waiting on this caller.
+     *
+     * @param callerEmployeeId The signed-in caller's employee id, resolved from the session and
+     *     never from the request. An id off the request would let any caller ask for a colleague's
+     *     queue, which is the defect #683 closed on the leave queue.
+     * @param decidesEveryRecord Whether the caller holds the attendance record-management roles,
+     *     the answer {@code AttendanceSecurityService.canManageRecords()} gives.
+     * @return A specification matching the pending geofence exceptions this caller may decide.
+     */
+    public static Specification<Attendance> waitingOn(Long callerEmployeeId,
+                                                      boolean decidesEveryRecord) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(root.get("approvalStatus"), ApprovalStatus.PENDING));
+            predicates.add(cb.isTrue(root.<Boolean>get("requiresGeofenceApproval")));
+            // Nobody decides their own absence from the site, whatever roles they hold.
+            predicates.add(cb.notEqual(root.get("employeeId"), callerEmployeeId));
+            if (!decidesEveryRecord) {
+                // A record naming nobody does not match here, and does not need to: it is the
+                // record managers' by the branch above.
+                predicates.add(cb.equal(root.get("geofenceApproverId"), callerEmployeeId));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -21,10 +21,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.attendance.dto.*;
 import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/attendance")
@@ -178,6 +180,51 @@ public class AttendanceController {
             @PathVariable Long id,
             @Valid @RequestBody AttendanceApprovalDto dto) {
         return ResponseEntity.ok(attendanceService.approveAttendance(id, dto));
+    }
+
+    // The queue is the caller's own and takes no parameters. Reading the approver from a query
+    // parameter under a guard that only asks for a role is the shape #683 took off the leave
+    // queue: the guard checks a role, the query reads a number the caller chose, and an
+    // administrator ends up able to read a colleague's queue while the approvers a chain is
+    // actually built from can read none of their own. The caller is resolved from the session in
+    // the service, so a caller that still sends approverId is served their own queue, a query
+    // parameter no handler declares being ignored.
+    @GetMapping("/pending-approvals")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List the attendance days waiting on you",
+            description = "Returns the attendance days held for a geofence decision that the signed-in "
+                    + "caller may decide: the days that name them as approver, and, for a holder of the "
+                    + "attendance record-management roles, every other held day in the tenant, which is "
+                    + "how the days no approver could be resolved for are reached. A caller's own days "
+                    + "are never in it, because nobody approves their own absence from site whatever "
+                    + "roles they hold. Newest day first, up to a fixed ceiling; the response carries "
+                    + "X-Total-Count with the true number waiting, and X-Result-Capped when there were "
+                    + "more than one response can hold."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Records waiting on the caller returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to serve")
+    })
+    public ResponseEntity<List<AttendanceResponseDto>> getPendingApprovals() {
+        return UnpagedResultCap.respond(
+                attendanceService.getPendingApprovals(0, UnpagedResultCap.MAX_ROWS));
+    }
+
+    @GetMapping("/pending-approvals/count")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Count the attendance days waiting on you",
+            description = "Returns how many attendance days are awaiting a decision from the signed-in "
+                    + "caller, for the badge a client draws on the menu. Counted over the same set the "
+                    + "listing serves."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to count")
+    })
+    public ResponseEntity<Map<String, Long>> getPendingApprovalCount() {
+        return ResponseEntity.ok(Map.of("count", attendanceService.getPendingApprovalCount()));
     }
 
     @PostMapping("/mark-absent")

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -21,10 +21,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.attendance.dto.*;
 import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/attendance/web")
@@ -176,6 +178,51 @@ public class AttendanceControllerWeb {
             @PathVariable Long id,
             @Valid @RequestBody AttendanceApprovalDto dto) {
         return ResponseEntity.ok(attendanceService.approveAttendance(id, dto));
+    }
+
+    // The queue is the caller's own and takes no parameters. Reading the approver from a query
+    // parameter under a guard that only asks for a role is the shape #683 took off the leave
+    // queue: the guard checks a role, the query reads a number the caller chose, and an
+    // administrator ends up able to read a colleague's queue while the approvers a chain is
+    // actually built from can read none of their own. The caller is resolved from the session in
+    // the service, so a caller that still sends approverId is served their own queue, a query
+    // parameter no handler declares being ignored.
+    @GetMapping("/pending-approvals")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List the attendance days waiting on you",
+            description = "Returns the attendance days held for a geofence decision that the signed-in "
+                    + "caller may decide: the days that name them as approver, and, for a holder of the "
+                    + "attendance record-management roles, every other held day in the tenant, which is "
+                    + "how the days no approver could be resolved for are reached. A caller's own days "
+                    + "are never in it, because nobody approves their own absence from site whatever "
+                    + "roles they hold. Newest day first, up to a fixed ceiling; the response carries "
+                    + "X-Total-Count with the true number waiting, and X-Result-Capped when there were "
+                    + "more than one response can hold."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Records waiting on the caller returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to serve")
+    })
+    public ResponseEntity<List<AttendanceResponseDto>> getPendingApprovals() {
+        return UnpagedResultCap.respond(
+                attendanceService.getPendingApprovals(0, UnpagedResultCap.MAX_ROWS));
+    }
+
+    @GetMapping("/pending-approvals/count")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Count the attendance days waiting on you",
+            description = "Returns how many attendance days are awaiting a decision from the signed-in "
+                    + "caller, for the badge a client draws on the menu. Counted over the same set the "
+                    + "listing serves."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to count")
+    })
+    public ResponseEntity<Map<String, Long>> getPendingApprovalCount() {
+        return ResponseEntity.ok(Map.of("count", attendanceService.getPendingApprovalCount()));
     }
 
     @PostMapping("/mark-absent")

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRepository.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.attendance;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
@@ -12,7 +13,15 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+/**
+ * Attendance rows.
+ *
+ * <p>{@link JpaSpecificationExecutor} is here for the approval queue added in issue #692:
+ * {@code AttendanceApprovalQueueSpecifications} builds one predicate that both the listing and its
+ * count are read through, so the badge and the list it labels cannot drift apart.
+ */
+public interface AttendanceRepository extends JpaRepository<Attendance, Long>,
+        JpaSpecificationExecutor<Attendance> {
 
     Optional<Attendance> findByEmployeeIdAndAttendanceDateAndProjectId(
             Long employeeId, LocalDate attendanceDate, Long projectId);

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -2,7 +2,10 @@ package org.tornotron.echno_backend.attendance;
 
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import jakarta.validation.ValidationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -551,6 +554,77 @@ public class AttendanceService {
         }
 
         return attendanceMapper.toResponseDto(attendanceRepository.save(attendance));
+    }
+
+    /**
+     * One page of the attendance days waiting on the signed-in caller's decision.
+     *
+     * <p>The routing built in #681 named an approver and had nowhere to show them what they had
+     * been named on. The only two listings are a project on one required date and one employee
+     * over a range, so an approver with people on several sites had to guess a site and a day, and
+     * a day held three days ago was invisible to anyone not already looking for it. A decision
+     * routed to a person who cannot find it does not get made.
+     *
+     * <p>The caller comes from the session and never from a parameter. The leave queue took an
+     * {@code approverId} under a guard that only asked for a role, so an administrator read any
+     * colleague's queue while the line managers a chain is built from could read none of their
+     * own; #683 took the parameter off, and this pair is built that way from the start.
+     *
+     * <p>What is in it, and why it is the geofence exceptions rather than everything pending, is
+     * argued in {@link AttendanceApprovalQueueSpecifications}. In short: every record is born
+     * {@code PENDING} and stays there until somebody decides it, so pending is an ordinary
+     * record's resting state and a queue of all of them would be the whole table.
+     *
+     * @param pageNo Zero-based page number.
+     * @param pageSize Rows per page.
+     * @return The page of records, newest day first.
+     * @throws AccessDeniedException if the caller has no employee record in this organization, so
+     *     there is nobody for a queue to belong to.
+     */
+    @Transactional(readOnly = true)
+    public Page<AttendanceResponseDto> getPendingApprovals(int pageNo, int pageSize) {
+        return attendanceRepository
+                .findAll(queueWaitingOnCaller("read your attendance approval queue"),
+                        PageRequest.of(pageNo, pageSize, AttendanceApprovalQueueSpecifications.QUEUE_ORDER))
+                .map(attendanceMapper::toResponseDto);
+    }
+
+    /**
+     * How many attendance days are waiting on the caller, for the badge a client draws on the menu.
+     *
+     * <p>A real count query over the same predicate the listing uses, rather than the size of a
+     * page of it. A page total is not a count once the queue is longer than a page, and Spring
+     * skips the count query altogether when the first page comes back short, so a badge built from
+     * a page would be right only while it did not matter.
+     *
+     * @return The number of records waiting on the caller.
+     * @throws AccessDeniedException if the caller has no employee record in this organization.
+     */
+    @Transactional(readOnly = true)
+    public long getPendingApprovalCount() {
+        return attendanceRepository.count(queueWaitingOnCaller("count your attendance approval queue"));
+    }
+
+    /**
+     * The queue predicate for whoever is signed in, refusing a caller there is no queue for.
+     *
+     * <p>Both halves of the queue read the caller the same way, so the badge cannot be counted for
+     * one person and the list served for another.
+     *
+     * @param action What the caller was trying to do, named in the refusal.
+     * @return The specification matching the days waiting on the caller.
+     * @throws AccessDeniedException if the caller has no employee record in this organization.
+     */
+    private Specification<Attendance> queueWaitingOnCaller(String action) {
+        Employee caller = resolveCurrentEmployee();
+        if (caller == null) {
+            throw new AccessDeniedException(
+                    "You have no employee record in this organization, so there is no attendance "
+                            + "approval queue that is yours. Ask an administrator to add you to the "
+                            + "organization as an employee before you " + action + ".");
+        }
+        return AttendanceApprovalQueueSpecifications.waitingOn(
+                caller.getId(), attendanceSecurity.canManageRecords());
     }
 
     /**

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -406,4 +406,7 @@
     <!-- v4.0 - Stock adjustments: name the document the correction answers, so a transfer variance can be closed and read as closed -->
     <include file="db/changelog/v4.0/090-add-stock-adjustment-source-document.xml"/>
 
+    <!-- v4.0 - Attendance: index the approval queue's predicate, which nothing queried before -->
+    <include file="db/changelog/v4.0/091-index-attendance-approval-queue.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/091-index-attendance-approval-queue.xml
+++ b/src/main/resources/db/changelog/v4.0/091-index-attendance-approval-queue.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="091-index-attendance-approval-queue" author="echno">
+        <comment>
+            The approval queue added in 692 asks a question nothing asked of this table before:
+            which days in this tenant are held for a geofence decision and still pending. Until now
+            requires_geofence_approval and geofence_approver_id were written when a punch fell
+            outside the fence and read back on the one record being decided, so neither was ever a
+            predicate over the table.
+
+            The queue is read on every visit to the approvals screen and again for the badge beside
+            it, over the one table that grows with every employee on every day on every project.
+            Without an index each read is a scan of the tenant's whole attendance history to find a
+            handful of held days, which stops being cheap exactly when a client has been using the
+            product long enough to have a history.
+
+            One composite rather than a column each, because the predicates are all equalities and
+            they always arrive together. organization_id leads it: the org filter is on every read
+            and is the most selective thing available. requires_geofence_approval and
+            approval_status follow, which is the whole predicate for a caller holding the
+            record-management roles, and geofence_approver_id sits last for the caller who is
+            named on the record rather than holding a role. A prefix of an index is usable on its
+            own, so the manager's three-column question is answered by the same index as the
+            approver's four-column one.
+
+            employee_id is deliberately not in it. It carries the "never your own record" rule,
+            which is an inequality and narrows nothing an index can help with.
+        </comment>
+
+        <createIndex tableName="attendance" indexName="idx_attendance_approval_queue">
+            <column name="organization_id"/>
+            <column name="requires_geofence_approval"/>
+            <column name="approval_status"/>
+            <column name="geofence_approver_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="attendance" indexName="idx_attendance_approval_queue"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/attendance/AttendanceApprovalQueueIT.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/AttendanceApprovalQueueIT.java
@@ -1,0 +1,278 @@
+package org.tornotron.echno_backend.attendance;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The attendance approval queue against a real CockroachDB: who sees which held day, and what the
+ * count says once the queue is longer than a page.
+ *
+ * <p>Issue #692. Exercised at the repository and specification rather than through the service,
+ * because that is where the two things at risk live: the {@code orgFilter} the criteria query
+ * inherits, and the count query, which is a separate statement from the one that returns rows.
+ * Who the caller is and how the two branches are chosen belong to the service and are pinned by
+ * {@link AttendanceApprovalQueueTest}.
+ *
+ * <p>The seed is built so that no assertion can pass by accident: every excluded row is excluded
+ * for exactly one reason, and each reason has a row of its own. A queue that dropped its status
+ * filter, its flag filter, its self-exclusion, its approver filter or its tenant scope fails a
+ * different test here.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AttendanceApprovalQueueIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private AttendanceRepository attendanceRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /** The employee a held day names as its approver. Holds no record-management role. */
+    private static final long APPROVER = 4100L;
+
+    /** A second named approver, so a filter that had stopped narrowing would be caught. */
+    private static final long OTHER_APPROVER = 4200L;
+
+    /** A caller who holds the record-management roles, so every held day is theirs to decide. */
+    private static final long RECORD_MANAGER = 4300L;
+
+    /** Ordinary employees whose days are the ones being held. */
+    private static final long WORKER_ONE = 7100L;
+    private static final long WORKER_TWO = 7200L;
+
+    private Long orgAId;
+    private Long orgBId;
+
+    /** Attendance is unique per employee, date and project, so each seeded row needs its own day. */
+    private int seededDay;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        disableOrgFilter();
+        seededDay = 0;
+
+        Organization orgA = persistOrganization("Queue Org A");
+        Organization orgB = persistOrganization("Queue Org B");
+        entityManager.flush();
+        orgAId = orgA.getId();
+        orgBId = orgB.getId();
+
+        // Waiting on APPROVER by name.
+        persistAttendance(orgA, WORKER_ONE, true, ApprovalStatus.PENDING, APPROVER);
+        // Waiting on nobody by name: resolveApprover found neither a reporting manager nor a
+        // project manager on the site. These fall to the record managers, and a queue keyed only
+        // on the id would leave them where nobody can see them.
+        persistAttendance(orgA, WORKER_TWO, true, ApprovalStatus.PENDING, null);
+        // Waiting on somebody else.
+        persistAttendance(orgA, WORKER_ONE, true, ApprovalStatus.PENDING, OTHER_APPROVER);
+        // Already decided: the decision is made, so it is nobody's queue any more.
+        persistAttendance(orgA, WORKER_ONE, true, ApprovalStatus.APPROVED, APPROVER);
+        // Pending but never held: this is the resting state of every attendance record ever
+        // created, and the row that makes "everything pending" the wrong query.
+        persistAttendance(orgA, WORKER_TWO, false, ApprovalStatus.PENDING, null);
+        // The record manager's own day off site, naming APPROVER. Nobody signs off their own
+        // absence from the site, whatever roles they hold.
+        persistAttendance(orgA, RECORD_MANAGER, true, ApprovalStatus.PENDING, APPROVER);
+        // The named approver's own day. Held, pending, and not theirs either.
+        persistAttendance(orgA, APPROVER, true, ApprovalStatus.PENDING, OTHER_APPROVER);
+
+        // The other tenant's held days carry the same approver id, which is the point: an id must
+        // narrow within a tenant and never across one.
+        persistAttendance(orgB, WORKER_ONE, true, ApprovalStatus.PENDING, APPROVER);
+        persistAttendance(orgB, WORKER_TWO, true, ApprovalStatus.PENDING, APPROVER);
+        persistAttendance(orgB, WORKER_ONE, true, ApprovalStatus.PENDING, OTHER_APPROVER);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @AfterEach
+    void cleanup() {
+        disableOrgFilter();
+        TenantContext.clear();
+    }
+
+    /**
+     * The named approver's queue is the days that name them, and nothing else.
+     *
+     * <p>Two of the seeded rows name APPROVER and are still pending and still held. The third row
+     * naming them has been decided, and the fourth is in the other tenant.
+     */
+    @Test
+    void theNamedApproverSeesTheHeldDaysThatNameThemAndNothingElse() {
+        enableOrgFilter(orgAId);
+
+        List<Attendance> queue = queueFor(APPROVER, false);
+
+        assertThat(queue)
+                .as("the worker's held day and the record manager's own, both naming this approver")
+                .hasSize(2)
+                .allSatisfy(row -> {
+                    assertThat(row.getGeofenceApproverId()).isEqualTo(APPROVER);
+                    assertThat(row.getRequiresGeofenceApproval()).isTrue();
+                    assertThat(row.getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING);
+                })
+                .extracting(Attendance::getEmployeeId)
+                .containsExactlyInAnyOrder(WORKER_ONE, RECORD_MANAGER);
+    }
+
+    /**
+     * A record manager sees the held days that name nobody, which a queue keyed on the id drops.
+     *
+     * <p>{@code resolveApprover} returns null when the employee has no reporting manager and no
+     * project manager is assigned to the site. The reporting-manager field is set on a small
+     * minority of employees on staging, so this is the ordinary case rather than the edge, and a
+     * record nobody can find is the failure this endpoint exists to fix.
+     */
+    @Test
+    void aRecordManagerSeesEveryHeldDayIncludingTheOnesNamingNobody() {
+        enableOrgFilter(orgAId);
+
+        List<Attendance> queue = queueFor(RECORD_MANAGER, true);
+
+        assertThat(queue)
+                .extracting(Attendance::getGeofenceApproverId)
+                .as("the record naming nobody is in the queue, alongside the ones naming others")
+                .containsExactlyInAnyOrder(APPROVER, null, OTHER_APPROVER, OTHER_APPROVER);
+    }
+
+    /**
+     * Nobody's own held day is in their queue, whichever branch put them there.
+     *
+     * <p>{@code requireActorMayApprove} refuses a self-approval on a held record ahead of the role
+     * check, so a record manager is refused their own day exactly as an ordinary employee is.
+     * Offering it in the queue would draw a button the server answers with a 403.
+     */
+    @Test
+    void nobodySeesTheirOwnHeldDay() {
+        enableOrgFilter(orgAId);
+
+        assertThat(queueFor(RECORD_MANAGER, true))
+                .as("the manager's own day off site is held and pending, and still not theirs")
+                .extracting(Attendance::getEmployeeId)
+                .doesNotContain(RECORD_MANAGER);
+
+        assertThat(queueFor(APPROVER, false))
+                .extracting(Attendance::getEmployeeId)
+                .doesNotContain(APPROVER);
+    }
+
+    /**
+     * The count is a count, not the length of the page beside it.
+     *
+     * <p>Spring's {@code PageableExecutionUtils} skips the count query when the first page comes
+     * back short and reports the row-list length as the total, so an assertion made on a short page
+     * proves nothing about counting. This asks for two of the record manager's four and reads the
+     * count separately: a badge built from the page would say two.
+     */
+    @Test
+    void theCountIsTheWholeQueueAndNotTheFirstPage() {
+        enableOrgFilter(orgAId);
+
+        Page<Attendance> firstPage = attendanceRepository.findAll(
+                AttendanceApprovalQueueSpecifications.waitingOn(RECORD_MANAGER, true),
+                PageRequest.of(0, 2, AttendanceApprovalQueueSpecifications.QUEUE_ORDER));
+
+        assertThat(firstPage.getContent())
+                .as("the page is deliberately smaller than the queue")
+                .hasSize(2);
+        assertThat(attendanceRepository.count(
+                AttendanceApprovalQueueSpecifications.waitingOn(RECORD_MANAGER, true)))
+                .as("four held days are waiting on this caller; a count that read the page would "
+                        + "say two, and one that ignored the tenant would say seven")
+                .isEqualTo(4);
+    }
+
+    /** The other tenant's queue holds its own rows only, read with the same approver id. */
+    @Test
+    void theQueueIsScopedToTheTenant() {
+        enableOrgFilter(orgBId);
+
+        assertThat(queueFor(APPROVER, false))
+                .as("two held days name this approver here, and the other tenant's two are not in it")
+                .hasSize(2)
+                .allSatisfy(row -> assertThat(row.getOrganization().getId()).isEqualTo(orgBId));
+    }
+
+    /** Newest day first, so a page walk visits every held day exactly once. */
+    @Test
+    void theQueueIsOrderedNewestDayFirst() {
+        enableOrgFilter(orgAId);
+
+        List<Attendance> queue = queueFor(RECORD_MANAGER, true);
+
+        assertThat(queue)
+                .extracting(Attendance::getAttendanceDate)
+                .isSortedAccordingTo(Comparator.reverseOrder());
+    }
+
+    private List<Attendance> queueFor(long callerEmployeeId, boolean decidesEveryRecord) {
+        return attendanceRepository.findAll(
+                        AttendanceApprovalQueueSpecifications
+                                .waitingOn(callerEmployeeId, decidesEveryRecord),
+                        PageRequest.of(0, 50, AttendanceApprovalQueueSpecifications.QUEUE_ORDER))
+                .getContent();
+    }
+
+    private void persistAttendance(Organization org, long employeeId, boolean held,
+                                   ApprovalStatus approvalStatus, Long geofenceApproverId) {
+        Attendance attendance = Attendance.builder()
+                .employeeId(employeeId)
+                .employeeName("Employee " + employeeId)
+                .attendanceDate(LocalDate.of(2026, 9, 1).plusDays(seededDay))
+                .projectId(1L)
+                .projectName("Tower A")
+                .status(AttendanceStatus.PRESENT)
+                // Set explicitly: the entity's builder carries no @Builder.Default for this, so
+                // the field initializer is bypassed and the column is NOT NULL.
+                .approvalStatus(approvalStatus)
+                .requiresGeofenceApproval(held)
+                .geofenceApproverId(geofenceApproverId)
+                .organization(org)
+                .build();
+        entityManager.persist(attendance);
+        seededDay++;
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void enableOrgFilter(Long orgId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", orgId);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/AttendanceApprovalQueueTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/AttendanceApprovalQueueTest.java
@@ -1,0 +1,335 @@
+package org.tornotron.echno_backend.attendance;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.validation.Validation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
+import org.tornotron.echno_backend.attendance.service.AttendanceCalculationService;
+import org.tornotron.echno_backend.attendance.service.AttendanceGeofenceService;
+import org.tornotron.echno_backend.attendance.service.AttendanceSettingsService;
+import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The attendance approval queue is the caller's own, and it asks for the same records the approve
+ * endpoint would accept.
+ *
+ * <p>Issue #692. The geofence routing built in #681 names an approver on the record and the
+ * decision has worked since; what did not exist was any way to find a record. The two listings are
+ * a project on one required date and one employee over a range, so a supervisor with people on
+ * several sites had to guess a site and a day, and a day held last week was invisible to anyone not
+ * already looking for it.
+ *
+ * <p>Two things are pinned here, and both are ways the same feature has gone wrong before.
+ *
+ * <p>The first is where the caller comes from. The leave queue took an {@code approverId} query
+ * parameter under a guard that only asked for a role, so an administrator read any colleague's
+ * queue while the line managers an approval chain is actually built from could read none of their
+ * own. That is the shape closed in #589, #599, #607, #631, #635 and #683, and again across the
+ * sweep findings #687 to #691. This pair takes no parameter at all: the id comes from the session,
+ * and the same resolution serves both the list and the count, so the badge cannot be counted for
+ * one person and the list served for another.
+ *
+ * <p>The second is what the predicate says, asserted against the criteria calls the specification
+ * actually makes rather than by reading it. A queue that offered a record the approve endpoint
+ * refuses draws a button the server answers with a 403, and the one refusal that is narrower than
+ * the role model is the self-approval rule: {@code requireActorMayApprove} puts it ahead of the
+ * role check, so a project manager's own day off site is not theirs to decide either.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AttendanceApprovalQueueTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long CALLER_USER_ID = 9100L;
+    private static final Long CALLER_EMPLOYEE_ID = 55L;
+
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private ShiftTimingRepository shiftTimingRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private ClockEventSequenceValidator sequenceValidator;
+    @Mock private AttendanceMapper attendanceMapper;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private UserContextService userContextService;
+    @Mock private AttendanceSecurityService attendanceSecurity;
+    @Mock private AttendanceGeofenceService geofenceService;
+
+    private AttendanceService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
+                organizationRepository, projectRepository, settingsService, calculationService,
+                sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
+                userContextService,
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
+                attendanceSecurity, geofenceService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private void signedInAsTheNamedApprover() {
+        Employee caller = new Employee();
+        caller.setId(CALLER_EMPLOYEE_ID);
+        when(userContextService.getCurrentUserId()).thenReturn(CALLER_USER_ID);
+        when(employeeRepository.findByUserIdAndOrganizationId(CALLER_USER_ID, ORG_ID))
+                .thenReturn(Optional.of(caller));
+    }
+
+    private void theCallerHasNoEmployeeRecordHere() {
+        when(userContextService.getCurrentUserId()).thenReturn(CALLER_USER_ID);
+        when(employeeRepository.findByUserIdAndOrganizationId(CALLER_USER_ID, ORG_ID))
+                .thenReturn(Optional.empty());
+    }
+
+    private void theQueueComesBackEmpty() {
+        when(attendanceRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+    }
+
+    // ── Where the caller comes from ──────────────────────────────────────────────────────────
+
+    @Test
+    void theQueueIsReadForTheSignedInCallerAndTakesNoApproverArgument() {
+        signedInAsTheNamedApprover();
+        theQueueComesBackEmpty();
+
+        assertThat(service.getPendingApprovals(0, UnpagedResultCap.MAX_ROWS).getContent()).isEmpty();
+
+        assertThat(capturedPredicates())
+                .as("the approver the queue is narrowed to is the caller's own employee id")
+                .containsEntry("geofenceApproverId", CALLER_EMPLOYEE_ID);
+    }
+
+    @Test
+    void theCountIsCountedForTheSameCallerTheListIsServedFor() {
+        signedInAsTheNamedApprover();
+        when(attendanceRepository.count(any(Specification.class))).thenReturn(7L);
+
+        assertThat(service.getPendingApprovalCount()).isEqualTo(7L);
+
+        ArgumentCaptor<Specification<Attendance>> captor = specificationCaptor();
+        verify(attendanceRepository).count(captor.capture());
+        assertThat(predicatesOf(captor.getValue()))
+                .containsEntry("geofenceApproverId", CALLER_EMPLOYEE_ID);
+    }
+
+    /**
+     * The badge is a count query, not the length of a page.
+     *
+     * <p>A page total cannot answer this once the queue is longer than a page, and Spring's
+     * {@code PageableExecutionUtils} does not even run the count query when the first page comes
+     * back short, so a badge derived from a listing would be right only while it did not matter.
+     * Seven waiting while the listing would have returned nothing is the shape that separates the
+     * two.
+     */
+    @Test
+    void theCountDoesNotComeFromTheListing() {
+        signedInAsTheNamedApprover();
+        when(attendanceRepository.count(any(Specification.class))).thenReturn(7L);
+        theQueueComesBackEmpty();
+
+        assertThat(service.getPendingApprovalCount()).isEqualTo(7L);
+
+        verify(attendanceRepository, never()).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordHereIsRefusedAQueueRatherThanServedSomebodyElses() {
+        theCallerHasNoEmployeeRecordHere();
+
+        assertThatThrownBy(() -> service.getPendingApprovals(0, UnpagedResultCap.MAX_ROWS))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(attendanceRepository, never()).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordHereIsRefusedTheCount() {
+        theCallerHasNoEmployeeRecordHere();
+
+        assertThatThrownBy(service::getPendingApprovalCount)
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(attendanceRepository, never()).count(any(Specification.class));
+    }
+
+    // ── What the predicate says ──────────────────────────────────────────────────────────────
+
+    /**
+     * The queue is the pending geofence exceptions, never the caller's own.
+     *
+     * <p>Pending on its own is not a queue: every record is created {@code PENDING} and stays
+     * there until somebody decides it, so a listing of everything pending a record manager may
+     * decide would be the tenant's entire attendance history. The flag is what separates a day
+     * held for a decision from a day nobody has looked at.
+     */
+    @Test
+    void theQueueIsTheHeldDaysThatArePendingAndNeverTheCallersOwn() {
+        signedInAsTheNamedApprover();
+        theQueueComesBackEmpty();
+
+        service.getPendingApprovals(0, UnpagedResultCap.MAX_ROWS);
+        Map<String, Object> predicates = capturedPredicates();
+
+        assertThat(predicates).containsEntry("approvalStatus", ApprovalStatus.PENDING);
+        assertThat(predicates)
+                .as("held for a geofence decision, which is what the flag was added to say")
+                .containsEntry("requiresGeofenceApproval", Boolean.TRUE);
+        assertThat(predicates)
+                .as("a manager who marked from off site does not decide their own day, and the "
+                        + "approve endpoint refuses it ahead of any role check")
+                .containsEntry("employeeId!", CALLER_EMPLOYEE_ID);
+    }
+
+    /**
+     * A record manager's queue is not narrowed to the records naming them.
+     *
+     * <p>{@code resolveApprover} names nobody when the employee has no reporting manager and no
+     * project manager is assigned to the site, and the reporting-manager field is set on a small
+     * minority of employees, so that is the ordinary case rather than the edge. Those records fall
+     * to the record-management roles, and a queue keyed only on the id would drop them: they would
+     * sit pending with nobody able to see them.
+     */
+    @Test
+    void aRecordManagerSeesTheHeldDaysThatNameNobody() {
+        signedInAsTheNamedApprover();
+        when(attendanceSecurity.canManageRecords()).thenReturn(true);
+        theQueueComesBackEmpty();
+
+        service.getPendingApprovals(0, UnpagedResultCap.MAX_ROWS);
+        Map<String, Object> predicates = capturedPredicates();
+
+        assertThat(predicates)
+                .as("no approver predicate, so a record naming nobody is still in the queue")
+                .doesNotContainKey("geofenceApproverId");
+        assertThat(predicates)
+                .as("their own held day is still not theirs to decide")
+                .containsEntry("employeeId!", CALLER_EMPLOYEE_ID);
+    }
+
+    @Test
+    void theQueueIsOrderedAndCapped() {
+        signedInAsTheNamedApprover();
+        theQueueComesBackEmpty();
+
+        service.getPendingApprovals(0, UnpagedResultCap.MAX_ROWS);
+
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(attendanceRepository).findAll(any(Specification.class), pageable.capture());
+        assertThat(pageable.getValue().getSort())
+                .as("an unordered page walk can show one record twice and never reach another")
+                .isEqualTo(AttendanceApprovalQueueSpecifications.QUEUE_ORDER);
+        assertThat(pageable.getValue().getPageSize()).isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+
+    // ── Reading the specification ────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private ArgumentCaptor<Specification<Attendance>> specificationCaptor() {
+        return ArgumentCaptor.forClass(Specification.class);
+    }
+
+    private Map<String, Object> capturedPredicates() {
+        ArgumentCaptor<Specification<Attendance>> captor = specificationCaptor();
+        verify(attendanceRepository).findAll(captor.capture(), any(Pageable.class));
+        return predicatesOf(captor.getValue());
+    }
+
+    /**
+     * Runs the specification against a recording criteria builder and returns what it asked for.
+     *
+     * <p>Keys are attribute names, with a trailing {@code !} for an inequality. Read this way the
+     * predicate set is asserted rather than described, so deleting one of the three conditions is
+     * a failure rather than a documentation drift.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Map<String, Object> predicatesOf(Specification<Attendance> specification) {
+        Map<String, Object> asked = new HashMap<>();
+        Map<String, Path> paths = new HashMap<>();
+
+        Root<Attendance> root = mock(Root.class);
+        when(root.get(anyString())).thenAnswer(invocation -> {
+            String attribute = invocation.getArgument(0);
+            return paths.computeIfAbsent(attribute, name -> mock(Path.class));
+        });
+
+        CriteriaBuilder cb = mock(CriteriaBuilder.class);
+        Predicate predicate = mock(Predicate.class);
+        when(cb.equal(any(), any(Object.class))).thenAnswer(invocation -> {
+            asked.put(nameOf(paths, invocation.getArgument(0)), invocation.getArgument(1));
+            return predicate;
+        });
+        when(cb.notEqual(any(), any(Object.class))).thenAnswer(invocation -> {
+            asked.put(nameOf(paths, invocation.getArgument(0)) + "!", invocation.getArgument(1));
+            return predicate;
+        });
+        when(cb.isTrue(any())).thenAnswer(invocation -> {
+            asked.put(nameOf(paths, invocation.getArgument(0)), Boolean.TRUE);
+            return predicate;
+        });
+        when(cb.and(any(Predicate[].class))).thenReturn(predicate);
+
+        specification.toPredicate(root, mock(CriteriaQuery.class), cb);
+        return asked;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private String nameOf(Map<String, Path> paths, Object path) {
+        return paths.entrySet().stream()
+                .filter(entry -> entry.getValue() == path)
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse("unknown");
+    }
+}


### PR DESCRIPTION
Closes #692.

## The gap

Since #681 an attendance day marked from outside a project's geofence is routed to a named person: the employee gives a reason, `AttendanceGeofenceService.resolveApprover` names who decides, and `AttendanceService.approveAttendance` accepts that person's decision. The decision has worked from the first day. Finding the record has not.

The two listings are `attendance/project/{projectId}`, which requires a `date` and has no approval filter, and `attendance/employee/{employeeId}`, which is one person over a range. So an approver reaches a held day only by already knowing it is there. tornotron/echno-web#402 gave the named approver the Approve and Reject buttons; this is the half that lets them find the record to press them on.

## What is added

Four endpoints, none of which takes a parameter:

| Endpoint | Answers |
|---|---|
| `GET /api/v1/attendance/pending-approvals` | The held days waiting on the caller, newest first, capped at 500 with `X-Total-Count` and `X-Result-Capped` |
| `GET /api/v1/attendance/pending-approvals/count` | `{"count": n}` for the sidebar badge |
| `GET /api/v1/attendance/web/pending-approvals` | The web twin |
| `GET /api/v1/attendance/web/pending-approvals/count` | The web twin |

The twins are the convention on this controller and every endpoint on it has one, so both were written rather than one; an earlier fix in this area shipped a twin short and left half a feature dead.

The caller comes from the session. Reading an approver off the query string under a guard that only asks for a role is the defect closed in #589, #599, #607, #631, #635 and #683, and again in the sweep findings #687 to #691: the guard checks a role, the query reads a number the caller sent, and the two never meet, so an administrator reads a colleague's queue while the line managers a chain is actually built from read none of their own. A caller that still sends `approverId` is served their own queue, a query parameter no handler declares being ignored.

## How the query agrees with the write path

`AttendanceService.requireActorMayApprove` runs two rules in order, and `AttendanceApprovalQueueSpecifications.waitingOn` is built to be the same two:

1. **Self-approval is refused ahead of the role check.** A record manager who marked from off site is refused their own day whatever roles they hold. The queue excludes `employeeId = caller` unconditionally, so it never offers an action the API answers with a 403.
2. **`canDecideApproval` is the record-management roles plus the approver the record names.** A caller holding the roles sees every other held day in the tenant, which is what reaches the records `resolveApprover` could name nobody for. Anyone else sees the days that name them. The id is read from the stored `geofenceApproverId`, so the chain is not walked again and the queue cannot drift from the record.

A null `geofenceApproverId` widens rather than strands: those records are the record managers' by the first branch. That is the common case rather than the edge, the reporting-manager field being set on a small minority of employees today.

## The one place the queue is narrower than `canDecideApproval`

The issue suggested the queue be "the set `canDecideApproval` would accept, restricted to `approvalStatus = PENDING`". Taken literally that is the entire attendance table: `checkIn` builds every record with `approvalStatus = PENDING` and nothing moves it until somebody decides the day, so pending is an ordinary record's resting state rather than a request for attention. An HR admin's queue would be every attendance row the organization has.

So the queue also filters `requiresGeofenceApproval = true`, which is what that flag was added for and what the entity documents it as ("what an approver's queue filters on"). The queue is therefore a strict subset of what the approve endpoint accepts, which is the safe direction: it never offers a record the server would refuse.

**Nothing else disagrees.** The web gate `features/attendance/lib/approval-gate.ts` mirrors the same two rules in the same order, including the fail-closed treatment of an unresolved viewer id, and this query agrees with it on every held record. The gate additionally allows a record manager to decide an ordinary, unflagged pending record, which the backend also allows and this queue simply does not list, for the reason above.

## Also

- `AttendanceRepository` gains `JpaSpecificationExecutor`, so the listing and the count read one predicate. A separate JPQL pair would have been two statements to keep in step, and the badge disagreeing with the list it labels is a bug users report as "the number is wrong".
- The count is `count(spec)`, not a page total. Spring's `PageableExecutionUtils` skips the count query when the first page comes back short, so a badge derived from a listing is right only while the queue is shorter than a page.
- Liquibase `090` indexes `(organization_id, requires_geofence_approval, approval_status, geofence_approver_id)`. Neither geofence column was ever a search term before; both are now read on every visit to the approvals screen, over the table that grows with every employee on every day on every project. A prefix of the index answers the record manager's three-column question, the whole of it the named approver's four.

## Tests

Two classes, and the split is the same one `RegularizationRegisterQueryIT` settled: who the caller is belongs to the service, what the SQL does belongs against a real database.

`AttendanceApprovalQueueTest` (Mockito, no context) captures the specification the service hands the repository and runs it against a recording criteria builder, so the predicate set is asserted rather than described.

| Test | Fails without the change because |
|---|---|
| `theQueueIsReadForTheSignedInCallerAndTakesNoApproverArgument` | the queue is narrowed to the caller's own employee id, resolved from the session |
| `theCountIsCountedForTheSameCallerTheListIsServedFor` | the badge and the list resolve the caller identically |
| `theCountDoesNotComeFromTheListing` | the count runs a count query and never touches `findAll` |
| `aCallerWithNoEmployeeRecordHereIsRefusedAQueueRatherThanServedSomebodyElses` | a caller with no employee record here is refused, not served |
| `aCallerWithNoEmployeeRecordHereIsRefusedTheCount` | same, on the count |
| `theQueueIsTheHeldDaysThatArePendingAndNeverTheCallersOwn` | the three predicates are `PENDING`, held, and not the caller's own |
| `aRecordManagerSeesTheHeldDaysThatNameNobody` | the approver predicate is dropped for a record manager, and the self-exclusion is not |
| `theQueueIsOrderedAndCapped` | an unordered page walk can show one record twice and never reach another |

`AttendanceApprovalQueueIT` (`@DataJpaTest` against CockroachDB) seeds ten rows across two tenants, each excluded row excluded for exactly one reason, so a dropped filter fails a different test.

| Test | Fails without the change because |
|---|---|
| `theNamedApproverSeesTheHeldDaysThatNameThemAndNothingElse` | the decided, the unheld, the other approver's and the other tenant's rows all stay out |
| `aRecordManagerSeesEveryHeldDayIncludingTheOnesNamingNobody` | a queue keyed only on the id drops the null-approver rows |
| `nobodySeesTheirOwnHeldDay` | the self-exclusion applies to the record manager, not only to the ordinary employee |
| `theCountIsTheWholeQueueAndNotTheFirstPage` | a page of two is asked for against a queue of four and the count is read separately; a page total would say two, an unscoped count seven |
| `theQueueIsScopedToTheTenant` | the same approver id is seeded in both tenants |
| `theQueueIsOrderedNewestDayFirst` | the order is total, with the primary key underneath the date |

**Verification path: CI.** This laptop has no container runtime, so the integration test cannot run here, and it is under load, so nothing was built on it. Every red above is reasoned from the code rather than measured against `development`, which is the honest description for a feature whose tests cannot compile against a branch where the endpoints do not exist. No red is claimed as measured.

`docs/openapi.json` is regenerated from this branch's own `openapi-served` build artifact rather than locally, and CI re-verifies it.

Downstream: `@tornotron/echno-core` gains the two methods and their hooks in a paired PR, since the contract there is hand-maintained and nothing would fail to compile without it.
