### PR TITLE
Make the directory and leave-policy reads check the id they are given

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -34659,7 +34659,7 @@
     },
     "/api/v1/employee/web/managerId/{managerId}/subordinates": {
       "get": {
-        "description": "Returns every employee who reports directly to the given manager.",
+        "description": "Returns every employee who reports directly to the given manager. Callable by that manager, or by a system or HR admin for anybody.",
         "operationId": "getDirectSubordinates",
         "parameters": [
           {
@@ -34714,7 +34714,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is neither the manager named nor a system or HR admin"
           },
           "404": {
             "content": {
@@ -34880,7 +34880,7 @@
     },
     "/api/v1/employee/web/managers/organizationId/{organizationId}": {
       "get": {
-        "description": "Returns every employee holding a manager organization role within the given organization.",
+        "description": "Returns every employee holding a manager organization role within the given organization, which has to be the caller's own. Identical to the list beside it, which takes the organization from the session instead.",
         "operationId": "getAllManagersForAnOrganization",
         "parameters": [
           {
@@ -34935,7 +34935,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not entitled to the organization named, or lacks the required role in it"
           },
           "404": {
             "content": {
@@ -66291,7 +66291,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -66416,7 +66416,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not entitled to the organization named, or lacks the required role in it"
           },
           "404": {
             "content": {
@@ -67095,7 +67095,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -300,14 +300,15 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing a list of employee DTOs who report to the manager and HTTP status 200 (OK).
      */
     @GetMapping("/managerId/{managerId}/subordinates")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#managerId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "List a manager's direct subordinates",
-            description = "Returns every employee who reports directly to the given manager."
+            description = "Returns every employee who reports directly to the given manager. Callable "
+                    + "by that manager, or by a system or HR admin for anybody."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subordinates returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the manager named nor a system or HR admin"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No manager with the given id")
     })
     public ResponseEntity<List<EmployeeDto>> getDirectSubordinates(@PathVariable Long managerId) {
@@ -329,14 +330,17 @@ public class EmployeeControllerWeb {
     }
 
     @GetMapping("/managers/organizationId/{organizationId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isCurrentTenant(#organizationId) "
+            + "and @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     @Operation(
             summary = "List managers for an organization",
-            description = "Returns every employee holding a manager organization role within the given organization."
+            description = "Returns every employee holding a manager organization role within the given "
+                    + "organization, which has to be the caller's own. Identical to the list beside it, "
+                    + "which takes the organization from the session instead."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Managers returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not entitled to the organization named, or lacks the required role in it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
     })
     public ResponseEntity<List<EmployeeDto>> getAllManagersForAnOrganization(@PathVariable Long organizationId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
@@ -88,7 +88,8 @@ public class LeavePolicyController {
     }
 
     @GetMapping("/organization/{organizationId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isCurrentTenant(#organizationId) "
+            + "and @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "List an organization's leave policies",
             description = "Returns the leave policies configured for the organization. Active policies "
@@ -96,7 +97,7 @@ public class LeavePolicyController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policies returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not entitled to the organization named, or lacks the required role in it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
     })
     public ResponseEntity<List<LeavePolicyDto>> getPoliciesByOrganization(
@@ -109,8 +110,7 @@ public class LeavePolicyController {
     }
 
     @GetMapping("/employee/{employeeId}")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "List policies applicable to an employee",
             description = "Returns the leave policies the employee is eligible for, filtered by their "
@@ -118,7 +118,7 @@ public class LeavePolicyController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Applicable policies returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<List<LeavePolicyDto>> getApplicablePoliciesForEmployee(

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
@@ -96,7 +96,7 @@ public class LeavePolicyControllerWeb {
 //    }
 
     @GetMapping("/employee")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "List policies applicable to an employee",
             description = "Returns the leave policies the employee is eligible for, filtered by their "
@@ -104,7 +104,7 @@ public class LeavePolicyControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Applicable policies returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee identified by the id nor a holder of the system-admin or hr-admin role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<List<LeavePolicyDto>> getApplicablePoliciesForEmployee(

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -142,7 +142,15 @@ public class LeavePolicyService {
     /**
      * Lists the active policies for an organization, ordered by display order.
      *
-     * @param organizationId The organization's ID.
+     * <p>The organization has to be the caller's own, which the handler establishes with
+     * {@code @orgSecurity.isCurrentTenant}. That is worth saying here because the
+     * {@code existsById} below reads as though it were the tenant check and is not: it asks only
+     * whether the organization exists anywhere in the deployment, and {@code Organization} is the
+     * tenant root, so it carries neither the {@code orgFilter} nor the load listener's protection.
+     * What keeps the result inside the tenant is the guard, plus the filter on
+     * {@link LeavePolicy} itself.
+     *
+     * @param organizationId The organization's ID, which the guard has established is the caller's.
      * @return The active policies in display order.
      * @throws ResourceNotFoundException if the organization is not found.
      */

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeDirectoryReadGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeDirectoryReadGuardTest.java
@@ -1,0 +1,140 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Two directory reads that took an id from the caller and then checked something else.
+ *
+ * <p>The subordinate list asked for one of three organization-wide roles and never looked at the
+ * manager it was given. Reporting lines are set on {@code Employee.manager} and have nothing to do
+ * with the Keycloak-derived role set, so a site supervisor who is somebody's manager in the data
+ * and holds no {@code project-manager} role was refused their own direct reports, while any holder
+ * of that role could name any other manager and receive their whole team as full
+ * {@code EmployeeDto}s, salary and date of birth included. The same manager-versus-role mismatch
+ * {@code AttendanceSecurityService.canDecideApproval} exists to answer, and that #685 found in the
+ * leave approval chain.
+ *
+ * <p>The manager directory names an organization the guard never reads. {@code Employee} carries
+ * the {@code orgFilter}, so a foreign id returns an empty list rather than another tenant's
+ * managers, which is why this half is a redundant parameter rather than a leak. It is still a
+ * parameter that decides what is answered while nothing establishes the caller is entitled to it,
+ * and the check for that is the one #687 introduced.
+ */
+@WebMvcTest(EmployeeControllerWeb.class)
+@Import(EmployeeDirectoryReadGuardTest.TestSecurityConfig.class)
+class EmployeeDirectoryReadGuardTest {
+
+    private static final long OWN_ORG = 100L;
+    private static final long FOREIGN_ORG = 200L;
+    private static final long CALLER_AS_MANAGER = 7L;
+    private static final long ANOTHER_MANAGER = 8L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EmployeeService employeeService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /**
+     * A line manager: people report to them in the data, and they hold none of the three roles the
+     * old guard asked for.
+     */
+    private void callerIsALineManagerWithNoRole() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin", "project-manager"))
+                .thenReturn(false);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(CALLER_AS_MANAGER, "system-admin", "hr-admin"))
+                .thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(ANOTHER_MANAGER, "system-admin", "hr-admin"))
+                .thenReturn(false);
+    }
+
+    /** A project-manager: holds the role, is not the manager named. */
+    private void callerIsAProjectManager() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin", "project-manager"))
+                .thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(ANOTHER_MANAGER, "system-admin", "hr-admin"))
+                .thenReturn(false);
+        when(orgSecurity.isCurrentTenant(OWN_ORG)).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(FOREIGN_ORG)).thenReturn(false);
+    }
+
+    @Test
+    void aLineManagerCanReadTheirOwnDirectReports() throws Exception {
+        callerIsALineManagerWithNoRole();
+
+        mockMvc.perform(get("/api/v1/employee/web/managerId/" + CALLER_AS_MANAGER + "/subordinates")
+                        .with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void anotherManagersTeamIsRefusedToARoleHolderWhoIsNotThatManager() throws Exception {
+        callerIsAProjectManager();
+
+        mockMvc.perform(get("/api/v1/employee/web/managerId/" + ANOTHER_MANAGER + "/subordinates")
+                        .with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    @Test
+    void theManagerDirectoryIsRefusedForAnOrganizationTheCallerIsNotEntitledTo() throws Exception {
+        callerIsAProjectManager();
+
+        mockMvc.perform(get("/api/v1/employee/web/managers/organizationId/" + FOREIGN_ORG).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    @Test
+    void theManagerDirectoryStillAnswersForTheCallersOwnOrganization() throws Exception {
+        callerIsAProjectManager();
+
+        mockMvc.perform(get("/api/v1/employee/web/managers/organizationId/" + OWN_ORG).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyReadGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyReadGuardTest.java
@@ -123,6 +123,19 @@ class LeavePolicyReadGuardTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    void anEmployeeStillCannotReadAColleaguesApplicablePolicies() throws Exception {
+        // The other side of widening this read to the administrators: the employee branch is
+        // still self, and only self. Without this the change looks the same as dropping the
+        // guard to bare tenant membership, which is the mistake the summary route in #689 was.
+        callerIsAnOrdinaryEmployee();
+
+        mockMvc.perform(get("/api/v1/leave-policies/employee/" + COLLEAGUE).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(policyService);
+    }
+
     @TestConfiguration
     @EnableMethodSecurity
     static class TestSecurityConfig {

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyReadGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyReadGuardTest.java
@@ -1,0 +1,136 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The leave-policy listing takes an organization from the path, and the form that spends those
+ * policies takes an employee.
+ *
+ * <p>The listing's guard established a role in the caller's own tenant and never read the id it was
+ * given. The service then asked only whether the organization existed, which is a check on the
+ * deployment rather than on the caller. {@code LeavePolicy} carries the {@code orgFilter}, so a
+ * foreign id returned an empty list rather than another tenant's accrual rates and encashment
+ * rules, which puts this well below #687 in consequence: what is left is a parameter that decides
+ * what is answered with nothing establishing entitlement to it, and an {@code existsById} that
+ * reads as though it were doing tenant work. The check it wants is the one #687 introduced.
+ *
+ * <p>The applicable-policies read moves with it for a different reason.
+ * {@code LeaveRequestController} lets a system or HR admin raise a leave request on an employee's
+ * behalf, while this read, which is what the request form offers them, was self-only. The caller
+ * entitled to finish the job could not read what the form needed. That is #666 exactly, and the
+ * expression the two now share is the one the create endpoint already used.
+ */
+@WebMvcTest({LeavePolicyController.class, LeavePolicyControllerWeb.class})
+@Import(LeavePolicyReadGuardTest.TestSecurityConfig.class)
+class LeavePolicyReadGuardTest {
+
+    private static final long OWN_ORG = 100L;
+    private static final long FOREIGN_ORG = 200L;
+    private static final long SELF = 7L;
+    private static final long COLLEAGUE = 8L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LeavePolicyService policyService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** An hr-admin of their own organization and of no other. */
+    private void callerIsAnHrAdmin() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(OWN_ORG)).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(FOREIGN_ORG)).thenReturn(false);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(COLLEAGUE, "system-admin", "hr-admin")).thenReturn(true);
+    }
+
+    /** An ordinary employee, reading their own. */
+    private void callerIsAnOrdinaryEmployee() {
+        when(orgSecurity.isSelfInCurrentTenant(SELF)).thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(SELF, "system-admin", "hr-admin")).thenReturn(true);
+    }
+
+    @Test
+    void theListingIsRefusedForAnOrganizationTheCallerIsNotEntitledTo() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(get("/api/v1/leave-policies/organization/" + FOREIGN_ORG).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(policyService);
+    }
+
+    @Test
+    void theListingStillAnswersForTheCallersOwnOrganization() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(get("/api/v1/leave-policies/organization/" + OWN_ORG).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void anAdministratorCanReadThePoliciesTheRequestFormWillOffer() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(get("/api/v1/leave-policies/employee/" + COLLEAGUE).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void anAdministratorCanReadThemOnTheWebTwinToo() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(get("/api/v1/leave-policies/web/employee")
+                        .param("employeeId", String.valueOf(COLLEAGUE)).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void anEmployeeStillReadsTheirOwnApplicablePolicies() throws Exception {
+        callerIsAnOrdinaryEmployee();
+
+        mockMvc.perform(get("/api/v1/leave-policies/employee/" + SELF).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Closes #690. Closes #691.

Uses the `@orgSecurity.isCurrentTenant` guard #696 introduced for #687. That has since merged, so this now sits directly on `development`.

## What was verified, and where it is smaller than filed

**Both organization-id findings are the redundant-parameter form of this family, not the dangerous one.** Checked on the entities rather than inferred from the missing predicate: `Employee` and `LeavePolicy` both implement `TenantScopedEntity` and carry `@Filter(name = "orgFilter", ...)`, and `HibernateFilterConfig` enables that filter on every `@Transactional` method with a tenant in force. A foreign organization id therefore returns an empty list rather than another tenant's managers or another tenant's accrual rates and encashment caps. Neither is #687, where `Organization` itself is loaded and the tenant root sits outside both the filter and the load listener.

What is left in both is real but modest: a parameter that decides what is answered with nothing establishing the caller is entitled to it, and in the leave-policy case an `existsById` that reads as though it were the tenant check and is not.

**#691 is not a duplicate of #687.** Different site, different repository call: #687 was `organizationRepository.findById` producing a credential bound to whatever was named; this is `existsById` in front of a filtered query. It is the general hazard #687's body flagged for separate handling, and this is that handling for one instance of it.

**#690's subordinate half is the one that matters, and it is as filed.** Reporting lines are set by `assignManager` on `Employee.manager`, which is independent of the Keycloak-derived `OrgRole` set, so the guard and the data were answering different questions in both directions at once: a line manager holding no `project-manager` role got a 403 on their own direct reports, and any holder of that role could name another manager and receive their whole team as full `EmployeeDto`s, carrying `salary`, `dateOfBirth`, `address` and `phoneNumber`.

## The fix

`GET /employee/web/managerId/{managerId}/subordinates` moves to `@orgSecurity.isSelfOrHasAnyOrgRole(#managerId, 'system-admin', 'hr-admin')`. Both halves close at once: the manager reads their own team through the self branch, and the administrative roles read anybody's. `project-manager` stops being a blanket key to every manager's team and keeps its own team through the same self branch. Neither `echno-core` nor `echno-web` calls this route (`useSubordinates` is defined in core and consumed nowhere), so the narrowing costs no screen.

`GET /employee/web/managers/organizationId/{organizationId}` and `GET /leave-policies/organization/{organizationId}` keep their path segment and gain `@orgSecurity.isCurrentTenant(#organizationId)` alongside the role check, so the segment becomes binding rather than decorative. One answers where, the other what. Deleting the manager route as redundant against `GET /managers` was the alternative the issue offered and is defensible: the path string appears nowhere in `echno-core` or `echno-web`, only a stale `employeeKeys.managersByOrg` query-key factory with no service method behind it. It is left in place because removing a route from a published contract is a separate decision from repairing its guard, and this PR should not make both.

`LeavePolicyService.getPoliciesByOrganization` gains a note saying why its `existsById` is not the tenant check it reads like, so the next reader does not take it for one.

## The read that was traced rather than filed

`GET /leave-policies/employee/{employeeId}` and its web twin were `isSelfInCurrentTenant`, while `LeaveRequestController:48` lets a system or HR admin raise a leave request **on an employee's behalf** with `isSelfOrHasAnyOrgRole`. The request form at `app/users/dashboard/workforce/leaves/manage/requests/new/page.tsx` calls exactly this read to populate itself. So the caller entitled to finish the job could not read what the form needed: #666 again, in the file #691 names. The two guards are now the same expression.

This grants nothing new. The same roles already read every policy in the organization, with full accrual and encashment rules, through the role-gated `GET /leave-policies/web`; this returns a subset of that filtered by one employee's gender and service months.

## Twins

- Subordinates and the manager directory exist only on `EmployeeControllerWeb`. There is no mobile twin to keep in step.
- The leave-policy organization listing's web twin is **commented out** at `LeavePolicyControllerWeb` lines 84 to 95, so there is no live counterpart. The console reaches leave policies through `GET /leave-policies/web` instead, which takes no id and is correct as it stands. That confirms the issue's guess about which route survives.
- The applicable-policies read exists on both twins and both are changed.

## Tests

The first commit is the tests alone. It was run on CI against the unmodified code (run [34050748852](https://github.com/tornotron/echno-backend/actions/runs/34050748852)); `Compile` passed and `Test` failed on exactly the six cases below, so every red here is **measured** and none is reasoned. This workstation has no container runtime and is under load, so CI was the verification path.

| Test | What it holds | Red before the fix |
|---|---|---|
| `EmployeeDirectoryReadGuardTest.aLineManagerCanReadTheirOwnDirectReports` | a manager holding no organization-wide role reaches their own team | **measured** |
| `EmployeeDirectoryReadGuardTest.anotherManagersTeamIsRefusedToARoleHolderWhoIsNotThatManager` | a `project-manager` no longer walks manager ids | **measured** |
| `EmployeeDirectoryReadGuardTest.theManagerDirectoryIsRefusedForAnOrganizationTheCallerIsNotEntitledTo` | the path segment binds | **measured** |
| `EmployeeDirectoryReadGuardTest.theManagerDirectoryStillAnswersForTheCallersOwnOrganization` | the ordinary case is unaffected | passed before and after, by design |
| `LeavePolicyReadGuardTest.theListingIsRefusedForAnOrganizationTheCallerIsNotEntitledTo` | same for leave policies | **measured** |
| `LeavePolicyReadGuardTest.theListingStillAnswersForTheCallersOwnOrganization` | the ordinary case is unaffected | passed before and after, by design |
| `LeavePolicyReadGuardTest.anAdministratorCanReadThePoliciesTheRequestFormWillOffer` | the workflow half, mobile | **measured** |
| `LeavePolicyReadGuardTest.anAdministratorCanReadThemOnTheWebTwinToo` | the workflow half, web | **measured** |
| `LeavePolicyReadGuardTest.anEmployeeStillReadsTheirOwnApplicablePolicies` | the employee loses nothing | passed before and after, by design |
| `LeavePolicyReadGuardTest.anEmployeeStillCannotReadAColleaguesApplicablePolicies` | the employee branch is still self and only self | passed before and after, by design |

## OpenAPI

`@PreAuthorize` expressions and response-description text only, no route or DTO change.

## Recorded in #690, deliberately not fixed here

Three weaker observations the issue lists rather than files. None is folded in, because each is a decision rather than a guard with an obvious right answer:

- `GET /employee/web/{id}` is role-gated while the `PATCH` beside it is correctly `isSelfOrHasAnyOrgRole(#id, ...)`, so an employee cannot read the record they may edit. `UserControllerWeb:130` gives them another self-route, which is the only thing keeping this benign. The mobile twin sits under a phantom `hasAuthority('employee:read')` and so refuses everybody, which is #684's mechanism in another module.
- `GET /employee/web/{employeeId}/roles` on bare membership lets any member enumerate who holds `system-admin` and `hr-admin`.
- `ProjectControllerWeb:373` reads `isMemberOfCurrentTenant() or hasAnyOrgRole(...)`, where the `or` makes the role clause dead and any member lists any colleague's project assignments.

Whether a `project-manager` should read colleagues' salaries through `EmployeeDto` is the same kind of question and is likewise left open.


## Review

CodeRabbit reviewed this and raised one nitpick, which was valid and is applied in the last commit: the suite proved the administrators could now reach the applicable-policies read and did not prove an ordinary employee still could not reach a colleague's, which would leave the change indistinguishable from dropping the guard to bare membership. `anEmployeeStillCannotReadAColleaguesApplicablePolicies` holds that side.

Its second suggestion, an administrator case naming an employee of another organization, is not applicable at this level. `isSelfOrHasAnyOrgRole` answers such a call on the role branch, and what refuses it afterwards is the service's own `findByIdAndOrganizationId` plus the `orgFilter` on `Employee`. Neither is exercised in a web slice where `@orgSecurity` is a mock, so a test there would assert the mock rather than the property. `TenantIsolationIT` is where that belongs.
