### PR TITLE
Hold the non-web joinOrganization route to the caller's own organization

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -33352,7 +33352,7 @@
     },
     "/api/v1/employee/joinOrganization/{userId}/{orgId}": {
       "post": {
-        "description": "Creates an employee record that links the given user to the given organization, using the supplied employment details. Returns the created employee.",
+        "description": "Creates an employee record that links the given user to the organization named in the path, which must be the organization the caller's session is scoped to. Uses the supplied employment details. Returns the created employee.",
         "operationId": "joinOrganization_1",
         "parameters": [
           {
@@ -33423,7 +33423,7 @@
                 }
               }
             },
-            "description": "Caller lacks the employee create or admin authority"
+            "description": "Caller lacks the employee create or admin authority, or named an organization that is not the current tenant"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
@@ -51,24 +51,43 @@ public class EmployeeController {
     }
 
     /**
-     * Allows a user to join an organization as an employee.
+     * Adds a user to the caller's own organization as an employee.
+     *
+     * <p>This is an administrative action, not the onboarding route. A person with no membership
+     * yet joins by redeeming an invite code at
+     * {@code POST /api/v1/invitation/web/validate/userId/{userId}}, which is guarded by
+     * {@code @orgSecurity.isSelfUser} precisely because the redeemer has no tenant, and which
+     * reaches {@link EmployeeService#joinOrganization} in process rather than through this route.
+     * Nothing about onboarding passes through here, so binding the guard to an organization
+     * costs that flow nothing.
+     *
+     * <p>{@code employee:create} and {@code employee:admin} are Keycloak resource permissions
+     * carried on the RPT, and {@code docs/org-scoped-roles.md} calls them global: they say what
+     * the holder may do and nothing at all about where. On a route that names an organization in
+     * its path and then loads {@link org.tornotron.echno_backend.organization.Organization} by
+     * that id, "what" on its own is not an answer. The tenant root is the one entity neither
+     * ambient defence covers, so the id has to be checked here or not at all, which is what
+     * {@code isCurrentTenant} does.
      *
      * @param userId             The ID of the user joining.
-     * @param orgId              The ID of the organization to join.
+     * @param orgId              The organization named by the caller, which must be the one their
+     *                           session is scoped to.
      * @param employeeJoinOrgDto DTO containing additional employment details.
      * @return A {@link ResponseEntity} with the created employee's DTO and HTTP status 201 (Created).
      */
     @PostMapping("/joinOrganization/{userId}/{orgId}")
-    @PreAuthorize("hasAuthority('employee:create') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.isCurrentTenant(#orgId)"
+            + " and (hasAuthority('employee:create') or hasAuthority('employee:admin'))")
     @Operation(
             summary = "Add a user to an organization as an employee",
-            description = "Creates an employee record that links the given user to the given organization, "
-                    + "using the supplied employment details. Returns the created employee."
+            description = "Creates an employee record that links the given user to the organization "
+                    + "named in the path, which must be the organization the caller's session is "
+                    + "scoped to. Uses the supplied employment details. Returns the created employee."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Employee record created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The employment details failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee create or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee create or admin authority, or named an organization that is not the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user or organization with the given id")
     })
     public ResponseEntity<EmployeeDto> joinOrganization(@PathVariable Long userId, @PathVariable Long orgId, @Valid @RequestBody EmployeeJoinOrgDto employeeJoinOrgDto) {

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeMobileJoinGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeMobileJoinGuardTest.java
@@ -1,0 +1,152 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Proves that the non-web {@code joinOrganization} route refuses an organization the caller is
+ * not entitled to, and that an ordinary administrator acting inside their own organization is
+ * unaffected.
+ *
+ * <p>The route names an organization in its path and
+ * {@link EmployeeService#joinOrganization} then loads it by that id. Its guard used to be the
+ * bare realm authorities alone, which are global: {@code docs/org-scoped-roles.md} describes
+ * {@code employee:create} and {@code employee:admin} as applying everywhere and being scoped to
+ * no organization at all. They therefore answer what the caller may do and say nothing about
+ * where, while the write lands wherever the path said.
+ *
+ * <p>That write is the consequential one. Besides the employee row it adds the user to the
+ * Keycloak group for the named organization, and that group is what {@code JwtAuthConverter}
+ * turns into the {@code ORG_MEMBER_} authority {@code TenantFilter} requires before it will set
+ * a tenant at all. The product is the membership the rest of the tenant layer is built on,
+ * rather than a credential still waiting to be redeemed.
+ *
+ * <p>Nothing underneath catches it, for the reason recorded in
+ * {@code org.tornotron.echno_backend.projectInviteCode.ProjectInviteCodeTenantGuardTest}:
+ * {@code Organization} is the tenant root, outside both the {@code orgFilter} and the
+ * fail-closed load listener. The duplicate {@code existsByUserAndOrganization} check inside the
+ * service does not stand in for a guard either, because {@code Employee} is filtered, so it
+ * evaluates within the caller's own tenant and cannot see a row in another one.
+ *
+ * <p>The caller modelled here holds {@code employee:create} and is a member of
+ * {@link #OWN_ORG}. {@code @orgSecurity} is mocked so the tenant branch is exercised without
+ * building JWT group claims; the authority is real, granted on the token, because that half of
+ * the expression is what has to keep working.
+ */
+@WebMvcTest(EmployeeController.class)
+@Import(EmployeeMobileJoinGuardTest.TestSecurityConfig.class)
+class EmployeeMobileJoinGuardTest {
+
+    private static final long OWN_ORG = 100L;
+    private static final long FOREIGN_ORG = 200L;
+    private static final long USER_ID = 7L;
+
+    private static final String VALID_BODY = """
+            {"designation":"Site Engineer","department":"Civil","status":"active"}
+            """;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EmployeeService employeeService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @BeforeEach
+    void callerIsEntitledToTheirOwnOrganizationOnly() {
+        when(orgSecurity.isCurrentTenant(OWN_ORG)).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(FOREIGN_ORG)).thenReturn(false);
+    }
+
+    @Test
+    void join_intoAnotherOrganization_isForbiddenAndNeverReachesTheService() throws Exception {
+        mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + FOREIGN_ORG)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:create")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isForbidden());
+
+        // The refusal has to land before the service runs. A 403 over a completed join would
+        // leave the employee row and, worse, the Keycloak group membership behind.
+        verifyNoInteractions(employeeService);
+    }
+
+    @Test
+    void join_holdingTheGlobalAdminAuthorityIntoAnotherOrganization_isAlsoForbidden() throws Exception {
+        mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + FOREIGN_ORG)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:admin")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    @Test
+    void join_intoTheCallersOwnOrganization_isStillAllowed() throws Exception {
+        mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + OWN_ORG)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:create")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isCreated());
+    }
+
+    /**
+     * The authority half of the expression still has to be satisfied on its own. Being scoped to
+     * the organization is not a substitute for holding the permission, or every member of an
+     * organization could add employees to it.
+     */
+    @Test
+    void join_intoTheCallersOwnOrganizationWithoutTheAuthority_isForbidden() throws Exception {
+        mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + OWN_ORG)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Closes #697.

## The verdict

The issue asked whether this route is part of mobile onboarding, because if it is, a guard demanding the caller already be entitled to the organization would make onboarding impossible. It is not, and the answer is checkable rather than a judgement call:

- **Onboarding is a different endpoint.** Someone with no membership joins by redeeming an invite code at `POST /api/v1/invitation/web/validate/userId/{userId}`. Its guard, `@orgSecurity.isSelfUser(#userId)`, is deliberately tenant-independent, which is exactly right: the redeemer has no tenant, and that is the state the flow exists to end. **The invite code is the credential there, and that endpoint is correct to be open.** Nothing in this PR touches it.
- **The two paths converge below the controller, not at it.** `ProjectInviteCodeService.validateAndUseInviteCode` calls `EmployeeService.joinOrganization(...)` in process, with the organization taken from the redeemed code. `@PreAuthorize` sits on the controller method, so redemption never evaluates this guard and cannot be affected by changing it.
- **Nothing calls the route.** `echno-core` sends the web form, `/employee/web/joinOrganization/userId/{userId}/organizationId/{orgId}`, and its own note in `employee-service.ts` records that the package used to send this bare shape and every call 404'd. `echno-web` reaches employees only through those hooks. The `echno` Flutter app is stale since 2025-11 and the working copy here is empty, so it calls nothing at all.

So the route is administrative: an entitled person adding someone to an organization. Tightening it breaks nothing and leaves onboarding exactly as it was.

## What was wrong with the guard

`hasAuthority('employee:create') or hasAuthority('employee:admin')`. These are Keycloak resource permissions carried on the RPT, and `docs/org-scoped-roles.md` describes them as **global**: "If you gave a user the `organization:admin` permission, they became an admin for **every single organization** in the system." They answer what the holder may do and say nothing about where. On a route that names an organization in its path and then loads `Organization` by that id, "what" alone is not an answer.

That id reaches `EmployeeService.joinOrganization:148`, which resolves it with `organizationRepository.findById(orgId)`. Neither ambient defence sees it, for the reason #696 established: `Organization` is the tenant root, so it implements no `TenantScopedEntity`, carries no `orgFilter`, and `TenantIsolationLoadListener` returns on its first line for it. The duplicate `existsByUserAndOrganization` check does not stand in for a guard either, because `Employee` **is** filtered, so it evaluates inside the caller's own tenant and cannot see a row in another one.

The write is the consequential part. Besides the employee row, `:191` calls `keycloakGroupService.addUserToOrganization(user.getKeycloakId(), org.getId())`. That group is what `JwtAuthConverter` turns into `ORG_MEMBER_<id>`, which is the authority `TenantFilter` requires before it will set a tenant at all. The product is the membership the whole tenant layer rests on, rather than a credential still waiting to be redeemed.

## The fix

The web twin's shape from #696, and the composition this repository's own document prescribes for a route that names an organization (`hasAuthority(...) and @orgSecurity.isMember(#orgId)`), with `isCurrentTenant` in place of `isMember` because it is the stronger of the two: `TenantFilter` refuses an `X-Organization-Id` the caller holds no `ORG_MEMBER_` authority for, so equality with `TenantContext` establishes entitlement rather than restating the permission. The authority half is kept and still has to be satisfied on its own, so one clause answers where and the other what.

The service keeps its organization parameter. #696's rule is to drop a caller-supplied id so the guard and the write cannot read different keys, and it does not apply here: `EmployeeService.joinOrganization` has a second caller, invite-code redemption, which arrives with no tenant at all and names the organization from the code. Moving the key into `TenantContext` would refuse redemption outright. The guard and the write read the same path variable, which is the property that matters.

## What remains

The route has no caller and a correct twin, so **deleting it** is cleaner than guarding it. That is a published-contract change on a public repository, so it is not folded in here; worth a separate decision alongside the other non-web twins.

## Tests

| Test | What it holds | Red before the fix |
|---|---|---|
| `EmployeeMobileJoinGuardTest.join_intoAnotherOrganization_isForbiddenAndNeverReachesTheService` | an `employee:create` holder naming another organization is refused, before the service runs | **measured** (run 34051109674, `AssertionError` on the status assertion against the unmodified controller) |
| `EmployeeMobileJoinGuardTest.join_holdingTheGlobalAdminAuthorityIntoAnotherOrganization_isAlsoForbidden` | the admin authority does not buy the other organization either | **measured** (same run) |
| `EmployeeMobileJoinGuardTest.join_intoTheCallersOwnOrganization_isStillAllowed` | the ordinary case is unaffected | passed before and after, by design |
| `EmployeeMobileJoinGuardTest.join_intoTheCallersOwnOrganizationWithoutTheAuthority_isForbidden` | being scoped to the organization is not a substitute for the permission | passed before and after, by design |

The test file was pushed as its own commit ahead of the fix, so the run that recorded the red ran the file as committed here. Both reds were the status assertion: the request was not refused.

## OpenAPI

Two description strings changed and no structure, so the two blocks in `docs/openapi.json` were edited in place to the exact strings the annotations now produce. CI re-verifies against the served document.
