### PR TITLE
Hold the attendance and leave-balance reads to the policy they were meant to have

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -26899,7 +26899,7 @@
         ]
       },
       "get": {
-        "description": "Returns a single attendance record including its clock events, movements, regularizations and approval state.",
+        "description": "Returns a single attendance record including its clock events, movements, regularizations and approval state. Readable by the employee it belongs to, by a holder of an attendance record-management role, or by the approver the record names.",
         "operationId": "getById_5",
         "parameters": [
           {
@@ -26951,7 +26951,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee the record belongs to, nor a holder of an attendance record-management role, nor the approver the record names"
           },
           "404": {
             "content": {
@@ -27246,7 +27246,7 @@
         ]
       },
       "get": {
-        "description": "Returns a single attendance record including its clock events, movements, regularizations and approval state.",
+        "description": "Returns a single attendance record including its clock events, movements, regularizations and approval state. Readable by the employee it belongs to, by a holder of an attendance record-management role, or by the approver the record names.",
         "operationId": "getById_4",
         "parameters": [
           {
@@ -27298,7 +27298,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee the record belongs to, nor a holder of an attendance record-management role, nor the approver the record names"
           },
           "404": {
             "content": {
@@ -62979,7 +62979,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -63110,7 +63110,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -63357,7 +63357,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -63473,7 +63473,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -63598,7 +63598,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -63966,7 +63966,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -64088,7 +64088,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -64204,7 +64204,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -76170,7 +76170,7 @@
     },
     "/api/v1/movement-records/attendance/{attendanceId}": {
       "get": {
-        "description": "Returns every movement logged against a given attendance record.",
+        "description": "Returns every movement logged against a given attendance record. Readable by whoever may read that attendance record.",
         "operationId": "getByAttendance_1",
         "parameters": [
           {
@@ -76225,7 +76225,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller may not read the attendance record these movements belong to"
           },
           "404": {
             "content": {
@@ -76409,7 +76409,7 @@
     },
     "/api/v1/movement-records/web/attendance/{attendanceId}": {
       "get": {
-        "description": "Returns every movement logged against a given attendance record.",
+        "description": "Returns every movement logged against a given attendance record. Readable by whoever may read that attendance record.",
         "operationId": "getByAttendance",
         "parameters": [
           {
@@ -76464,7 +76464,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller may not read the attendance record these movements belong to"
           },
           "404": {
             "content": {
@@ -76525,7 +76525,7 @@
     },
     "/api/v1/movement-records/web/{id}": {
       "get": {
-        "description": "Returns a single movement record including its verification state.",
+        "description": "Returns a single movement record including its verification state. Readable by whoever may read the attendance record it hangs off.",
         "operationId": "getById_3",
         "parameters": [
           {
@@ -76577,7 +76577,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller may not read the attendance record this movement belongs to"
           },
           "404": {
             "content": {
@@ -76751,7 +76751,7 @@
     },
     "/api/v1/movement-records/{id}": {
       "get": {
-        "description": "Returns a single movement record including its verification state.",
+        "description": "Returns a single movement record including its verification state. Readable by whoever may read the attendance record it hangs off.",
         "operationId": "getById_2",
         "parameters": [
           {
@@ -76803,7 +76803,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller may not read the attendance record this movement belongs to"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -103,11 +103,13 @@ public class AttendanceController {
     @Operation(
             summary = "Get an attendance record by id",
             description = "Returns a single attendance record including its clock events, movements, "
-                    + "regularizations and approval state."
+                    + "regularizations and approval state. Readable by the employee it belongs to, "
+                    + "by a holder of an attendance record-management role, or by the approver the "
+                    + "record names."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance record found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee the record belongs to, nor a holder of an attendance record-management role, nor the approver the record names"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
     public ResponseEntity<AttendanceResponseDto> getById(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -101,11 +101,13 @@ public class AttendanceControllerWeb {
     @Operation(
             summary = "Get an attendance record by id",
             description = "Returns a single attendance record including its clock events, movements, "
-                    + "regularizations and approval state."
+                    + "regularizations and approval state. Readable by the employee it belongs to, "
+                    + "by a holder of an attendance record-management role, or by the approver the "
+                    + "record names."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance record found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee the record belongs to, nor a holder of an attendance record-management role, nor the approver the record names"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
     public ResponseEntity<AttendanceResponseDto> getById(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -459,15 +459,48 @@ public class AttendanceService {
     /**
      * Retrieves a single attendance record by its ID.
      *
+     * <p>Who may read it is settled here against the stored record rather than in the
+     * {@code @PreAuthorize} guard, the same way {@link #requireActorMayApprove} settles who may
+     * decide one. The id on the request names a record, so it identifies no person for an
+     * annotation to check; the employee and the designated approver are columns the record
+     * carries. The response is the same {@link AttendanceResponseDto} the employee-scoped listing
+     * beside it returns, down to the check-in coordinates and the attachment, so the two reads
+     * answer to the same policy.
+     *
      * @param id The ID of the attendance record.
      * @return The attendance record.
      * @throws ResourceNotFoundException if no record with the given ID exists in this organization.
+     * @throws AccessDeniedException if the caller may not read this employee's records.
      */
     @Transactional(readOnly = true)
     public AttendanceResponseDto getAttendanceById(Long id) {
         Attendance attendance = attendanceRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Attendance record with ID " + id + " was not found"));
+        requireActorMayViewRecord(attendance);
         return attendanceMapper.toResponseDto(attendance);
+    }
+
+    /**
+     * Refuses the call unless the caller may read this record.
+     *
+     * <p>The policy is {@link AttendanceSecurityService#canViewAttendanceRecord}: the employee
+     * themselves, a holder of an attendance record-management role, or the approver the record
+     * names. The last of those is why this cannot be an annotation, and it has to be here rather
+     * than left out, because a manager asked to decide a geofence exception has to be able to look
+     * at the record they are deciding.
+     *
+     * @param attendance The record being read, loaded from the database.
+     * @throws AccessDeniedException if the caller may not read it.
+     */
+    private void requireActorMayViewRecord(Attendance attendance) {
+        if (attendanceSecurity.canViewAttendanceRecord(
+                attendance.getEmployeeId(), attendance.getGeofenceApproverId())) {
+            return;
+        }
+        throw new AccessDeniedException(
+                "Attendance records can only be read by the employee they belong to, by a holder "
+                        + "of an attendance record-management role, or by the approver the record "
+                        + "names");
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
@@ -61,11 +61,12 @@ public class MovementRecordController {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a movement record by id",
-            description = "Returns a single movement record including its verification state."
+            description = "Returns a single movement record including its verification state. "
+                    + "Readable by whoever may read the attendance record it hangs off."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Movement record found"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller may not read the attendance record this movement belongs to"),
             @ApiResponse(responseCode = "404", description = "No movement record with the given id")
     })
     public ResponseEntity<MovementRecordDto> getById(@PathVariable Long id) {
@@ -76,11 +77,12 @@ public class MovementRecordController {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List movements for an attendance record",
-            description = "Returns every movement logged against a given attendance record."
+            description = "Returns every movement logged against a given attendance record. "
+                    + "Readable by whoever may read that attendance record."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Movement records returned"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller may not read the attendance record these movements belong to"),
             @ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
     public ResponseEntity<List<MovementRecordDto>> getByAttendance(@PathVariable Long attendanceId) {

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
@@ -62,11 +62,12 @@ public class MovementRecordControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a movement record by id",
-            description = "Returns a single movement record including its verification state."
+            description = "Returns a single movement record including its verification state. "
+                    + "Readable by whoever may read the attendance record it hangs off."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Movement record found"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller may not read the attendance record this movement belongs to"),
             @ApiResponse(responseCode = "404", description = "No movement record with the given id")
     })
     public ResponseEntity<MovementRecordDto> getById(@PathVariable Long id) {
@@ -77,11 +78,12 @@ public class MovementRecordControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List movements for an attendance record",
-            description = "Returns every movement logged against a given attendance record."
+            description = "Returns every movement logged against a given attendance record. "
+                    + "Readable by whoever may read that attendance record."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Movement records returned"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller may not read the attendance record these movements belong to"),
             @ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
     public ResponseEntity<List<MovementRecordDto>> getByAttendance(@PathVariable Long attendanceId) {

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordRepository.java
@@ -30,7 +30,19 @@ public interface MovementRecordRepository extends JpaRepository<MovementRecord, 
     @Query("SELECT m FROM MovementRecord m WHERE m.id = :id AND m.organization.id = :orgId")
     Optional<MovementRecord> lockByIdAndOrganizationId(@Param("id") Long id, @Param("orgId") Long orgId);
 
-    List<MovementRecord> findByAttendanceIdOrderByStartTimeAsc(Long attendanceId);
+    /**
+     * The movements logged against one attendance record, earliest first.
+     *
+     * <p>The organization is a predicate here rather than left to the Hibernate {@code orgFilter}.
+     * The filter does cover {@link MovementRecord}, so this is defence in depth rather than a
+     * repair: it was the one read in this class that said nothing about the tenant it meant, and
+     * a query that only works because a session filter happens to be enabled is the shape the
+     * 2026-08-18 audit flagged as a trap for whoever calls it next.
+     */
+    @Query("SELECT m FROM MovementRecord m WHERE m.attendance.id = :attendanceId "
+            + "AND m.organization.id = :orgId ORDER BY m.startTime ASC")
+    List<MovementRecord> findByAttendanceIdAndOrganizationId(@Param("attendanceId") Long attendanceId,
+                                                             @Param("orgId") Long orgId);
 
     List<MovementRecord> findByEmployeeIdAndStartTimeBetween(Long employeeId,
                                                               LocalDateTime from,

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/MovementRecordService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/MovementRecordService.java
@@ -204,18 +204,70 @@ public class MovementRecordService {
         return movementRecordMapper.toDto(movementRecordRepository.save(record));
     }
 
+    /**
+     * Lists the movements logged against one attendance record.
+     *
+     * <p>The attendance record is resolved first and decides the answer. A movement trail is a
+     * sequence of an employee's positions and purposes through a work day, so the people who may
+     * read it are the people who may read the attendance it hangs off, and deriving it rather
+     * than restating it is what stops the two rules drifting apart later.
+     *
+     * @param attendanceId The attendance record whose movements are wanted.
+     * @return The movements, earliest first.
+     * @throws ResourceNotFoundException if no such attendance record exists in this organization.
+     * @throws AccessDeniedException if the caller may not read that record.
+     */
     @Transactional(readOnly = true)
     public List<MovementRecordDto> getMovementsByAttendance(Long attendanceId) {
-        return movementRecordRepository.findByAttendanceIdOrderByStartTimeAsc(attendanceId)
+        Long orgId = TenantContext.getCurrentOrgId();
+        Attendance attendance = attendanceRepository.findByIdAndOrganization_Id(attendanceId, orgId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Attendance record with ID " + attendanceId + " was not found"));
+        requireActorMayViewRecordsOf(attendance);
+
+        return movementRecordRepository.findByAttendanceIdAndOrganizationId(attendanceId, orgId)
                 .stream()
                 .map(movementRecordMapper::toDto)
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Reads one movement record.
+     *
+     * <p>Same policy, reached through the attendance the movement belongs to.
+     *
+     * @param id The movement record to read.
+     * @return The movement record.
+     * @throws ResourceNotFoundException if no such movement exists in this organization.
+     * @throws AccessDeniedException if the caller may not read the attendance it hangs off.
+     */
     @Transactional(readOnly = true)
     public MovementRecordDto getMovementById(Long id) {
         MovementRecord record = movementRecordRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Movement record with ID " + id + " was not found"));
+        requireActorMayViewRecordsOf(record.getAttendance());
         return movementRecordMapper.toDto(record);
+    }
+
+    /**
+     * Refuses the call unless the caller may read the given attendance record.
+     *
+     * <p>See {@link AttendanceSecurityService#canViewAttendanceRecord}: the employee themselves, a
+     * holder of an attendance record-management role, or the approver the record names. Both ids
+     * come off the stored attendance row, so the caller cannot nominate themselves by choosing an
+     * id on the request.
+     *
+     * @param attendance The attendance record the movements belong to.
+     * @throws AccessDeniedException if the caller may not read it.
+     */
+    private void requireActorMayViewRecordsOf(Attendance attendance) {
+        if (attendanceSecurity.canViewAttendanceRecord(
+                attendance.getEmployeeId(), attendance.getGeofenceApproverId())) {
+            return;
+        }
+        throw new AccessDeniedException(
+                "Movement records can only be read by the employee they belong to, by a holder of "
+                        + "an attendance record-management role, or by the approver the attendance "
+                        + "record names");
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttendanceSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttendanceSecurityService.java
@@ -60,6 +60,29 @@ public class AttendanceSecurityService {
     }
 
     /**
+     * View one stored attendance record, and the movement trail hanging off it.
+     *
+     * <p>The people who may read an employee's attendance are settled by
+     * {@link #canViewEmployeeRecords}, plus the approver the record itself names. That addition is
+     * the same one {@link #canDecideApproval} makes and is there for the same reason: a geofence
+     * exception is decided by the employee's reporting manager, who is usually not a holder of any
+     * organization-wide role. Somebody asked to decide a record has to be able to look at it, and
+     * without this branch the deciding would have been allowed while the reading was refused.
+     *
+     * <p>Both ids are read off the stored record, never off the request. A record-level check is
+     * what the by-id reads need, because the id on the request names a record rather than a person
+     * and so says nothing about who is entitled to it.
+     *
+     * @param employeeId The employee the record belongs to.
+     * @param designatedApproverId The approver the record names, or null when none is.
+     * @return Whether the caller may read it.
+     */
+    public boolean canViewAttendanceRecord(Long employeeId, Long designatedApproverId) {
+        return canViewEmployeeRecords(employeeId)
+                || (designatedApproverId != null && orgSecurity.isSelfInCurrentTenant(designatedApproverId));
+    }
+
+    /**
      * Record or correct attendance for one employee: the employee themselves, or a manager / HR.
      *
      * <p>Same policy as {@link #canViewEmployeeRecords}, named separately because the write

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceController.java
@@ -36,8 +36,7 @@ public class LeaveBalanceController {
     }
 
     @GetMapping("/employee/{employeeId}")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "List an employee's leave balances",
             description = "Returns every leave policy balance held by the employee for the given year, "
@@ -45,7 +44,7 @@ public class LeaveBalanceController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balances returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<List<LeaveBalanceDto>> getEmployeeBalances(
@@ -56,8 +55,7 @@ public class LeaveBalanceController {
     }
 
     @GetMapping("/employee/{employeeId}/policy/{policyId}")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Get an employee's balance for one policy",
             description = "Returns, or calculates on demand, the employee's balance under the given leave "
@@ -65,7 +63,7 @@ public class LeaveBalanceController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balance returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or leave policy with the given id")
     })
     public ResponseEntity<LeaveBalanceDto> getSpecificBalance(
@@ -77,8 +75,7 @@ public class LeaveBalanceController {
     }
 
     @GetMapping("/employee/{employeeId}/summary")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Get an employee's balance summary",
             description = "Returns the employee's balances for the given year together with totals for "
@@ -86,7 +83,7 @@ public class LeaveBalanceController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Summary returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<LeaveBalanceSummaryDto> getBalanceSummary(
@@ -136,8 +133,7 @@ public class LeaveBalanceController {
     }
 
     @GetMapping("/employee/{employeeId}/transactions")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Get an employee's transaction history",
             description = "Returns every leave balance transaction recorded for the employee, across all "
@@ -145,7 +141,7 @@ public class LeaveBalanceController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Transaction history returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionHistory(

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
@@ -36,7 +36,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "List an employee's leave balances",
             description = "Returns every leave policy balance held by the employee for the given year, "
@@ -44,7 +44,7 @@ public class LeaveBalanceControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balances returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<List<LeaveBalanceDto>> getEmployeeBalances(
@@ -55,7 +55,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping("/specific")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Get an employee's balance for one policy",
             description = "Returns, or calculates on demand, the employee's balance under the given leave "
@@ -63,7 +63,7 @@ public class LeaveBalanceControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balance returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or leave policy with the given id")
     })
     public ResponseEntity<LeaveBalanceDto> getSpecificBalance(
@@ -75,7 +75,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping("/summary")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Get an employee's balance summary",
             description = "Returns the employee's balances for the given year together with totals for "
@@ -83,7 +83,7 @@ public class LeaveBalanceControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Summary returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<LeaveBalanceSummaryDto> getBalanceSummary(
@@ -131,7 +131,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping("/transactions")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Get an employee's transaction history",
             description = "Returns every leave balance transaction recorded for the employee, across all "
@@ -139,7 +139,7 @@ public class LeaveBalanceControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Transaction history returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionHistory(

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRecordReadAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRecordReadAuthorizationTest.java
@@ -1,0 +1,242 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import jakarta.validation.Validation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceService;
+import org.tornotron.echno_backend.attendance.MovementRecord;
+import org.tornotron.echno_backend.attendance.MovementRecordRepository;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
+import org.tornotron.echno_backend.attendance.mapper.MovementRecordMapper;
+import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * Who may read a stored attendance record, and the movement trail hanging off it.
+ *
+ * <p>The by-id reads were guarded by tenant membership alone. Every one of them is tenant scoped
+ * and none was employee scoped, so any member of an organization could walk integer ids and read
+ * every colleague's day: the response is the same {@code AttendanceResponseDto} the employee-scoped
+ * listing returns, carrying the employee, the check-in and check-out coordinates, the geofence
+ * state and the attachment, which for this product is a photograph and a position. The policy that
+ * should have decided it, {@code canViewEmployeeRecords}, was already written and already applied
+ * to the route directly beside them.
+ *
+ * <p>The id on these requests names a record rather than a person, so an annotation has nothing to
+ * check. The employee and the designated approver are columns the record carries, which is why the
+ * decision is taken in the service against the loaded row, the way the approval path already reads
+ * its approver off the record.
+ *
+ * <p>The policy bean here is the real one over a mocked {@link OrganizationSecurityService}, so
+ * these exercise the composition rather than a stub of it, and the refusals are red on the old code
+ * by the read going through.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttendanceRecordReadAuthorizationTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long COLLEAGUE_EMPLOYEE_ID = 8L;
+    private static final Long APPROVER_EMPLOYEE_ID = 9L;
+    private static final Long ATTENDANCE_ID = 781L;
+    private static final Long MOVEMENT_ID = 4410L;
+
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private ShiftTimingRepository shiftTimingRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private ClockEventSequenceValidator sequenceValidator;
+    @Mock private AttendanceMapper attendanceMapper;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private UserContextService userContextService;
+    @Mock private AttendanceGeofenceService geofenceService;
+    @Mock private MovementRecordRepository movementRecordRepository;
+    @Mock private MovementRecordMapper movementRecordMapper;
+    @Mock private SelfApprovalPolicy selfApprovalPolicy;
+
+    /** The one thing stubbed: what the caller's token says about them. */
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private AttendanceSecurityService attendanceSecurity() {
+        return new AttendanceSecurityService(
+                orgSecurity,
+                new String[]{"system-admin", "hr-admin"},
+                new String[]{"system-admin", "hr-admin", "project-manager"});
+    }
+
+    private AttendanceService attendanceService() {
+        return new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
+                organizationRepository, projectRepository, settingsService, calculationService,
+                sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
+                userContextService,
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
+                attendanceSecurity(), geofenceService);
+    }
+
+    private MovementRecordService movementRecordService() {
+        return new MovementRecordService(movementRecordRepository, attendanceRepository,
+                employeeRepository, organizationRepository, settingsService, movementRecordMapper,
+                attendanceSecurity(), new AttendanceActorResolver(userContextService, employeeRepository),
+                selfApprovalPolicy);
+    }
+
+    private Organization organization() {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        return organization;
+    }
+
+    /** A colleague's day, flagged for a geofence decision and naming who is to take it. */
+    private Attendance colleaguesAttendance() {
+        Attendance attendance = new Attendance();
+        attendance.setId(ATTENDANCE_ID);
+        attendance.setEmployeeId(COLLEAGUE_EMPLOYEE_ID);
+        attendance.setEmployeeName("Colleague");
+        attendance.setProjectId(12L);
+        attendance.setRequiresGeofenceApproval(true);
+        attendance.setGeofenceApproverId(APPROVER_EMPLOYEE_ID);
+        attendance.setOrganization(organization());
+        return attendance;
+    }
+
+    private MovementRecord colleaguesMovement() {
+        return MovementRecord.builder()
+                .id(MOVEMENT_ID)
+                .attendance(colleaguesAttendance())
+                .employeeId(COLLEAGUE_EMPLOYEE_ID)
+                .employeeName("Colleague")
+                .organization(organization())
+                .build();
+    }
+
+    /**
+     * A plain member of the tenant: no record-management role, and not the employee whose record
+     * this is. Membership alone is what the old guard asked for.
+     */
+    private void callerIsAnOrdinaryMember() {
+        lenient().when(orgSecurity.isSelfOrHasAnyOrgRole(any(Long.class), any(String[].class)))
+                .thenReturn(false);
+        lenient().when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class)))
+                .thenReturn(false);
+        lenient().when(orgSecurity.isSelfInCurrentTenant(any(Long.class))).thenReturn(false);
+    }
+
+    /** The employee the record belongs to. */
+    private void callerIsTheEmployee() {
+        lenient().when(orgSecurity.isSelfOrHasAnyOrgRole(eq(COLLEAGUE_EMPLOYEE_ID), any(String[].class)))
+                .thenReturn(true);
+        lenient().when(orgSecurity.isSelfInCurrentTenant(any(Long.class))).thenReturn(false);
+    }
+
+    /**
+     * The reporting manager the record names as its approver, holding no organization-wide role.
+     * The case the fix must not shut out: somebody asked to decide a record has to see it.
+     */
+    private void callerIsTheDesignatedApprover() {
+        lenient().when(orgSecurity.isSelfOrHasAnyOrgRole(any(Long.class), any(String[].class)))
+                .thenReturn(false);
+        lenient().when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class)))
+                .thenReturn(false);
+        lenient().when(orgSecurity.isSelfInCurrentTenant(eq(APPROVER_EMPLOYEE_ID))).thenReturn(true);
+    }
+
+    private void attendanceRecordExists() {
+        lenient().when(attendanceRepository.findByIdAndOrganization_Id(ATTENDANCE_ID, ORG_ID))
+                .thenReturn(Optional.of(colleaguesAttendance()));
+    }
+
+    @Test
+    void attendanceById_isRefused_toAMemberWhoIsNeitherTheEmployeeNorAManager() {
+        callerIsAnOrdinaryMember();
+        attendanceRecordExists();
+
+        assertThatThrownBy(() -> attendanceService().getAttendanceById(ATTENDANCE_ID))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void attendanceById_isAllowed_toTheEmployeeItBelongsTo() {
+        callerIsTheEmployee();
+        attendanceRecordExists();
+
+        assertThatCode(() -> attendanceService().getAttendanceById(ATTENDANCE_ID))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void attendanceById_isAllowed_toTheApproverTheRecordNames() {
+        callerIsTheDesignatedApprover();
+        attendanceRecordExists();
+
+        assertThatCode(() -> attendanceService().getAttendanceById(ATTENDANCE_ID))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void movementById_isRefused_toAMemberWhoMayNotReadTheAttendanceItHangsOff() {
+        callerIsAnOrdinaryMember();
+        lenient().when(movementRecordRepository.findByIdAndOrganization_Id(MOVEMENT_ID, ORG_ID))
+                .thenReturn(Optional.of(colleaguesMovement()));
+
+        assertThatThrownBy(() -> movementRecordService().getMovementById(MOVEMENT_ID))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void movementsByAttendance_areRefused_toAMemberWhoMayNotReadTheAttendance() {
+        callerIsAnOrdinaryMember();
+        attendanceRecordExists();
+
+        assertThatThrownBy(() -> movementRecordService().getMovementsByAttendance(ATTENDANCE_ID))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void movementsByAttendance_areAllowed_toTheEmployeeTheAttendanceBelongsTo() {
+        callerIsTheEmployee();
+        attendanceRecordExists();
+
+        assertThatCode(() -> movementRecordService().getMovementsByAttendance(ATTENDANCE_ID))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveBalanceReadGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveBalanceReadGuardTest.java
@@ -1,0 +1,177 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Who may read a leave balance, on both twins.
+ *
+ * <p>The controller pair pointed in two directions at once. The balance reads were gated on the
+ * system-admin and hr-admin roles, so an employee could not find out how many days they had left,
+ * which is the first question anybody asks a leave module. The summary beside them was gated on
+ * bare tenant membership, so the same employee could read any colleague's entitlement and remaining
+ * days by passing their id. Repairing one and not the other leaves the module wrong in the opposite
+ * direction, so both move here.
+ *
+ * <p>The transaction ledger moves with them, in the third direction. It was self-only, which left
+ * the balance-management screen unable to show the transactions behind a balance an administrator
+ * had just adjusted: the same shape as #666, where the endpoint named in the issue was repaired and
+ * the caller was still unable to finish the job. The expression the whole set lands on,
+ * {@code isSelfOrHasAnyOrgRole}, is the one {@code LeaveRequestController} already uses for the
+ * request these balances are spent by.
+ *
+ * <p>{@code @orgSecurity} is mocked so the branches are exercised without building JWT group
+ * claims. The service is mocked and its return value is irrelevant; what matters is whether the
+ * request reaches it.
+ */
+@WebMvcTest({LeaveBalanceController.class, LeaveBalanceControllerWeb.class})
+@Import(LeaveBalanceReadGuardTest.TestSecurityConfig.class)
+class LeaveBalanceReadGuardTest {
+
+    private static final long SELF = 7L;
+    private static final long COLLEAGUE = 8L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LeaveBalanceService balanceService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /**
+     * An ordinary employee: themselves and nobody else, holding neither administrative role.
+     *
+     * <p>Membership is stubbed true because it is what the caller genuinely holds. That is what
+     * makes the summary case a measurement rather than an artefact: the old guard asked for
+     * membership and nothing else, so the colleague's summary really was returned to this caller.
+     */
+    private void callerIsAnOrdinaryEmployee() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(SELF, "system-admin", "hr-admin")).thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(COLLEAGUE, "system-admin", "hr-admin")).thenReturn(false);
+    }
+
+    /** An hr-admin: the role branch answers for anybody, before the change and after it. */
+    private void callerIsAnHrAdmin() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(COLLEAGUE, "system-admin", "hr-admin")).thenReturn(true);
+    }
+
+    @Test
+    void anEmployeeCanReadTheirOwnBalances() throws Exception {
+        callerIsAnOrdinaryEmployee();
+
+        mockMvc.perform(get("/api/v1/leave-balances/employee/" + SELF).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void anEmployeeCanReadTheirOwnBalancesOnTheWebTwin() throws Exception {
+        callerIsAnOrdinaryEmployee();
+
+        mockMvc.perform(get("/api/v1/leave-balances/web").param("employeeId", String.valueOf(SELF))
+                        .with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void anEmployeeCanReadTheirOwnSummary() throws Exception {
+        callerIsAnOrdinaryEmployee();
+
+        mockMvc.perform(get("/api/v1/leave-balances/employee/" + SELF + "/summary").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aColleaguesSummaryIsRefusedToAnOrdinaryEmployee() throws Exception {
+        callerIsAnOrdinaryEmployee();
+
+        mockMvc.perform(get("/api/v1/leave-balances/employee/" + COLLEAGUE + "/summary").with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(balanceService);
+    }
+
+    @Test
+    void aColleaguesSummaryIsRefusedOnTheWebTwinToo() throws Exception {
+        callerIsAnOrdinaryEmployee();
+
+        mockMvc.perform(get("/api/v1/leave-balances/web/summary")
+                        .param("employeeId", String.valueOf(COLLEAGUE)).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(balanceService);
+    }
+
+    @Test
+    void anAdministratorCanReadTheLedgerBehindABalanceTheyAdjusted() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(get("/api/v1/leave-balances/employee/" + COLLEAGUE + "/transactions")
+                        .with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void anAdministratorCanStillReadAnyEmployeesBalances() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(get("/api/v1/leave-balances/employee/" + COLLEAGUE).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void recalculateStaysWithTheAdministrators() throws Exception {
+        // Deliberately not moved. It is the one route in the pair that is written as a command
+        // rather than a read, and an employee triggering a recalculation of their own figures is
+        // a different decision from an employee being told what they are.
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/leave-balances/employee/" + SELF + "/recalculate").with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(balanceService);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Closes #688. Closes #689.

## What was verified, and where it is smaller than filed

Both issues were checked against the code rather than taken on trust, because the sweep that filed them had already corrected its own cross-tenant claims once.

**#688 stands as written, and it is the more serious of the two.** `Attendance` and `MovementRecord` both implement `TenantScopedEntity` and carry `@Filter(name = "orgFilter", ...)`, so nothing here crosses a tenant. That was never the claim. The claim is that within one organization the by-id reads were guarded by membership alone while `@attendanceSecurity.canViewEmployeeRecords` gated the employee-scoped route on the same controller, and both return the same `AttendanceResponseDto`. So the policy was written, documented, applied on one route, and bypassable on the one next to it by counting.

**#689's two halves are not equally severe, and the issue text overstates one of them.**

- The read that is too narrow is real: an employee could not read their own entitlement, consumed or remaining days, and the only balance-adjacent route they could reach for themselves returned the ledger rather than the balances. `features/leave/components/dashboard/employee-dashboard.tsx` and the leave-request form both call these.
- "Every HR administrator can see everyone's" is **not** a defect. An hr-admin reading any employee's leave balance inside their own organization is the job. That half of the title should be read as describing the summary route only, which was on bare tenant membership, so **any** employee could read a colleague's entitlement by passing their id. That one is real and is fixed.
- One correction to the issue's endpoint table: `POST /recalculate` does not call `recalculateBalances`. Both twins call `getAllBalancesForEmployee`, the same method the GET beside them calls, so the route is a read wearing a POST and there is no bulk recalculate in the service at all. It is left role-gated and filed separately rather than folded in here.

**The `@Transactional` note that matters for review:** these reads are not pure. `getOrCalculateBalance` persists a balance row through `initializeBalance` and recomputes accrual when a month has passed. Widening them to the employee therefore lets an employee cause their own row to be initialised, which is how the figures come to exist at all. No other employee's row is reachable.

## The fix

**Attendance and movements (#688).** The check is taken in the service against the loaded record, not in an annotation, because the id on these requests names a record and so identifies no person. That is exactly where the writes in the same package already take theirs. New `AttendanceSecurityService.canViewAttendanceRecord(employeeId, designatedApproverId)`: `canViewEmployeeRecords` plus the approver the record names.

The approver branch is load-bearing rather than decorative. A geofence exception is decided by the employee's reporting manager, who usually holds none of the organization-wide roles, and `canDecideApproval` already lets them decide it. Without the branch this change would have produced a caller who may approve a record and may not look at it, which is #666 in a new place. There is a test for it.

The movement reads reach the policy through the attendance they hang off, so a movement trail is readable by exactly the people who may read the day it belongs to, rather than by a second rule that would drift from the first. `findByAttendanceIdOrderByStartTimeAsc` also gains an explicit organization predicate: the filter did cover it, so this is defence in depth and not a repair, but it was the one read in the class that said nothing about the tenant it meant.

**Leave balances (#689).** The balance listing, the single-policy balance, the summary and the transaction ledger all land on `@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')`, which is what `LeaveRequestController` already uses for the request these balances are spent by. That is a widening for the first two, a narrowing for the summary, and a widening for the ledger.

The ledger moved because of the workflow trace the issue asked for. `app/users/dashboard/workforce/leaves/manage/balance/page.tsx` reads the summary and the transaction history side by side, and adjusts balances from `balance-adjustment-dialog.tsx`. The ledger was self-only, so an administrator could adjust a balance and not see the transaction their adjustment produced. It grants nothing new in kind: `/{balanceId}/transactions` already hands those roles the same rows.

`recalculate` and `adjust` stay with the administrators. Both are written as commands, and an employee triggering a recalculation of their own figures is a different decision from an employee being told what they are.

## Both twins

Checked on all six routes. The mobile and `/web` controllers were byte-identical in guard on every one, and both are changed.

## Tests

The first commit is the tests alone. It was run on CI against the unmodified code (run [34050549515](https://github.com/tornotron/echno-backend/actions/runs/34050549515)); the `Compile` step passed and `Test` failed on exactly the eight cases below, so every red here is **measured** and none is reasoned. This workstation has no container runtime and is under load, so CI was the verification path throughout.

| Test | What it holds | Red before the fix |
|---|---|---|
| `AttendanceRecordReadAuthorizationTest.attendanceById_isRefused_toAMemberWhoIsNeitherTheEmployeeNorAManager` | an ordinary member cannot read a colleague's day by id | **measured** |
| `AttendanceRecordReadAuthorizationTest.movementById_isRefused_toAMemberWhoMayNotReadTheAttendanceItHangsOff` | same for one movement | **measured** |
| `AttendanceRecordReadAuthorizationTest.movementsByAttendance_areRefused_toAMemberWhoMayNotReadTheAttendance` | same for the trail | **measured** |
| `AttendanceRecordReadAuthorizationTest.attendanceById_isAllowed_toTheEmployeeItBelongsTo` | the employee still reads their own | passed before and after, by design |
| `AttendanceRecordReadAuthorizationTest.attendanceById_isAllowed_toTheApproverTheRecordNames` | the designated approver is not shut out | passed before and after, by design |
| `AttendanceRecordReadAuthorizationTest.movementsByAttendance_areAllowed_toTheEmployeeTheAttendanceBelongsTo` | same for the trail | passed before and after, by design |
| `LeaveBalanceReadGuardTest.anEmployeeCanReadTheirOwnBalances` | the narrow half, mobile | **measured** |
| `LeaveBalanceReadGuardTest.anEmployeeCanReadTheirOwnBalancesOnTheWebTwin` | the narrow half, web | **measured** |
| `LeaveBalanceReadGuardTest.aColleaguesSummaryIsRefusedToAnOrdinaryEmployee` | the wide half, mobile | **measured** |
| `LeaveBalanceReadGuardTest.aColleaguesSummaryIsRefusedOnTheWebTwinToo` | the wide half, web | **measured** |
| `LeaveBalanceReadGuardTest.anAdministratorCanReadTheLedgerBehindABalanceTheyAdjusted` | the workflow half | **measured** |
| `LeaveBalanceReadGuardTest.anEmployeeCanReadTheirOwnSummary` | the summary an employee could already reach still answers | passed before and after, by design |
| `LeaveBalanceReadGuardTest.anAdministratorCanStillReadAnyEmployeesBalances` | the administrators lose nothing | passed before and after, by design |
| `LeaveBalanceReadGuardTest.recalculateStaysWithTheAdministrators` | the command route did not move | passed before and after, by design |

The attendance cases drive the real `AttendanceSecurityService` over a mocked `OrganizationSecurityService`, so they exercise the policy composition rather than a stub of it.

## OpenAPI

Description text only, twenty lines, no structure. Taken from the build's own `openapi-served` artifact rather than regenerated here, since this workstation has no container runtime; the artifact is written from the identical canonical string the update flag produces, and CI re-verifies it.
