### PR TITLE
Bound how many invite codes may be offered for redemption

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -56505,7 +56505,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrganizationDto"
+                  "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
             },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7182,6 +7182,8 @@
           },
           "maxUses": {
             "format": "int32",
+            "maximum": 1000,
+            "minimum": 1,
             "type": "integer"
           },
           "phone": {
@@ -7202,6 +7204,8 @@
           },
           "validityDays": {
             "format": "int32",
+            "maximum": 365,
+            "minimum": 1,
             "type": "integer"
           }
         },
@@ -56403,7 +56407,7 @@
     },
     "/api/v1/invitation/web/validate/userId/{userId}": {
       "post": {
-        "description": "Validates the supplied invite code and joins the user to the organization it grants access to.",
+        "description": "Validates the supplied invite code and joins the user to the organization it grants access to. Attempts are limited: one is charged before the code is looked up and given back when the code is accepted, so a successful redemption costs nothing and repeated wrong codes are answered with 429 and a Retry-After header.",
         "operationId": "validateInviteCode",
         "parameters": [
           {
@@ -56496,6 +56500,16 @@
               }
             },
             "description": "Unprocessable Entity"
+          },
+          "429": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationDto"
+                }
+              }
+            },
+            "description": "The attempt allowance is spent; Retry-After says when it refills"
           },
           "500": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -6,8 +6,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.authorization.ExpressionAuthorizationDecision;
 import org.springframework.validation.FieldError;
@@ -255,6 +257,25 @@ public class GlobalExceptionHandler {
     public ProblemDetail handleInvalidInviteCodeException(InvalidInviteCodeException ex, WebRequest request) {
         logger.error("Invalid Invite Code: ", ex);
         return problem(HttpStatus.BAD_REQUEST, "Invalid Invite Code", ex.getMessage(), request);
+    }
+
+    /**
+     * An operation whose attempt allowance is spent.
+     *
+     * <p>Returned as a {@link ResponseEntity} rather than a bare {@link ProblemDetail} so it can
+     * carry {@code Retry-After}, which is the one thing a well-behaved client needs and the one
+     * thing a wrong number in the body cannot supply. The detail is deliberately uninformative
+     * about how much allowance remains, since that would pace whoever provoked it; the header is
+     * not, because it says only when the refusal ends, which the client is entitled to know.
+     */
+    @ExceptionHandler(TooManyAttemptsException.class)
+    public ResponseEntity<ProblemDetail> handleTooManyAttempts(TooManyAttemptsException ex, WebRequest request) {
+        logger.warn("Attempt allowance exhausted: {}", ex.getMessage());
+        ProblemDetail body = problem(HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests", ex.getMessage(), request);
+        long retryAfterSeconds = Math.max(1, ex.getRetryAfter().toSeconds());
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .header(HttpHeaders.RETRY_AFTER, Long.toString(retryAfterSeconds))
+                .body(body);
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/common/exception/TooManyAttemptsException.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/TooManyAttemptsException.java
@@ -1,0 +1,26 @@
+package org.tornotron.echno_backend.common.exception;
+
+import java.time.Duration;
+
+/**
+ * Raised when a caller has used up the attempts allowed for an operation within its window.
+ *
+ * <p>Carries how long the caller should wait, which becomes the {@code Retry-After} header. The
+ * message deliberately says only that the allowance is spent, never how many attempts remain or
+ * which of the allowances refused, because that would tell whoever provoked it how to pace the
+ * next run.
+ */
+public class TooManyAttemptsException extends RuntimeException {
+
+    private final transient Duration retryAfter;
+
+    public TooManyAttemptsException(String message, Duration retryAfter) {
+        super(message);
+        this.retryAfter = retryAfter;
+    }
+
+    /** How long until the allowance has refilled enough for one more attempt. */
+    public Duration getRetryAfter() {
+        return retryAfter;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/ratelimit/AttemptBuckets.java
+++ b/src/main/java/org/tornotron/echno_backend/common/ratelimit/AttemptBuckets.java
@@ -1,0 +1,34 @@
+package org.tornotron.echno_backend.common.ratelimit;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+
+/**
+ * Supplies a token bucket for a named key, so a caller counting attempts does not have to know
+ * whether the count lives in this process or in the shared Redis.
+ *
+ * <p>Both implementations hand back a {@link Bucket}, which is the interface a local bucket and a
+ * Redis-backed {@code BucketProxy} have in common. Which one is in use follows the same single
+ * switch as every other piece of cross-replica state, {@code echno.cache.provider}: the default
+ * {@code caffeine} keeps the counts in process, {@code redis} shares them across pods. A limit
+ * held in process is still a limit, but on a multi-replica deployment it is one allowance per
+ * replica rather than one allowance, so the effective ceiling is multiplied by the replica count.
+ * That is the reason the redis path exists rather than a preference.
+ *
+ * <p>The key namespace is the caller's to choose and is expected to be prefixed, because on the
+ * redis path the keys of every limiter share one keyspace.
+ */
+public interface AttemptBuckets {
+
+    /**
+     * The bucket for this key, created against the given configuration if it does not exist yet.
+     *
+     * <p>The configuration is only consulted on creation. Changing a limit therefore takes effect
+     * for keys that have expired since the change, which for the windows used here is minutes.
+     *
+     * @param key           the bucket's identity, prefixed by the calling limiter
+     * @param configuration the bandwidths to create the bucket with
+     * @return the bucket, never null
+     */
+    Bucket bucketFor(String key, BucketConfiguration configuration);
+}

--- a/src/main/java/org/tornotron/echno_backend/common/ratelimit/AttemptBucketsConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/ratelimit/AttemptBucketsConfig.java
@@ -1,0 +1,37 @@
+package org.tornotron.echno_backend.common.ratelimit;
+
+import io.lettuce.core.RedisClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.tornotron.echno_backend.projectInviteCode.InviteCodeRedemptionProperties;
+
+/**
+ * Chooses where attempt counts live, from the same single switch as every other piece of
+ * cross-replica state: {@code echno.cache.provider}.
+ *
+ * <p>The two conditions are written as exact opposites rather than as a primary and a
+ * {@code @ConditionalOnMissingBean} fallback, because ordering between bean methods of an
+ * ordinary configuration class is not something to rest a security control on. Exactly one of
+ * them matches for any value of the property.
+ *
+ * <p>The redis bean depends on the {@code RedisClient} that {@code RedisConfig} publishes under
+ * the identical condition, so the two are created together or not at all.
+ */
+@Configuration(proxyBeanMethods = false)
+public class AttemptBucketsConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "echno.cache.provider", havingValue = "redis")
+    public AttemptBuckets redisAttemptBuckets(RedisClient bucket4jRedisClient,
+                                              InviteCodeRedemptionProperties inviteCodeRedemption) {
+        return new RedisAttemptBuckets(bucket4jRedisClient, inviteCodeRedemption.getWindow());
+    }
+
+    @Bean
+    @ConditionalOnExpression("!'${echno.cache.provider:caffeine}'.equals('redis')")
+    public AttemptBuckets inProcessAttemptBuckets() {
+        return new InProcessAttemptBuckets();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/ratelimit/InProcessAttemptBuckets.java
+++ b/src/main/java/org/tornotron/echno_backend/common/ratelimit/InProcessAttemptBuckets.java
@@ -1,0 +1,62 @@
+package org.tornotron.echno_backend.common.ratelimit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.local.LocalBucketBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+
+/**
+ * {@link AttemptBuckets} held in this JVM, the default when {@code echno.cache.provider} is not
+ * {@code redis}.
+ *
+ * <p>Backed by a bounded Caffeine cache rather than a plain map, for the reason
+ * {@code UnscopedAccessGuard} bounds its own tracking map: the key is caller-influenced, so an
+ * unbounded map is a leak someone can drive. Entries expire after an idle period longer than any
+ * bandwidth window in use, so a bucket is only dropped once it would have refilled to full
+ * anyway, and a fresh bucket starts full.
+ *
+ * <p>Eviction under the size cap is the one case where dropping a bucket loses something: a
+ * partly spent bucket evicted early comes back full. The cap is far above the number of distinct
+ * callers a deployment has, and reaching it is itself the signal that the limit wants a different
+ * key rather than a larger map.
+ */
+@Slf4j
+public class InProcessAttemptBuckets implements AttemptBuckets {
+
+    /**
+     * Distinct keys tracked at once. Each entry is one small bucket, so this bounds memory rather
+     * than tuning the limit.
+     */
+    private static final long MAX_TRACKED_KEYS = 100_000;
+
+    /** How long an untouched bucket is kept. */
+    private static final Duration IDLE_RETENTION = Duration.ofHours(6);
+
+    private final Cache<String, Bucket> buckets = Caffeine.newBuilder()
+            .maximumSize(MAX_TRACKED_KEYS)
+            .expireAfterAccess(IDLE_RETENTION)
+            .build();
+
+    @Override
+    public Bucket bucketFor(String key, BucketConfiguration configuration) {
+        return buckets.get(key, missing -> {
+            log.debug("Opening an in-process attempt bucket for {}", missing);
+            LocalBucketBuilder builder = Bucket.builder();
+            for (Bandwidth bandwidth : configuration.getBandwidths()) {
+                builder.addLimit(bandwidth);
+            }
+            return builder.build();
+        });
+    }
+
+    /** Visible for tests that need to observe how many keys are being tracked. */
+    long trackedKeys() {
+        buckets.cleanUp();
+        return buckets.estimatedSize();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/ratelimit/InProcessAttemptBuckets.java
+++ b/src/main/java/org/tornotron/echno_backend/common/ratelimit/InProcessAttemptBuckets.java
@@ -53,10 +53,4 @@ public class InProcessAttemptBuckets implements AttemptBuckets {
             return builder.build();
         });
     }
-
-    /** Visible for tests that need to observe how many keys are being tracked. */
-    long trackedKeys() {
-        buckets.cleanUp();
-        return buckets.estimatedSize();
-    }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/ratelimit/RedisAttemptBuckets.java
+++ b/src/main/java/org/tornotron/echno_backend/common/ratelimit/RedisAttemptBuckets.java
@@ -1,0 +1,55 @@
+package org.tornotron.echno_backend.common.ratelimit;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
+import io.lettuce.core.RedisClient;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * {@link AttemptBuckets} held in the shared Redis, active when {@code echno.cache.provider} is
+ * {@code redis}.
+ *
+ * <p>This is what makes an attempt limit mean one allowance rather than one allowance per pod.
+ * Without it a multi-replica deployment multiplies every ceiling by its replica count, which for
+ * a limit whose whole purpose is to bound how many values may be tried is the difference between
+ * a bound and a suggestion. {@code RedisDistributedStateIT} holds the underlying property, that
+ * two independent proxy managers over the same key draw on one allowance.
+ *
+ * <p>Redis is not authoritative state and this deliberately does not fail closed on it: if Redis
+ * is unreachable the bucket4j call throws, and the limiter treats that as an unavailable limit
+ * and lets the request through rather than refusing every redemption in the deployment. Availability
+ * is chosen over the limit here because the limit is a rate reducer over an already-authenticated
+ * endpoint, not the thing that decides whether a code is valid.
+ */
+@Slf4j
+public class RedisAttemptBuckets implements AttemptBuckets {
+
+    /**
+     * How long Redis keeps a bucket after its last write. Past the point where the bucket has
+     * refilled to full there is nothing left to remember, so the key is allowed to expire; a
+     * margin is added so a bucket is never dropped while it still holds a deficit.
+     */
+    private static final Duration EXPIRY_MARGIN = Duration.ofMinutes(5);
+
+    private final ProxyManager<String> proxyManager;
+
+    public RedisAttemptBuckets(RedisClient redisClient, Duration longestWindow) {
+        this.proxyManager = LettuceBasedProxyManager.builderFor(redisClient)
+                .withExpirationStrategy(ExpirationAfterWriteStrategy
+                        .basedOnTimeForRefillingBucketUpToMax(longestWindow.plus(EXPIRY_MARGIN)))
+                .build()
+                .withMapper(key -> key.getBytes(StandardCharsets.UTF_8));
+        log.info("Attempt limits are backed by the shared Redis, so they are enforced across replicas");
+    }
+
+    @Override
+    public Bucket bucketFor(String key, BucketConfiguration configuration) {
+        return proxyManager.builder().build(key, () -> configuration);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/ratelimit/RedisAttemptBuckets.java
+++ b/src/main/java/org/tornotron/echno_backend/common/ratelimit/RedisAttemptBuckets.java
@@ -16,40 +16,72 @@ import java.time.Duration;
  * {@code redis}.
  *
  * <p>This is what makes an attempt limit mean one allowance rather than one allowance per pod.
- * Without it a multi-replica deployment multiplies every ceiling by its replica count, which for
- * a limit whose whole purpose is to bound how many values may be tried is the difference between
- * a bound and a suggestion. {@code RedisDistributedStateIT} holds the underlying property, that
- * two independent proxy managers over the same key draw on one allowance.
+ * Without it a multi-replica deployment multiplies every ceiling by its replica count, which for a
+ * limit whose purpose is to bound how many values may be tried is the difference between a bound
+ * and a suggestion. {@code RedisDistributedStateIT} holds the underlying property, that two
+ * independent proxy managers over the same key draw on one allowance.
  *
- * <p>Redis is not authoritative state and this deliberately does not fail closed on it: if Redis
- * is unreachable the bucket4j call throws, and the limiter treats that as an unavailable limit
- * and lets the request through rather than refusing every redemption in the deployment. Availability
- * is chosen over the limit here because the limit is a rate reducer over an already-authenticated
- * endpoint, not the thing that decides whether a code is valid.
+ * <p><b>Nothing here touches Redis until a request does.</b> The proxy manager opens a connection
+ * when it is built, so building it in the constructor would make an unreachable Redis a context
+ * that never refreshes: the compose staging renders {@code ECHNO_CACHE_PROVIDER=redis} from the app
+ * deploy while the redis container itself comes from a separate infra run, so "configured for redis,
+ * redis not up yet" is an ordinary state rather than a fault. {@code RedisUnreachableBootIT} is the
+ * test that holds the whole application to that, and it is what caught this being built eagerly.
+ *
+ * <p>Redis is not authoritative state and this deliberately does not fail closed on it. A failure
+ * to reach it propagates out of {@link #bucketFor}, and {@code InviteCodeRedemptionLimiter} treats
+ * that as an unavailable limit and lets the request through rather than refusing every redemption
+ * in the deployment. Availability is chosen over the limit because the limit reduces a rate over an
+ * already-authenticated endpoint; it is not what decides whether a code is valid.
  */
 @Slf4j
 public class RedisAttemptBuckets implements AttemptBuckets {
 
     /**
      * How long Redis keeps a bucket after its last write. Past the point where the bucket has
-     * refilled to full there is nothing left to remember, so the key is allowed to expire; a
-     * margin is added so a bucket is never dropped while it still holds a deficit.
+     * refilled to full there is nothing left to remember, so the key is allowed to expire; a margin
+     * is added so a bucket is never dropped while it still holds a deficit.
      */
     private static final Duration EXPIRY_MARGIN = Duration.ofMinutes(5);
 
-    private final ProxyManager<String> proxyManager;
+    private final RedisClient redisClient;
+    private final Duration longestWindow;
+
+    private volatile ProxyManager<String> proxyManager;
 
     public RedisAttemptBuckets(RedisClient redisClient, Duration longestWindow) {
-        this.proxyManager = LettuceBasedProxyManager.builderFor(redisClient)
-                .withExpirationStrategy(ExpirationAfterWriteStrategy
-                        .basedOnTimeForRefillingBucketUpToMax(longestWindow.plus(EXPIRY_MARGIN)))
-                .build()
-                .withMapper(key -> key.getBytes(StandardCharsets.UTF_8));
-        log.info("Attempt limits are backed by the shared Redis, so they are enforced across replicas");
+        this.redisClient = redisClient;
+        this.longestWindow = longestWindow;
+        log.info("Attempt limits will be backed by the shared Redis, so they are enforced across replicas");
     }
 
     @Override
     public Bucket bucketFor(String key, BucketConfiguration configuration) {
-        return proxyManager.builder().build(key, () -> configuration);
+        return proxyManager().builder().build(key, () -> configuration);
+    }
+
+    /**
+     * The proxy manager, built on first use.
+     *
+     * <p>A build that fails leaves the field null, so the next request tries again rather than
+     * writing off Redis for the life of the process. That matters for the case this laziness exists
+     * for: Redis arriving a few minutes after the application did.
+     */
+    private ProxyManager<String> proxyManager() {
+        ProxyManager<String> existing = proxyManager;
+        if (existing != null) {
+            return existing;
+        }
+        synchronized (this) {
+            if (proxyManager == null) {
+                proxyManager = LettuceBasedProxyManager.builderFor(redisClient)
+                        .withExpirationStrategy(ExpirationAfterWriteStrategy
+                                .basedOnTimeForRefillingBucketUpToMax(longestWindow.plus(EXPIRY_MARGIN)))
+                        .build()
+                        .withMapper(key -> key.getBytes(StandardCharsets.UTF_8));
+                log.info("Attempt-limit buckets connected to the shared Redis");
+            }
+            return proxyManager;
+        }
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/InviteCodeRedemptionLimiter.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/InviteCodeRedemptionLimiter.java
@@ -1,0 +1,166 @@
+package org.tornotron.echno_backend.projectInviteCode;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.ConsumptionProbe;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.exception.TooManyAttemptsException;
+import org.tornotron.echno_backend.common.ratelimit.AttemptBuckets;
+
+import java.time.Duration;
+
+/**
+ * Bounds how many invite codes may be offered for redemption.
+ *
+ * <p>An invite code is a bearer credential. Redemption resolves it with
+ * {@code findByCode} and no organization qualifier, and it cannot have one, because the person
+ * redeeming holds no membership yet: that is the state the flow exists to get them out of. The
+ * guard on the endpoint, {@code isSelfUser}, is correct and deliberately says nothing about a
+ * tenant. So the only thing standing between a value and membership of the organization it
+ * belongs to is that the value has to be known, and that property only holds while the number of
+ * values that can be offered is bounded. Nothing bounded it.
+ *
+ * <p>Two allowances, because they answer different questions.
+ *
+ * <ul>
+ *   <li><b>Per caller.</b> The endpoint is authenticated, so there is a principal to key on, and
+ *       it is a far better key than an address: {@code getRemoteAddr()} behind the Cloudflare
+ *       tunnel and the reverse proxy is the proxy, so an address-keyed limit here would be one
+ *       shared allowance for the whole deployment wearing the name of a per-client one.
+ *   <li><b>Per deployment.</b> A per-caller limit is worth exactly what another account costs,
+ *       and where self-registration is open that is close to nothing. This one does not move when
+ *       someone brings more accounts. It is set well above any believable volume of genuine wrong
+ *       codes, because someone who burns it delays everyone else until it refills, and that trade
+ *       is only acceptable while the ceiling is far from ordinary traffic.
+ * </ul>
+ *
+ * <p><b>A successful redemption is refunded.</b> A token is taken before the lookup, so an attempt
+ * is paid for whether or not the code turns out to exist, and given back when the code was good.
+ * A person redeeming the code they were sent therefore spends nothing at all, and the allowance is
+ * in practice a budget for wrong codes. Taking the token first is what makes it a limit on
+ * attempts rather than on failures: it is charged before anything is looked up, so there is no
+ * window in which an unbounded number of lookups is already in flight.
+ *
+ * <p>This reduces a rate. It does not make a code strong, and it should not be read as having
+ * closed the question: a credential worth guessing is still worth guessing more slowly. What
+ * settles it is a code wide enough that guessing is not a strategy, and that is a contract change
+ * across the published API, {@code echno-core} and the mobile client rather than a backend patch.
+ */
+@Slf4j
+@Component
+public class InviteCodeRedemptionLimiter {
+
+    /**
+     * The single deployment-wide bucket's key. A constant rather than a derived value: the point
+     * of this allowance is that nothing the caller controls splits it.
+     */
+    private static final String DEPLOYMENT_KEY = "invite-code-redemption:deployment";
+
+    private static final String CALLER_KEY_PREFIX = "invite-code-redemption:caller:";
+
+    /** Used when no authentication is on the context, which on this endpoint should not happen. */
+    private static final String UNAUTHENTICATED_CALLER = "unauthenticated";
+
+    private final AttemptBuckets buckets;
+    private final InviteCodeRedemptionProperties properties;
+
+    public InviteCodeRedemptionLimiter(AttemptBuckets buckets, InviteCodeRedemptionProperties properties) {
+        this.buckets = buckets;
+        this.properties = properties;
+    }
+
+    /**
+     * Charges one attempt to the current caller and to the deployment.
+     *
+     * @param callerKey the caller's identity, from {@link #currentCallerKey()}
+     * @throws TooManyAttemptsException if either allowance is spent
+     */
+    public void chargeAttempt(String callerKey) {
+        ConsumptionProbe caller = consume(CALLER_KEY_PREFIX + callerKey, properties.getAttemptsPerCaller());
+        if (caller != null && !caller.isConsumed()) {
+            log.warn("Invite-code redemption refused: the per-caller attempt allowance is spent");
+            throw refusal(caller);
+        }
+
+        ConsumptionProbe deployment = consume(DEPLOYMENT_KEY, properties.getAttemptsPerDeployment());
+        if (deployment != null && !deployment.isConsumed()) {
+            // The caller's own token was already taken and their allowance is not the one that
+            // refused, so give it back rather than charging them for a queue they did not cause.
+            refund(CALLER_KEY_PREFIX + callerKey, properties.getAttemptsPerCaller());
+            log.warn("Invite-code redemption refused: the deployment-wide attempt allowance is spent");
+            throw refusal(deployment);
+        }
+    }
+
+    /**
+     * Gives back the attempt charged by {@link #chargeAttempt}, for a redemption that succeeded.
+     *
+     * <p>Called after the code has been accepted, so it never runs on a wrong code. Adding tokens
+     * cannot take a bucket past its capacity, so a refund on an untouched bucket is a no-op.
+     */
+    public void refundAttempt(String callerKey) {
+        refund(CALLER_KEY_PREFIX + callerKey, properties.getAttemptsPerCaller());
+        refund(DEPLOYMENT_KEY, properties.getAttemptsPerDeployment());
+    }
+
+    /**
+     * The key the current request's attempts are counted against: the authenticated principal.
+     *
+     * <p>Read once and passed in, rather than resolved separately by the charge and the refund,
+     * so the two cannot end up reading different keys.
+     */
+    public String currentCallerKey() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            return UNAUTHENTICATED_CALLER;
+        }
+        return authentication.getName();
+    }
+
+    /**
+     * @return the probe, or null when this allowance is switched off or its store is unreachable
+     */
+    private ConsumptionProbe consume(String key, int capacity) {
+        if (capacity <= 0) {
+            return null;
+        }
+        try {
+            return bucket(key, capacity).tryConsumeAndReturnRemaining(1);
+        } catch (RuntimeException e) {
+            // A shared bucket store that cannot be reached leaves the limit unavailable. Refusing
+            // every redemption in the deployment on that basis would turn an outage in something
+            // advisory into an outage in onboarding, so the request proceeds and the failure is
+            // reported rather than absorbed.
+            log.error("Attempt bucket {} could not be read, redemption proceeds unlimited: {}", key, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private void refund(String key, int capacity) {
+        if (capacity <= 0) {
+            return;
+        }
+        try {
+            bucket(key, capacity).addTokens(1);
+        } catch (RuntimeException e) {
+            log.error("Attempt bucket {} could not be refunded: {}", key, e.getMessage(), e);
+        }
+    }
+
+    private Bucket bucket(String key, int capacity) {
+        Duration window = properties.getWindow();
+        BucketConfiguration configuration = BucketConfiguration.builder()
+                .addLimit(limit -> limit.capacity(capacity).refillGreedy(capacity, window))
+                .build();
+        return buckets.bucketFor(key, configuration);
+    }
+
+    private TooManyAttemptsException refusal(ConsumptionProbe probe) {
+        Duration retryAfter = Duration.ofNanos(probe.getNanosToWaitForRefill());
+        return new TooManyAttemptsException(
+                "Too many invite code attempts. Try again later.", retryAfter);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/InviteCodeRedemptionProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/InviteCodeRedemptionProperties.java
@@ -1,0 +1,55 @@
+package org.tornotron.echno_backend.projectInviteCode;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Limits on how often an invite code may be offered for redemption. Bound from
+ * {@code echno.invite-code.redemption.*}.
+ *
+ * <p>An invite code is a bearer credential: whoever presents a live value joins the organization
+ * it belongs to. Redemption looks the value up with no organization qualifier, and it cannot
+ * carry one, because the person redeeming has no tenant yet. What is left between a value and
+ * membership is that the value has to be known, and that only holds while the number of values
+ * that may be offered is bounded. These are the bound.
+ *
+ * <p>They reduce a rate; they do not make a code strong. A code whose shape leaves it worth
+ * guessing is still worth guessing more slowly. Widening the code is the change that removes the
+ * question, and it is a contract change across the published API, {@code echno-core} and the
+ * mobile client, so it is tracked separately.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "echno.invite-code.redemption")
+public class InviteCodeRedemptionProperties {
+
+    /**
+     * Attempts one caller may make in a window. Refunded on success, so an ordinary redemption
+     * spends nothing and this is in practice a budget for wrong codes.
+     *
+     * <p>Ten leaves room for someone mistyping a code they were legitimately given several times
+     * over, which is the only way a real person reaches this at all. Zero disables the per-caller
+     * limit.
+     */
+    private int attemptsPerCaller = 10;
+
+    /**
+     * Attempts the whole deployment may make in a window, across every caller.
+     *
+     * <p>The per-caller limit alone is only as strong as the cost of holding another account, and
+     * where self-registration is open that cost is close to nothing. This is the ceiling that
+     * does not move when someone brings more accounts.
+     *
+     * <p>It buys that at a price worth stating plainly: someone who burns it delays everyone
+     * else's redemptions until it refills. That is why it is set well above any believable volume
+     * of genuine wrong codes rather than tight, and why it is configurable per deployment. Zero
+     * disables it, which is the right setting only where something upstream is doing the same job.
+     */
+    private int attemptsPerDeployment = 500;
+
+    /** The window both allowances refill over. */
+    private Duration window = Duration.ofHours(1);
+}

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
@@ -1,10 +1,13 @@
 package org.tornotron.echno_backend.projectInviteCode;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -113,7 +116,14 @@ public class ProjectInviteCodeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation or the code is invalid or expired"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the target user nor a role holder in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "The attempt allowance is spent; Retry-After says when it refills")
+            // The schema is spelt out because this handler returns a ResponseEntity rather than a
+            // bare ProblemDetail, so it can carry Retry-After. Springdoc reads the advice's return
+            // type to fill in an undeclared body, and a ResponseEntity tells it nothing, so it
+            // falls back to the operation's own return type and documents the 429 as an
+            // OrganizationDto. It is a ProblemDetail like every other error on this API.
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429",
+                    description = "The attempt allowance is spent; Retry-After says when it refills",
+                    content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
     })
     public ResponseEntity<OrganizationDto> validateInviteCode(@Valid @RequestBody InviteCodeValidationDto inviteCodeValidationDto,
                                                               @PathVariable Long userId) {

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
@@ -104,13 +104,16 @@ public class ProjectInviteCodeController {
     @Operation(
             summary = "Validate and use an invite code",
             description = "Validates the supplied invite code and joins the user to the organization it "
-                    + "grants access to."
+                    + "grants access to. Attempts are limited: one is charged before the code is looked "
+                    + "up and given back when the code is accepted, so a successful redemption costs "
+                    + "nothing and repeated wrong codes are answered with 429 and a Retry-After header."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Invite code accepted and organization joined"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation or the code is invalid or expired"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the target user nor a role holder in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "The attempt allowance is spent; Retry-After says when it refills")
     })
     public ResponseEntity<OrganizationDto> validateInviteCode(@Valid @RequestBody InviteCodeValidationDto inviteCodeValidationDto,
                                                               @PathVariable Long userId) {

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeService.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeService.java
@@ -10,6 +10,7 @@ import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.InvalidInviteCodeException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.exception.TenantIdMissingException;
+import org.tornotron.echno_backend.common.exception.TooManyAttemptsException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -44,6 +45,7 @@ public class ProjectInviteCodeService {
     private final ProjectInviteCodeMapper projectInviteCodeMapper;
     private final org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper;
     private final ShiftTimingRepository shiftTimingRepository;
+    private final InviteCodeRedemptionLimiter redemptionLimiter;
 
     /**
      * Constructs a ProjectInviteCodeService with the necessary repositories and services.
@@ -51,8 +53,9 @@ public class ProjectInviteCodeService {
      * @param inviteCodeRepository   The repository for invite code data access.
      * @param employeeService        The service for employee-related operations.
      * @param organizationRepository The repository for organization data access.
+     * @param redemptionLimiter      Bounds how many codes may be offered for redemption.
      */
-    public ProjectInviteCodeService(ProjectInviteCodeRepository inviteCodeRepository, EmployeeService employeeService, OrganizationRepository organizationRepository, FileStorageService fileStorageService, EmployeeRepository employeeRepository, ProjectInviteCodeMapper projectInviteCodeMapper, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, ShiftTimingRepository shiftTimingRepository) {
+    public ProjectInviteCodeService(ProjectInviteCodeRepository inviteCodeRepository, EmployeeService employeeService, OrganizationRepository organizationRepository, FileStorageService fileStorageService, EmployeeRepository employeeRepository, ProjectInviteCodeMapper projectInviteCodeMapper, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, ShiftTimingRepository shiftTimingRepository, InviteCodeRedemptionLimiter redemptionLimiter) {
         this.inviteCodeRepository = inviteCodeRepository;
         this.employeeService = employeeService;
         this.organizationRepository = organizationRepository;
@@ -61,6 +64,7 @@ public class ProjectInviteCodeService {
         this.projectInviteCodeMapper = projectInviteCodeMapper;
         this.organizationMapper = organizationMapper;
         this.shiftTimingRepository = shiftTimingRepository;
+        this.redemptionLimiter = redemptionLimiter;
     }
 
     /**
@@ -70,6 +74,27 @@ public class ProjectInviteCodeService {
      */
     public int generateSecureFiveDigitNumber() {
         return 10000 + secureRandom.nextInt(90000);
+    }
+
+    /**
+     * Reads the submitted code as the integer the column stores.
+     *
+     * <p>The submitted value is a string of exactly five characters, which the request body's own
+     * constraint enforces, but nothing said those characters were digits. Parsing it directly
+     * turned a five-letter submission into a {@code NumberFormatException} and a 500, so a
+     * malformed code was answered by a server error rather than by a refusal, and it was answered
+     * that way without the attempt being judged at all.
+     *
+     * @param code the submitted code
+     * @return the code as an integer
+     * @throws InvalidInviteCodeException if it is not one
+     */
+    private int parseCode(String code) {
+        try {
+            return Integer.parseInt(code);
+        } catch (NumberFormatException e) {
+            throw new InvalidInviteCodeException("Invite code '" + code + "' is not a valid code");
+        }
     }
 
     /**
@@ -146,14 +171,30 @@ public class ProjectInviteCodeService {
     /**
      * Validates an invite code and, if successful, adds the user to the associated organization as an employee.
      *
+     * <p>Every call costs one attempt from {@link InviteCodeRedemptionLimiter}, charged before the
+     * code is looked up and given back when the code turns out to be good. The reason it is
+     * charged rather than only counted on failure is written out on the limiter: this is the one
+     * endpoint where a bearer credential is resolved with no organization qualifier and none is
+     * possible, so the number of values that may be offered is the only thing keeping the credential
+     * worth anything. Charging first is what makes the ceiling apply to attempts rather than to
+     * whatever fraction of them has already finished failing.
+     *
+     * <p>The charge lives outside the transaction's effects on purpose. It is held in the attempt
+     * bucket rather than in the database, so a rejected code rolls the transaction back and leaves
+     * the attempt counted, which is the whole point.
+     *
      * @param inviteCodeValidationDto DTO containing the user ID and the invite code to validate.
      * @return A DTO of the organization the user has joined.
+     * @throws TooManyAttemptsException if the caller's or the deployment's attempt allowance is spent.
      * @throws ResourceNotFoundException if the invite code is not found.
-     * @throws InvalidInviteCodeException if the code is expired, inactive, or has reached its usage limit.
+     * @throws InvalidInviteCodeException if the code is malformed, expired, inactive, or has reached its usage limit.
      */
     @Transactional
     public OrganizationDto validateAndUseInviteCode(InviteCodeValidationDto inviteCodeValidationDto,Long userId) {
-        ProjectInviteCode inviteCode = inviteCodeRepository.findByCode(Integer.parseInt(inviteCodeValidationDto.getCode()))
+        String callerKey = redemptionLimiter.currentCallerKey();
+        redemptionLimiter.chargeAttempt(callerKey);
+
+        ProjectInviteCode inviteCode = inviteCodeRepository.findByCode(parseCode(inviteCodeValidationDto.getCode()))
                 .orElseThrow(() -> new ResourceNotFoundException("Invite code '" + inviteCodeValidationDto.getCode() + "' was not found"));
         if(inviteCode.getExpiryDate().isBefore(LocalDateTime.now())) {
             throw new InvalidInviteCodeException("Invite code '" + inviteCodeValidationDto.getCode() + "' expired on " + inviteCode.getExpiryDate());
@@ -164,6 +205,7 @@ public class ProjectInviteCodeService {
         if(inviteCode.getCurrentUses() >= inviteCode.getMaxUses()) {
             throw new InvalidInviteCodeException("Invite code '" + inviteCodeValidationDto.getCode() + "' has reached its maximum usage limit of " + inviteCode.getMaxUses());
         }
+        redemptionLimiter.refundAttempt(callerKey);
         inviteCodeRepository.save(inviteCode);
         Organization organization = inviteCode.getOrganization();
         Map<String,Object> employeeDetails = inviteCode.getEmployeeDetails();

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/dto/InviteCodeGenerationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/dto/InviteCodeGenerationDto.java
@@ -2,6 +2,8 @@ package org.tornotron.echno_backend.projectInviteCode.dto;
 
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -11,8 +13,28 @@ import lombok.Data;
 @Data
 public class InviteCodeGenerationDto {
 
+    /**
+     * How many times the code may be redeemed. Defaults to single use, which is what an invite
+     * addressed to one person should be.
+     *
+     * <p>The bounds are guardrails rather than policy. Below one the code is born unusable; far
+     * above it the code stops being an invitation and becomes a standing key to the organization,
+     * which is a different thing with a different risk and should not be reachable by leaving a
+     * field unbounded. The one client that generates codes never sends this field at all.
+     */
+    @Min(value = 1, message = "maxUses must be at least 1")
+    @Max(value = 1000, message = "maxUses must be at most 1000")
     int maxUses = 1;
 
+    /**
+     * How long the code stays redeemable, in days.
+     *
+     * <p>Bounded for the same reason: an unbounded value is how a credential ends up with no
+     * expiry in practice, and a value large enough overflows the date arithmetic outright. A year
+     * is already generous for an invitation. The console offers 7 to 90.
+     */
+    @Min(value = 1, message = "validityDays must be at least 1")
+    @Max(value = 365, message = "validityDays must be at most 365")
     int validityDays = 5;
 
     private String employeeId;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -244,6 +244,29 @@ echno:
       # which can differ from the internal URL the backend dials, so list every URL
       # the same realm may present.
       accepted-issuers: ${ECHNO_JWT_ACCEPTED_ISSUERS:}
+  invite-code:
+    redemption:
+      # How many times a code may be offered before the caller has to wait. An attempt is charged
+      # before the code is looked up and given back when the code turns out to be good, so an
+      # ordinary redemption spends nothing and this is a budget for wrong codes.
+      #
+      # The redemption endpoint resolves a bearer credential with no organization qualifier, and
+      # none is possible, because the person redeeming holds no membership yet. What keeps the
+      # credential worth anything is that its value has to be known, and that only holds while the
+      # number of values that may be offered is bounded.
+      #
+      # Two allowances. The per-caller one is keyed on the authenticated principal, which is a far
+      # better key than the socket address: behind the tunnel and the reverse proxy that address is
+      # the proxy. The deployment-wide one is the ceiling that does not move when someone brings
+      # more accounts, and it is set well above any believable volume of genuine wrong codes,
+      # because whoever burns it delays everyone else until it refills. Either set to 0 disables
+      # that allowance.
+      #
+      # On a multi-replica deployment these are per replica unless echno.cache.provider is redis,
+      # which is what puts the counts in the shared store.
+      attempts-per-caller: ${ECHNO_INVITE_CODE_ATTEMPTS_PER_CALLER:10}
+      attempts-per-deployment: ${ECHNO_INVITE_CODE_ATTEMPTS_PER_DEPLOYMENT:500}
+      window: ${ECHNO_INVITE_CODE_ATTEMPT_WINDOW:1h}
   document-number:
     # Site transfer, purchase order, indent and GRN numbers carry the year they were issued in,
     # and the counter behind them resets with it. The year is read in this zone rather than the

--- a/src/test/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandlerTest.java
@@ -2,8 +2,10 @@ package org.tornotron.echno_backend.common.exception;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.expression.Expression;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.authorization.ExpressionAuthorizationDecision;
 import org.springframework.validation.BindingResult;
@@ -13,6 +15,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.tornotron.echno_backend.indent.enums.IndentStatus;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -258,5 +261,40 @@ class GlobalExceptionHandlerTest {
         assertThat(pd.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
         assertThat(pd.getTitle()).isEqualTo("Report Generation Failed");
         assertThat(pd.getDetail()).contains("report/report");
+    }
+
+    /**
+     * A spent attempt allowance. The status is the one that means "later" and the wait travels in
+     * Retry-After, which is why this handler returns a ResponseEntity where the rest return a bare
+     * problem: a header is the one part of the answer the body cannot carry.
+     */
+    @Test
+    void tooManyAttempts_isA429CarryingRetryAfter() {
+        ResponseEntity<ProblemDetail> response = handler.handleTooManyAttempts(
+                new TooManyAttemptsException("Too many invite code attempts. Try again later.",
+                        Duration.ofMinutes(4)),
+                requestWithPath("uri=/api/v1/invitation/web/validate/userId/55"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isEqualTo("240");
+        ProblemDetail pd = response.getBody();
+        assertThat(pd).isNotNull();
+        assertThat(pd.getTitle()).isEqualTo("Too Many Requests");
+        assertThat(pd.getDetail()).isEqualTo("Too many invite code attempts. Try again later.");
+        assertThat(pd.getProperties()).containsEntry("message", "Too many invite code attempts. Try again later.");
+    }
+
+    /**
+     * Retry-After is whole seconds, so a wait under one second still asks for one. Rounded to zero
+     * it would invite the immediate retry the header exists to prevent.
+     */
+    @Test
+    void tooManyAttempts_neverAsksTheClientToRetryImmediately() {
+        ResponseEntity<ProblemDetail> response = handler.handleTooManyAttempts(
+                new TooManyAttemptsException("Too many invite code attempts. Try again later.",
+                        Duration.ofMillis(200)),
+                requestWithPath("uri=/api/v1/invitation/web/validate/userId/55"));
+
+        assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isEqualTo("1");
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/common/ratelimit/RedisAttemptBucketsLazinessTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/ratelimit/RedisAttemptBucketsLazinessTest.java
@@ -1,0 +1,67 @@
+package org.tornotron.echno_backend.common.ratelimit;
+
+import io.github.bucket4j.BucketConfiguration;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.projectInviteCode.InviteCodeRedemptionLimiter;
+import org.tornotron.echno_backend.projectInviteCode.InviteCodeRedemptionProperties;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The Redis-backed buckets must not dial Redis before a request asks them to.
+ *
+ * <p>The compose staging renders {@code ECHNO_CACHE_PROVIDER=redis} from the application deploy
+ * while the redis container comes from a separate infra run, so "configured for redis, redis not up
+ * yet" is an ordinary state. {@code RedisUnreachableBootIT} holds the whole application to booting
+ * through it. This pins the same property on the one class responsible for it, without a context or
+ * a container, so a regression is named here rather than showing up as a whole-application boot
+ * failure.
+ *
+ * <p>It also pins the other half: once a request does arrive and Redis is still not there, the
+ * failure surfaces from {@code bucketFor} and the limiter lets the request through. A limit that
+ * cannot be consulted must not become an onboarding outage.
+ */
+class RedisAttemptBucketsLazinessTest {
+
+    // Port 1 is reserved and nothing listens on it, so a connection attempt is refused at once
+    // rather than hanging. The same address RedisUnreachableBootIT uses, for the same reason.
+    private final RedisClient unreachable =
+            RedisClient.create(RedisURI.builder().withHost("127.0.0.1").withPort(1).build());
+
+    @AfterEach
+    void shutdownClient() {
+        unreachable.shutdown();
+    }
+
+    @Test
+    void constructionDoesNotTouchRedis() {
+        assertThatCode(() -> new RedisAttemptBuckets(unreachable, Duration.ofHours(1)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aRequestAgainstAnUnreachableRedisFails() {
+        RedisAttemptBuckets buckets = new RedisAttemptBuckets(unreachable, Duration.ofHours(1));
+        BucketConfiguration configuration = BucketConfiguration.builder()
+                .addLimit(limit -> limit.capacity(10).refillGreedy(10, Duration.ofHours(1)))
+                .build();
+
+        assertThatThrownBy(() -> buckets.bucketFor("some-key", configuration))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void theLimiterTurnsThatFailureIntoAnUnlimitedRequestRatherThanARefusal() {
+        InviteCodeRedemptionProperties properties = new InviteCodeRedemptionProperties();
+        InviteCodeRedemptionLimiter limiter = new InviteCodeRedemptionLimiter(
+                new RedisAttemptBuckets(unreachable, Duration.ofHours(1)), properties);
+
+        assertThatCode(() -> limiter.chargeAttempt("ravi")).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/projectInviteCode/InviteCodeRedemptionLimiterTest.java
+++ b/src/test/java/org/tornotron/echno_backend/projectInviteCode/InviteCodeRedemptionLimiterTest.java
@@ -1,0 +1,216 @@
+package org.tornotron.echno_backend.projectInviteCode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.TooManyAttemptsException;
+import org.tornotron.echno_backend.common.ratelimit.AttemptBuckets;
+import org.tornotron.echno_backend.common.ratelimit.InProcessAttemptBuckets;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The policy the limiter enforces, against real buckets rather than a mock of them, because the
+ * thing worth holding is that the allowance actually runs out and actually comes back.
+ */
+class InviteCodeRedemptionLimiterTest {
+
+    private static final String CALLER = "ravi";
+    private static final String ANOTHER_CALLER = "meera";
+
+    private AttemptBuckets buckets;
+    private InviteCodeRedemptionProperties properties;
+
+    @BeforeEach
+    void freshBuckets() {
+        buckets = new InProcessAttemptBuckets();
+        properties = new InviteCodeRedemptionProperties();
+        properties.setWindow(Duration.ofHours(1));
+    }
+
+    private InviteCodeRedemptionLimiter limiter() {
+        return new InviteCodeRedemptionLimiter(buckets, properties);
+    }
+
+    @Test
+    void aCallerIsRefusedOnceTheirAllowanceIsSpent() {
+        properties.setAttemptsPerCaller(3);
+        InviteCodeRedemptionLimiter limiter = limiter();
+
+        for (int i = 0; i < 3; i++) {
+            int attempt = i;
+            assertThatCode(() -> limiter.chargeAttempt(CALLER))
+                    .as("attempt %d", attempt)
+                    .doesNotThrowAnyException();
+        }
+
+        assertThatThrownBy(() -> limiter.chargeAttempt(CALLER))
+                .isInstanceOf(TooManyAttemptsException.class);
+    }
+
+    /**
+     * The refusal has to say when it ends, or a client's only option is to keep asking, which is
+     * the behaviour the limit exists to stop.
+     */
+    @Test
+    void theRefusalCarriesHowLongToWait() {
+        properties.setAttemptsPerCaller(1);
+        properties.setWindow(Duration.ofHours(1));
+        InviteCodeRedemptionLimiter limiter = limiter();
+        limiter.chargeAttempt(CALLER);
+
+        assertThatThrownBy(() -> limiter.chargeAttempt(CALLER))
+                .isInstanceOfSatisfying(TooManyAttemptsException.class, e ->
+                        assertThat(e.getRetryAfter()).isPositive().isLessThanOrEqualTo(Duration.ofHours(1)));
+    }
+
+    /**
+     * The message must not tell whoever provoked it how to pace the next run, so it says neither
+     * how much allowance remains nor which of the two allowances refused.
+     */
+    @Test
+    void theRefusalSaysNothingAboutTheAllowanceItself() {
+        properties.setAttemptsPerCaller(1);
+        InviteCodeRedemptionLimiter limiter = limiter();
+        limiter.chargeAttempt(CALLER);
+
+        assertThatThrownBy(() -> limiter.chargeAttempt(CALLER))
+                .isInstanceOf(TooManyAttemptsException.class)
+                .hasMessageNotContainingAny("1", "caller", "deployment", "remaining");
+    }
+
+    /**
+     * One caller running their allowance down must not spend anyone else's. If it did, a single
+     * account could lock out onboarding for everybody, which the per-caller allowance is not for.
+     */
+    @Test
+    void oneCallerRunningOutDoesNotRefuseAnother() {
+        properties.setAttemptsPerCaller(2);
+        InviteCodeRedemptionLimiter limiter = limiter();
+        limiter.chargeAttempt(CALLER);
+        limiter.chargeAttempt(CALLER);
+        assertThatThrownBy(() -> limiter.chargeAttempt(CALLER))
+                .isInstanceOf(TooManyAttemptsException.class);
+
+        assertThatCode(() -> limiter.chargeAttempt(ANOTHER_CALLER)).doesNotThrowAnyException();
+    }
+
+    /**
+     * The point of the deployment-wide allowance: a per-caller limit is worth what another account
+     * costs, so the ceiling has to hold across callers as well as within one.
+     */
+    @Test
+    void theDeploymentAllowanceRefusesEvenACallerWithBudgetLeft() {
+        properties.setAttemptsPerCaller(10);
+        properties.setAttemptsPerDeployment(2);
+        InviteCodeRedemptionLimiter limiter = limiter();
+
+        limiter.chargeAttempt(CALLER);
+        limiter.chargeAttempt(ANOTHER_CALLER);
+
+        assertThatThrownBy(() -> limiter.chargeAttempt("a-third-account"))
+                .isInstanceOf(TooManyAttemptsException.class);
+    }
+
+    /**
+     * A caller refused by the deployment ceiling did not cause it, so their own budget is given
+     * back. Otherwise a queue nobody could see would quietly spend the allowance of everyone
+     * waiting in it.
+     */
+    @Test
+    void aDeploymentRefusalDoesNotSpendTheCallersOwnAllowance() {
+        properties.setAttemptsPerCaller(2);
+        properties.setAttemptsPerDeployment(1);
+        InviteCodeRedemptionLimiter limiter = limiter();
+
+        limiter.chargeAttempt(CALLER);
+        assertThatThrownBy(() -> limiter.chargeAttempt(ANOTHER_CALLER))
+                .isInstanceOf(TooManyAttemptsException.class);
+
+        // The second caller was refused once by the deployment ceiling, so of their own two
+        // attempts none has been spent. Lifting the ceiling shows both are still there.
+        properties.setAttemptsPerDeployment(0);
+        assertThatCode(() -> limiter.chargeAttempt(ANOTHER_CALLER)).doesNotThrowAnyException();
+        assertThatCode(() -> limiter.chargeAttempt(ANOTHER_CALLER)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> limiter.chargeAttempt(ANOTHER_CALLER))
+                .isInstanceOf(TooManyAttemptsException.class);
+    }
+
+    /**
+     * A refund restores what an accepted code cost, so somebody redeeming the invitation they were
+     * actually sent never approaches the limit however many times they do it.
+     */
+    @Test
+    void anAcceptedCodeCostsNothing() {
+        properties.setAttemptsPerCaller(2);
+        InviteCodeRedemptionLimiter limiter = limiter();
+
+        for (int i = 0; i < 20; i++) {
+            limiter.chargeAttempt(CALLER);
+            limiter.refundAttempt(CALLER);
+        }
+
+        assertThatCode(() -> limiter.chargeAttempt(CALLER)).doesNotThrowAnyException();
+        assertThatCode(() -> limiter.chargeAttempt(CALLER)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> limiter.chargeAttempt(CALLER))
+                .isInstanceOf(TooManyAttemptsException.class);
+    }
+
+    /** A refund cannot lift a bucket past its capacity, so it can never manufacture allowance. */
+    @Test
+    void aRefundOnAnUntouchedAllowanceGrantsNothingExtra() {
+        properties.setAttemptsPerCaller(1);
+        InviteCodeRedemptionLimiter limiter = limiter();
+
+        limiter.refundAttempt(CALLER);
+        limiter.refundAttempt(CALLER);
+
+        assertThatCode(() -> limiter.chargeAttempt(CALLER)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> limiter.chargeAttempt(CALLER))
+                .isInstanceOf(TooManyAttemptsException.class);
+    }
+
+    @Test
+    void zeroDisablesAnAllowanceEntirely() {
+        properties.setAttemptsPerCaller(0);
+        properties.setAttemptsPerDeployment(0);
+        InviteCodeRedemptionLimiter limiter = limiter();
+
+        for (int i = 0; i < 50; i++) {
+            int attempt = i;
+            assertThatCode(() -> limiter.chargeAttempt(CALLER))
+                    .as("attempt %d", attempt)
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    /**
+     * A bucket store that throws leaves the limit unavailable rather than the endpoint refused.
+     * Failing closed here would turn an outage in something advisory into an outage in onboarding,
+     * and the limit is a rate reducer over an already-authenticated endpoint, not the thing that
+     * decides whether a code is valid.
+     */
+    @Test
+    void anUnreachableBucketStoreLetsTheRequestThrough() {
+        AttemptBuckets broken = (key, configuration) -> {
+            throw new IllegalStateException("bucket store unreachable");
+        };
+        InviteCodeRedemptionLimiter limiter = new InviteCodeRedemptionLimiter(broken, properties);
+
+        assertThatCode(() -> limiter.chargeAttempt(CALLER)).doesNotThrowAnyException();
+        assertThatCode(() -> limiter.refundAttempt(CALLER)).doesNotThrowAnyException();
+    }
+
+    /**
+     * With no authentication on the context there is still a key, so the charge cannot be skipped.
+     * The endpoint is authenticated, so this is the state that should not arise rather than one
+     * that has to work well.
+     */
+    @Test
+    void theCallerKeyIsNeverNull() {
+        assertThat(limiter().currentCallerKey()).isNotNull().isNotBlank();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/projectInviteCode/InviteCodeRedemptionRefusalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/projectInviteCode/InviteCodeRedemptionRefusalTest.java
@@ -1,0 +1,108 @@
+package org.tornotron.echno_backend.projectInviteCode;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.exception.TooManyAttemptsException;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import java.time.Duration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * What a caller past the attempt allowance actually receives.
+ *
+ * <p>A limit whose refusal a client cannot act on is a limit that gets retried in a loop, so the
+ * status has to be the one that means "later" and it has to carry when. The body must not,
+ * because how much allowance is left is exactly what tells whoever provoked the refusal how to
+ * pace the next run.
+ */
+@WebMvcTest(ProjectInviteCodeController.class)
+@Import(InviteCodeRedemptionRefusalTest.TestSecurityConfig.class)
+class InviteCodeRedemptionRefusalTest {
+
+    private static final long USER_ID = 55L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProjectInviteCodeService projectInviteCodeService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @Test
+    void aSpentAllowanceAnswers429WithRetryAfterAndNoDetailOfTheAllowance() throws Exception {
+        when(orgSecurity.isSelfUser(USER_ID)).thenReturn(true);
+        when(projectInviteCodeService.validateAndUseInviteCode(any(), anyLong()))
+                .thenThrow(new TooManyAttemptsException(
+                        "Too many invite code attempts. Try again later.", Duration.ofMinutes(4)));
+
+        mockMvc.perform(post("/api/v1/invitation/web/validate/userId/" + USER_ID)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"code\":\"12345\"}"))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().string(HttpHeaders.RETRY_AFTER, "240"))
+                .andExpect(jsonPath("$.title").value("Too Many Requests"))
+                .andExpect(jsonPath("$.detail").value("Too many invite code attempts. Try again later."));
+    }
+
+    /**
+     * Retry-After is expressed in whole seconds, so a wait shorter than one second must still ask
+     * for at least one. Rounding it to zero would invite the immediate retry the header exists to
+     * prevent.
+     */
+    @Test
+    void aSubSecondWaitIsStillReportedAsASecond() throws Exception {
+        when(orgSecurity.isSelfUser(USER_ID)).thenReturn(true);
+        when(projectInviteCodeService.validateAndUseInviteCode(any(), anyLong()))
+                .thenThrow(new TooManyAttemptsException("Too many invite code attempts. Try again later.",
+                        Duration.ofMillis(200)));
+
+        mockMvc.perform(post("/api/v1/invitation/web/validate/userId/" + USER_ID)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"code\":\"12345\"}"))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().string(HttpHeaders.RETRY_AFTER, "1"));
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeServiceTest.java
@@ -12,7 +12,9 @@ import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.InvalidInviteCodeException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.exception.TenantIdMissingException;
+import org.tornotron.echno_backend.common.exception.TooManyAttemptsException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.ratelimit.InProcessAttemptBuckets;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.EmployeeService;
@@ -27,6 +29,7 @@ import org.tornotron.echno_backend.projectInviteCode.dto.InviteCodeValidationDto
 import org.tornotron.echno_backend.projectInviteCode.dto.ProjectInviteCodeDto;
 import org.tornotron.echno_backend.projectInviteCode.mapper.ProjectInviteCodeMapper;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -70,12 +73,22 @@ class ProjectInviteCodeServiceTest {
 
     private ProjectInviteCodeService service;
 
+    /**
+     * A real limiter over real in-process buckets rather than a mock, because what the redemption
+     * tests need to hold is that an attempt is actually spent and actually given back, and a mock
+     * of the limiter would only record that it was called.
+     */
+    private InviteCodeRedemptionLimiter redemptionLimiter;
+    private InviteCodeRedemptionProperties redemptionProperties;
+
     @BeforeEach
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
+        redemptionProperties = new InviteCodeRedemptionProperties();
+        redemptionLimiter = new InviteCodeRedemptionLimiter(new InProcessAttemptBuckets(), redemptionProperties);
         service = new ProjectInviteCodeService(inviteCodeRepository, employeeService, organizationRepository,
                 fileStorageService, employeeRepository, projectInviteCodeMapper, organizationMapper,
-                shiftTimingRepository);
+                shiftTimingRepository, redemptionLimiter);
     }
 
     @AfterEach
@@ -421,5 +434,114 @@ class ProjectInviteCodeServiceTest {
         assertThatExceptionOfType(TenantIdMissingException.class)
                 .isThrownBy(() -> service.readAllProjectInviteCodes());
         verify(inviteCodeRepository, never()).findByOrganization_Id(any());
+    }
+
+    /**
+     * Redemption resolves a bearer credential with no organization qualifier, and it cannot have
+     * one, because the person redeeming holds no membership yet. That leaves the number of values
+     * that may be offered as the only thing keeping the credential worth anything, so the count
+     * has to be bounded and the bound has to bite before the lookup.
+     */
+    @Test
+    void validateAndUse_pastTheAttemptAllowance_isRefusedWithoutLookingTheCodeUp() {
+        redemptionProperties.setAttemptsPerCaller(2);
+        when(inviteCodeRepository.findByCode(12345)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+
+        assertThatExceptionOfType(TooManyAttemptsException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+
+        // Twice, not three times. The third attempt was refused before the repository was reached,
+        // which is what makes this a limit on attempts rather than on the answers to them.
+        verify(inviteCodeRepository, org.mockito.Mockito.times(2)).findByCode(12345);
+    }
+
+    /**
+     * A code that turns out to be good gives the attempt back, so the person redeeming the
+     * invitation they were actually sent never approaches the allowance.
+     */
+    @Test
+    void validateAndUse_acceptedCode_costsNoAttempt() {
+        redemptionProperties.setAttemptsPerCaller(1);
+        ProjectInviteCode code = storedCode(true, LocalDateTime.now().plusDays(5), 500, 0);
+        when(inviteCodeRepository.findByCode(12345)).thenReturn(Optional.of(code));
+        when(organizationMapper.toDto(any())).thenReturn(new OrganizationDto());
+
+        for (int i = 0; i < 5; i++) {
+            service.validateAndUseInviteCode(validationDto(), USER_ID);
+        }
+
+        verify(inviteCodeRepository, org.mockito.Mockito.times(5)).findByCode(12345);
+    }
+
+    /**
+     * Every way a code can be turned down spends the attempt. A refusal that cost nothing would be
+     * a free probe, and the useful probe is precisely the one that fails.
+     */
+    @Test
+    void validateAndUse_everyKindOfRefusal_spendsTheAttempt() {
+        redemptionProperties.setAttemptsPerCaller(3);
+        when(inviteCodeRepository.findByCode(12345))
+                .thenReturn(Optional.of(storedCode(true, LocalDateTime.now().minusDays(1), 5, 0)))
+                .thenReturn(Optional.of(storedCode(false, LocalDateTime.now().plusDays(5), 5, 0)))
+                .thenReturn(Optional.of(storedCode(true, LocalDateTime.now().plusDays(5), 2, 2)));
+
+        assertThatExceptionOfType(InvalidInviteCodeException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+        assertThatExceptionOfType(InvalidInviteCodeException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+        assertThatExceptionOfType(InvalidInviteCodeException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+
+        assertThatExceptionOfType(TooManyAttemptsException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+    }
+
+    /**
+     * The submitted code is five characters, which the request body's constraint enforces, but
+     * nothing said they were digits. A five-letter submission used to reach {@code Integer.parseInt}
+     * and answer 500, so a malformed code was met with a server error instead of a refusal.
+     */
+    @Test
+    void validateAndUse_aCodeThatIsNotANumber_isRefusedRatherThanFailing() {
+        InviteCodeValidationDto dto = new InviteCodeValidationDto();
+        dto.setCode("ABCDE");
+
+        assertThatExceptionOfType(InvalidInviteCodeException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(dto, USER_ID));
+        verify(inviteCodeRepository, never()).findByCode(org.mockito.ArgumentMatchers.anyInt());
+    }
+
+    /** A malformed code is still an attempt, or it would be the free probe the others are not. */
+    @Test
+    void validateAndUse_aCodeThatIsNotANumber_stillSpendsTheAttempt() {
+        redemptionProperties.setAttemptsPerCaller(1);
+        InviteCodeValidationDto dto = new InviteCodeValidationDto();
+        dto.setCode("ABCDE");
+
+        assertThatExceptionOfType(InvalidInviteCodeException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(dto, USER_ID));
+        assertThatExceptionOfType(TooManyAttemptsException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(dto, USER_ID));
+    }
+
+    /**
+     * Expiry and a use limit are separately already true of a code: {@code validityDays} defaults
+     * to five days and {@code maxUses} to one, so the shipped default is a single-use invitation
+     * that dies in under a week. Neither bounds how many values may be offered, which is what the
+     * attempt allowance is for, and pinning the defaults here is what keeps a later edit from
+     * quietly turning the default code into a permanent one.
+     */
+    @Test
+    void aGeneratedCodeIsSingleUseAndShortLivedByDefault() {
+        InviteCodeGenerationDto dto = new InviteCodeGenerationDto();
+
+        assertThat(dto.getMaxUses()).isEqualTo(1);
+        assertThat(dto.getValidityDays()).isEqualTo(5);
+        assertThat(Duration.ofDays(dto.getValidityDays())).isLessThanOrEqualTo(Duration.ofDays(7));
     }
 }


### PR DESCRIPTION
Closes #699.

## The property, and which half of it this changes

An invite code is a bearer credential: whoever presents a live value joins the organization it belongs to. Redemption resolves it with `findByCode` and **no organization qualifier**, and it cannot have one, because the person redeeming holds no membership yet. That is the state the flow exists to end, and the guard, `@orgSecurity.isSelfUser(#userId)`, is deliberately tenant-independent for exactly that reason. Both are correct.

What is left standing between a value and membership is that the value has to be **known**. That property only holds while the number of values that can be offered is bounded. Nothing bounded it.

There are two ways to restore the bound: make the credential wide enough that knowing it is the only way to have it, or limit how fast values can be offered. The first is a contract change and is scoped below, not made here. **This PR does the second**, and it should not be read as having settled the question: a credential worth guessing is still worth guessing more slowly.

## What already existed

`bucket4j` is a compile dependency with a filter block in `application.yml`, and it has never run: `bucket4j.enabled: false`. Switching it on as written would not have helped, and would have hurt. Its key is `getRemoteAddr()`, which behind nginx, the Cloudflare Tunnel and Cloudflare is the proxy, so one bucket of 20 requests a minute would be shared by the whole deployment; and its scope is `^/api/.*`, below ordinary console use by one person. That is filed separately as #706.

At the edge, `echno-deployment` `tofu/envs/cloudflare` carries a rate limit on the Keycloak token path only, keyed on `ip.src` and `cf.colo.id`. So the pattern exists there, but not on this endpoint.

## What this adds, and where

An `InviteCodeRedemptionLimiter` in the redemption path, not a filter. The service is the only place that knows whether a code was accepted, and the endpoint is the only one that resolves a bearer credential without a tenant, so a limit written there can be exact where a path-matched filter cannot.

**An attempt is charged before the lookup and refunded when the code is accepted.** So a person redeeming the invitation they were actually sent spends nothing however often they do it, and the allowance is in practice a budget for wrong codes. Charging first is what makes it a limit on attempts rather than on the fraction of them that has already finished failing: the token is taken before anything is looked up, so there is no window in which an unbounded number of lookups is already in flight. The charge lives in the bucket rather than the database, so a rejected code rolls the transaction back and leaves the attempt counted, which is the point.

**Two allowances, answering different questions.**

- *Per caller*, keyed on the authenticated principal. The endpoint requires authentication, so there is a principal to key on, and it is a far better key than an address here: for the reason above, an address-keyed limit at the origin would be one shared allowance wearing the name of a per-client one.
- *Per deployment*. A per-caller limit is worth exactly what another account costs, and where self-registration is open that is close to nothing. This ceiling does not move when someone brings more accounts.

The deployment ceiling has a cost worth stating rather than burying: **someone who burns it delays everyone else's redemptions until it refills.** That is why it is set well above any believable volume of genuine wrong codes rather than tight, why it is configurable per deployment, and why zero disables it. It is a deliberate trade, not an oversight.

**Where the counts live** follows the same single switch as every other piece of cross-replica state, `echno.cache.provider`. In process by default; in the shared Redis when it is `redis`, without which a multi-replica deployment multiplies every ceiling by its replica count. `RedisDistributedStateIT` already held the underlying property that two proxy managers over one key draw on one allowance.

**An unreachable bucket store leaves the limit unavailable, not the endpoint refused.** Failing closed would turn an outage in something advisory into an outage in onboarding, and this limit reduces a rate over an already-authenticated endpoint; it is not what decides whether a code is valid.

## Two smaller things in the same path

- **A five-character code that was not digits reached `Integer.parseInt` and answered 500.** The request body constrains the code to exactly five characters and never said they were digits. So a malformed code was met with a server error rather than a refusal, and was not judged as an attempt at all. It is now an `InvalidInviteCodeException`, and it costs an attempt like any other wrong code.
- **`maxUses` and `validityDays` were unbounded ints.** That is how a credential ends up with an expiry far enough out to be no expiry, and a large enough `validityDays` overflows the date arithmetic outright. Bounded to 1..1000 and 1..365. The console sends 7 to 90 days and never sends `maxUses` at all, so the bounds refuse only values that were already nonsense.

## Expiry and single use: both already hold, by default

The issue asked whether a code that never expires or can be redeemed repeatedly is a separate weakness. Checked rather than assumed:

- **Expiry holds.** `validityDays` defaults to 5, `expiryDate` is set from it at generation, and redemption refuses a code whose expiry has passed. The console offers 7 to 90 days.
- **Single use holds.** `maxUses` defaults to 1, redemption refuses once `currentUses >= maxUses`, and the counter is incremented in the same transaction as the join. The shipped default is a single-use invitation that dies in under a week. `ProjectInviteCodeServiceTest.aGeneratedCodeIsSingleUseAndShortLivedByDefault` pins that, so a later edit cannot quietly turn the default code into a permanent one.

So neither is the weakness. Two riders, neither addressed here:

- The use counter carries no `@Version` and no lock, so two concurrent redemptions of one code both read the same count. It holds today because CockroachDB's default isolation is serializable and one of the two transactions retries. That is a property of the database rather than of the code, and it would not hold on a Postgres deployment at read committed. **Reasoned from the source and the engine's documented default, not measured.**
- `isActive` is never flipped false when a code is exhausted. Harmless, since the count check covers it, but the flag then means less than its name suggests.

## Widening the code: scope, cost, and one thing the issue assumed that is not so

The issue treated widening as blocked by shipped clients typing the code as a number. **They do not. Both clients already type it as a string.**

| | invite code type |
|---|---|
| `echno-backend` `ProjectInviteCode.code` / `ProjectInviteCodeDto.code` | `int` |
| `echno-core` `Invitation.inviteCode` | `string` |
| `echno-core` `InvitationResponseSchema.code` | `z.string().nullish()` |
| Flutter `echno` `Invitation.inviteCode` | `String?` |
| Flutter `echno` `validateInviteCode({required String code})` | `String` |

The backend is the odd one out, and its numeric response is what `echno-core`'s own schema rejects today; filed as tornotron/echno-core#97. So widening the backend's code to an opaque string moves it **towards** its clients.

Two further findings that change the cost:

- The Flutter app posts to `/invitation/generate` and `/invitation/validate`. The backend publishes `/api/v1/invitation/web/generateCode/organizationId/{id}` and `/api/v1/invitation/web/validate/userId/{userId}`. That surface is already off-contract and cannot be working against the current backend; last push 2025-11.
- `echno-web`'s join form already uppercases the input and calls the code case-insensitive, which is meaningless for a five-digit integer and would become meaningful.

What it would actually take, in this repository:

1. One Liquibase changeset in the next version folder: `project_invite_code.code` from `int` to `varchar`, keeping the unique constraint, casting existing rows. `ddl-auto` is `validate`, so the changeset is the whole migration.
2. `ProjectInviteCode.code` and `ProjectInviteCodeDto.code` to `String`; `findByCode` and `findByCodeAndOrganization_Id` likewise.
3. `InviteCodeValidationDto`: replace `@Size(min=5,max=5)` with the new shape's constraint. `parseCode` then disappears.
4. Replace `generateSecureFiveDigitNumber` with a generator over an unambiguous alphabet, **and add the collision retry that is missing today**: nothing retries a duplicate now, so a collision on the unique constraint is a 500, and at 90,000 values that stops being hypothetical once a deployment holds a few hundred live codes.
5. `docs/openapi.json` regenerates.

`echno-core` needs no type change; it needs #97 either way. The open decisions are the shape (length, alphabet, whether it stays human-typeable, since it is read aloud and typed on a phone) and whether the listing should keep returning code values or move to reveal-on-request once the code is expensive enough to protect. Those are for you, not for this PR.

## Recommended follow-up at the edge

Worth mirroring the Keycloak rule in `echno-deployment` onto `/api/v1/invitation/web/validate/`, keyed on `ip.src` as that one is. The edge is the one place a real client address is available, and it stops volume before the origin. It is a backstop rather than the control: it cannot tell an accepted code from a refused one, and it does not exist for a deployment that is not behind Cloudflare, which is why the load-bearing limit is the one in this PR.

## Tests

| Test | What it holds | Red before the fix |
|---|---|---|
| `InviteCodeRedemptionLimiterTest.aCallerIsRefusedOnceTheirAllowanceIsSpent` | the per-caller allowance actually runs out | new surface, nothing to measure |
| `InviteCodeRedemptionLimiterTest.theRefusalCarriesHowLongToWait` | the refusal says when it ends, so a client need not poll | new surface |
| `InviteCodeRedemptionLimiterTest.theRefusalSaysNothingAboutTheAllowanceItself` | the message does not pace the next run | new surface |
| `InviteCodeRedemptionLimiterTest.oneCallerRunningOutDoesNotRefuseAnother` | one account cannot lock out onboarding through the per-caller bucket | new surface |
| `InviteCodeRedemptionLimiterTest.theDeploymentAllowanceRefusesEvenACallerWithBudgetLeft` | the ceiling holds across accounts, not only within one | new surface |
| `InviteCodeRedemptionLimiterTest.aDeploymentRefusalDoesNotSpendTheCallersOwnAllowance` | a queue nobody caused does not also spend their budget | new surface |
| `InviteCodeRedemptionLimiterTest.anAcceptedCodeCostsNothing` | a real redemption never approaches the limit | new surface |
| `InviteCodeRedemptionLimiterTest.aRefundOnAnUntouchedAllowanceGrantsNothingExtra` | a refund cannot manufacture allowance | new surface |
| `InviteCodeRedemptionLimiterTest.zeroDisablesAnAllowanceEntirely` | the documented off switch is really off | new surface |
| `InviteCodeRedemptionLimiterTest.anUnreachableBucketStoreLetsTheRequestThrough` | an unavailable limit is not an onboarding outage | new surface |
| `ProjectInviteCodeServiceTest.validateAndUse_pastTheAttemptAllowance_isRefusedWithoutLookingTheCodeUp` | the third attempt never reaches the repository | new surface |
| `ProjectInviteCodeServiceTest.validateAndUse_acceptedCode_costsNoAttempt` | five successful redemptions on an allowance of one | new surface |
| `ProjectInviteCodeServiceTest.validateAndUse_everyKindOfRefusal_spendsTheAttempt` | expired, inactive and exhausted all cost an attempt, so none is a free probe | new surface |
| `ProjectInviteCodeServiceTest.validateAndUse_aCodeThatIsNotANumber_isRefusedRatherThanFailing` | a five-letter code is a refusal, not a 500 | **reasoned**; the old path threw `NumberFormatException` out of the service, which the test would have caught as the wrong type |
| `ProjectInviteCodeServiceTest.validateAndUse_aCodeThatIsNotANumber_stillSpendsTheAttempt` | a malformed code is judged like any other | new surface |
| `ProjectInviteCodeServiceTest.aGeneratedCodeIsSingleUseAndShortLivedByDefault` | expiry and single use are the shipped default | passes before and after; it exists to keep that true |
| `GlobalExceptionHandlerTest.tooManyAttempts_isA429CarryingRetryAfter` | 429 with `Retry-After`, and a body that says nothing about the allowance | new surface |
| `GlobalExceptionHandlerTest.tooManyAttempts_neverAsksTheClientToRetryImmediately` | a sub-second wait still asks for one second | new surface |
| `InviteCodeRedemptionRefusalTest` (2 cases) | the status and the header actually reach the wire through the controller | new surface |
| `RedisAttemptBucketsLazinessTest` (3 cases) | construction does not dial Redis; a request against an absent Redis fails there and the limiter lets it through | **measured** (run 34051839238: the eager version failed `RedisUnreachableBootIT.contextLoadsWithoutAReachableRedis` with a `RedisConnectionException` during context refresh) |

The one measured red is the Redis regression, caught by an existing test on the first CI run and fixed in the second commit. The rest is new surface, where there is no earlier behaviour to measure against: an unlimited endpoint has no failing case to record, only an absent limit.

This workstation has no container runtime and cannot run the Testcontainers-backed suite, so every result above is CI's.

## OpenAPI

Three deltas, each taken byte for byte from the build's own `openapi-served` artifact and verified against it rather than typed: the bounds now published on `maxUses` and `validityDays`, the validate operation's description, and its `429`. The file was not copied wholesale, because the artifact is generated from the pull request's **merge ref** against whatever `development` was at the time, so it predates two merges since and taking it entire would have reverted them.

Producing it also caught something worth having caught. The served `429` documented its body as an `OrganizationDto`. Springdoc fills in an undeclared error body from the advice method's return type, and this handler returns a `ResponseEntity` so it can carry `Retry-After`, which tells springdoc nothing; it fell back to the operation's own return type. The schema is now spelt out on the annotation. The published contract is what `echno-core` checks its call sites against, so a wrong schema there is worse than an absent one.
