### PR TITLE
Repair the employee read, the leave-policy duplicate target, and the project read guards

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -35262,7 +35262,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -35197,7 +35197,7 @@
     },
     "/api/v1/employee/web/{employeeId}/roles": {
       "get": {
-        "description": "Returns the set of organization roles held by the given employee.",
+        "description": "Returns the set of organization roles held by the given employee. Open to any member of the organization, since knowing who holds which role is how work is routed.",
         "operationId": "getOrgRoles",
         "parameters": [
           {
@@ -35685,7 +35685,7 @@
         ]
       },
       "get": {
-        "description": "Returns a single employee's full details.",
+        "description": "Returns a single employee's full details. Callable by the employee themselves or by a system admin, HR admin or project manager.",
         "operationId": "readAnEmployee_1",
         "parameters": [
           {
@@ -35737,7 +35737,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is neither the employee nor a system admin, HR admin or project manager"
           },
           "404": {
             "content": {
@@ -36030,7 +36030,7 @@
         ]
       },
       "get": {
-        "description": "Returns a single employee including their personal details, roles and status.",
+        "description": "Returns a single employee including their personal details, roles and status. Callable by the employee themselves or by a system admin, HR admin or project manager.",
         "operationId": "readAnEmployee",
         "parameters": [
           {
@@ -36082,7 +36082,7 @@
                 }
               }
             },
-            "description": "Caller lacks the employee read or admin authority"
+            "description": "Caller is neither the employee nor a system admin, HR admin or project manager"
           },
           "404": {
             "content": {
@@ -66974,7 +66974,7 @@
     },
     "/api/v1/leave-policies/web/duplicate": {
       "post": {
-        "description": "Copies the policy's quota, accrual and eligibility rules into a new policy owned by the target organization. Returns the newly created policy.",
+        "description": "Copies the policy's quota, accrual and eligibility rules into a new policy owned by the target organization. Returns the newly created policy. The caller must hold the system-admin or hr-admin role in their own organization and in the target.",
         "operationId": "duplicatePolicy_1",
         "parameters": [
           {
@@ -67035,7 +67035,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant or in the target organization"
           },
           "404": {
             "content": {
@@ -67906,7 +67906,7 @@
     },
     "/api/v1/leave-policies/{policyId}/duplicate": {
       "post": {
-        "description": "Copies the policy's quota, accrual and eligibility rules into a new policy owned by the target organization. Returns the newly created policy.",
+        "description": "Copies the policy's quota, accrual and eligibility rules into a new policy owned by the target organization. Returns the newly created policy. The caller must hold the system-admin or hr-admin role in their own organization and in the target.",
         "operationId": "duplicatePolicy",
         "parameters": [
           {
@@ -67967,7 +67967,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant or in the target organization"
           },
           "404": {
             "content": {
@@ -82846,7 +82846,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -83086,7 +83086,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -83225,7 +83225,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -83364,7 +83364,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -83588,7 +83588,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -83869,7 +83869,7 @@
                 }
               }
             },
-            "description": "Caller is neither a member of the current tenant nor holds an elevated role in it"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -83985,7 +83985,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
@@ -139,18 +139,31 @@ public class EmployeeController {
     /**
      * Retrieves a single employee by their ID.
      *
+     * <p>{@code employee:read} and {@code employee:admin}, which this asked for until now, are
+     * bare {@code resource:scope} authorities. {@code JwtAuthConverter} mints those in exactly one
+     * place, {@code extractPermissions}, which reads the {@code authorization} claim of an RPT, so
+     * each needs a Keycloak Authorization Services resource named {@code employee} carrying the
+     * matching scope. The only automated provisioner registers a scopeless Default Resource and a
+     * scopeless Default Permission, and a permission with no scopes yields no
+     * {@code resource:scope} authority at all; the multi-tenancy audit of 2026-08-18 confirmed
+     * zero scopes realm-wide against the live staging Keycloak. This endpoint therefore refused
+     * every caller from the day the annotation was written. Same phantom-guard mechanism as #684,
+     * and repaired the same way: the guard now says what the web twin's says, so the mobile client
+     * gets the surface the web one has rather than losing the endpoint. See #710.
+     *
      * @param id The ID of the employee to retrieve.
      * @return A {@link ResponseEntity} containing the employee DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin', 'project-manager')")
     @Operation(
             summary = "Get an employee by id",
-            description = "Returns a single employee including their personal details, roles and status."
+            description = "Returns a single employee including their personal details, roles and status. "
+                    + "Callable by the employee themselves or by a system admin, HR admin or project manager."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system admin, HR admin or project manager"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<EmployeeDto> readAnEmployee(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -155,18 +155,27 @@ public class EmployeeControllerWeb {
     /**
      * Retrieves a single employee by their ID.
      *
+     * <p>The self branch is what makes this read at least as open as the {@code PATCH} beside it,
+     * which has always been {@code isSelfOrHasAnyOrgRole}. Without it a person could edit their
+     * own record and then be refused reading it back, and any screen that shows the record before
+     * offering to edit it failed on the read rather than the write. Same shape as the project
+     * reads repaired in {@code eec6c37}. Nothing else widens: a member holding no elevated role
+     * still cannot open a colleague's record, which carries salary, date of birth and address.
+     * See #710.
+     *
      * @param id The ID of the employee to retrieve.
      * @return A {@link ResponseEntity} containing the employee DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin', 'project-manager')")
     @Operation(
             summary = "Get an employee by id",
-            description = "Returns a single employee's full details."
+            description = "Returns a single employee's full details. Callable by the employee themselves "
+                    + "or by a system admin, HR admin or project manager."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system admin, HR admin or project manager"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<EmployeeDto> readAnEmployee(@PathVariable Long id) {
@@ -378,11 +387,27 @@ public class EmployeeControllerWeb {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.removeOrgRole(employeeId, role));
     }
 
+    /**
+     * The roles one colleague holds, readable by any member of the organization.
+     *
+     * <p>Membership is deliberate rather than left over. Knowing who the site manager or the HR
+     * admin is, is how a person finds who to route a request to, and a directory that hides it is
+     * worse than one that shows it. The answer crosses no tenant, since {@code Employee} carries
+     * the org filter, and grants nothing: reading a role is not holding it. What it does give away
+     * is the shape of the organization's permissions to anyone who walks employee ids, which is
+     * reconnaissance rather than access, and the ids are already enumerable through the lookup
+     * list. #710 raised it and it was closed as a decision on that reasoning. The residual
+     * question, whether the full role set per person is the right granularity or whether a
+     * "contactable roles" view would serve the directory better, is a product one and is not
+     * answered by narrowing this to an admin role.
+     */
     @GetMapping("/{employeeId}/roles")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get an employee's org roles",
-            description = "Returns the set of organization roles held by the given employee."
+            description = "Returns the set of organization roles held by the given employee. Open to any "
+                    + "member of the organization, since knowing who holds which role is how work is "
+                    + "routed."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Roles returned"),

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -411,7 +411,7 @@ public class EmployeeControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Roles returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<Set<OrgRole>> getOrgRoles(@PathVariable Long employeeId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
@@ -202,16 +202,23 @@ public class LeavePolicyController {
      * Both halves are required: the source policy is read out of the current tenant, so a role
      * there is not made redundant by holding one in the target. See #698.
      *
-     * <p>What the repaired guard does not fix, and what a reader should know before relying on
-     * this endpoint: it cannot currently succeed for any input.
-     * {@code OrganizationLookupUnderTheOrgFilterIT} measured the target lookup against a database
-     * and the org filter reaches the {@code JOIN o.employees e} inside it, so a target that is not
-     * the current tenant resolves nothing and the method raises not-found. Naming the current
-     * tenant instead reaches the duplicate-code check, which the source policy's own leave-type
-     * code satisfies, so that answers 409. Whether cross-organization duplication is a feature at
-     * all is a product decision; if it is, the target resolution and the duplicate-code check both
-     * have to become deliberate cross-tenant reads rather than queries that quietly return
-     * nothing. Tracked separately.
+     * <p>The target really does resolve, which is what makes this repair load-bearing rather than
+     * tidy. {@code OrganizationLookupUnderTheOrgFilterIT} measured the lookup against a database:
+     * the org filter does not reach the {@code JOIN o.employees e} inside it, and the joined
+     * {@code Employee} is never selected, so the fail-closed load listener has no post-load to
+     * judge either. A foreign organization comes back silently, and the only thing established
+     * about it is that the caller has an employment row there.
+     *
+     * <p>What this guard does not fix, and what a reader should know before relying on the
+     * endpoint: the duplicate-code check at the next line asks
+     * {@code existsByOrganizationIdAndLeaveTypeCode} against {@code LeavePolicy}, which does carry
+     * the filter as a query root, so for any target other than the current tenant the predicate is
+     * unsatisfiable and the uniqueness rule is skipped on exactly the path that needs it. A real
+     * collision then reaches {@code uk_leave_policy_org_type} and surfaces as a 500 rather than a
+     * 409. Naming the current tenant instead makes that check match the source policy's own
+     * leave-type code, so it answers 409 always. Whether cross-organization duplication is a
+     * feature at all is a product decision; if it is, that check has to become a deliberate
+     * cross-tenant read. Tracked separately.
      *
      * @param policyId The ID of the source policy, read from the caller's own organization.
      * @param targetOrganizationId The organization to copy into, in which the caller must hold

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
@@ -205,12 +205,13 @@ public class LeavePolicyController {
      * <p>What the repaired guard does not fix, and what a reader should know before relying on
      * this endpoint: it cannot currently succeed for any input.
      * {@code OrganizationLookupUnderTheOrgFilterIT} measured the target lookup against a database
-     * and it raises {@code TenantAccessDeniedException} for a foreign organization, because the
-     * fail-closed load listener refuses the joined {@code Employee} row. Naming the current tenant
-     * instead reaches the duplicate-code check, which the source policy's own code satisfies, so
-     * that answers 409. Whether cross-organization duplication is a feature at all is a product
-     * decision; if it is, the target resolution and the duplicate-code check both need to be
-     * deliberate cross-tenant reads rather than accidental ones.
+     * and the org filter reaches the {@code JOIN o.employees e} inside it, so a target that is not
+     * the current tenant resolves nothing and the method raises not-found. Naming the current
+     * tenant instead reaches the duplicate-code check, which the source policy's own leave-type
+     * code satisfies, so that answers 409. Whether cross-organization duplication is a feature at
+     * all is a product decision; if it is, the target resolution and the duplicate-code check both
+     * have to become deliberate cross-tenant reads rather than queries that quietly return
+     * nothing. Tracked separately.
      *
      * @param policyId The ID of the source policy, read from the caller's own organization.
      * @param targetOrganizationId The organization to copy into, in which the caller must hold

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
@@ -183,17 +183,51 @@ public class LeavePolicyController {
         return ResponseEntity.ok(new ApiResponse("Leave policy activated successfully"));
     }
 
+    /**
+     * Copies a policy into another organization.
+     *
+     * <p>Two organizations are named by a call to this: the one the session is scoped to, which
+     * owns the source policy, and the target the copy is written into. The guard used to answer
+     * only for the first. The entitlement to the second came from
+     * {@code OrganizationRepository.findByIdAndUserEmail}, which establishes an {@code Employee}
+     * row in the target and nothing about what the caller may do there, so the guard read as
+     * though the role applied to the target when it did not. {@code Organization} is the tenant
+     * root, so it implements no {@code TenantScopedEntity} and neither the org filter nor the
+     * fail-closed load listener has anything to say about which one is resolved; a caller-named
+     * organization has to be answered for in the guard or nowhere.
+     *
+     * <p>{@code hasAnyOrgRole(#targetOrganizationId, ...)} is the half that does that. It reads
+     * the caller's authorities for the organization they named, rather than for the one their
+     * session happens to hold, which is all {@code hasAnyOrgRoleForCurrentTenant} can answer for.
+     * Both halves are required: the source policy is read out of the current tenant, so a role
+     * there is not made redundant by holding one in the target. See #698.
+     *
+     * <p>What the repaired guard does not fix, and what a reader should know before relying on
+     * this endpoint: it cannot currently succeed for any input.
+     * {@code OrganizationLookupUnderTheOrgFilterIT} measured the target lookup against a database
+     * and it raises {@code TenantAccessDeniedException} for a foreign organization, because the
+     * fail-closed load listener refuses the joined {@code Employee} row. Naming the current tenant
+     * instead reaches the duplicate-code check, which the source policy's own code satisfies, so
+     * that answers 409. Whether cross-organization duplication is a feature at all is a product
+     * decision; if it is, the target resolution and the duplicate-code check both need to be
+     * deliberate cross-tenant reads rather than accidental ones.
+     *
+     * @param policyId The ID of the source policy, read from the caller's own organization.
+     * @param targetOrganizationId The organization to copy into, in which the caller must hold
+     *                             the same role.
+     */
     @PostMapping("/{policyId}/duplicate")
-//    @PreAuthorize("hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')"
+            + " and @orgSecurity.hasAnyOrgRole(#targetOrganizationId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Duplicate a leave policy into another organization",
             description = "Copies the policy's quota, accrual and eligibility rules into a new policy owned "
-                    + "by the target organization. Returns the newly created policy."
+                    + "by the target organization. Returns the newly created policy. The caller must hold "
+                    + "the system-admin or hr-admin role in their own organization and in the target."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Policy duplicated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant or in the target organization"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy or target organization with the given id")
     })
     public ResponseEntity<LeavePolicyDto> duplicatePolicy(

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
@@ -166,16 +166,24 @@ public class LeavePolicyControllerWeb {
         return ResponseEntity.ok(new ApiResponse("Leave policy activated successfully"));
     }
 
+    /**
+     * Web twin of {@link LeavePolicyController#duplicatePolicy}, and gated the same way: the
+     * role is answered for both the caller's own organization and the target they named, because
+     * the target is a caller-supplied organization id and {@code Organization} is the tenant root
+     * that neither the org filter nor the load listener covers. See #698.
+     */
     @PostMapping("/duplicate")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')"
+            + " and @orgSecurity.hasAnyOrgRole(#targetOrganizationId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Duplicate a leave policy into another organization",
             description = "Copies the policy's quota, accrual and eligibility rules into a new policy owned "
-                    + "by the target organization. Returns the newly created policy."
+                    + "by the target organization. Returns the newly created policy. The caller must hold "
+                    + "the system-admin or hr-admin role in their own organization and in the target."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Policy duplicated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant or in the target organization"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy or target organization with the given id")
     })
     public ResponseEntity<LeavePolicyDto> duplicatePolicy(

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -34,6 +34,31 @@ import java.util.List;
 import java.util.Map;
 import org.tornotron.echno_backend.project.dto.ProjectUpdateFieldsDto;
 
+/**
+ * Project endpoints for the web client. Reads are open to any member of the current tenant;
+ * creating, updating, deleting and managing project membership need the system-admin or
+ * project-manager role in it.
+ *
+ * <p>The read guards used to read {@code isMemberOfCurrentTenant() or
+ * hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')}, added by {@code eec6c37} so a
+ * role-holder who is not recorded as a member could read what they were already allowed to write.
+ * The second clause could never decide anything. Both sides open on
+ * {@code TenantContext.getCurrentOrgId()}, and {@code TenantFilter} sets that only after
+ * confirming an {@code ORG_MEMBER_} authority for the organization, whether it comes from the
+ * {@code X-Organization-Id} header or is inferred from a sole membership. A caller holding
+ * {@code ORG_7_ROLE_system-admin} and no {@code ORG_MEMBER_7} therefore reaches the controller
+ * with no organization in force, and both clauses return false. The guard was one-part behaviour
+ * wearing a two-part expression, which is what #709 recorded.
+ *
+ * <p>So the clause is gone rather than turned into an {@code and}: an {@code and} would narrow
+ * these reads to role-holders and shut out the ordinary members they exist for.
+ * {@code TenantFilterTest.theRoleGuardCannotSucceedWhereTheMembershipGuardFails} pins the
+ * invariant that makes the removal a no-op, so if tenant resolution is ever widened to accept a
+ * role authority, that test fails first and this decision is revisited rather than silently
+ * reversed. The underlying question of whether a role-holder who is not a member should be able
+ * to resolve a tenant at all is a change to the security model, not to a controller, and is
+ * tracked separately.
+ */
 @RestController
 @RequestMapping("/api/v1/project/web")
 @Validated
@@ -109,7 +134,7 @@ public class ProjectControllerWeb {
      * @return A {@link ResponseEntity} containing the project DTOs and the count headers.
      */
     @GetMapping()
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List projects",
             description = "Returns the current tenant's projects as a bare array, capped at 500 "
@@ -119,7 +144,7 @@ public class ProjectControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Projects returned, capped at 500 rows"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
     public ResponseEntity<List<ProjectDto>> readAllProjects() {
         logger.info("All Projects Retrieved Successfully");
@@ -139,7 +164,7 @@ public class ProjectControllerWeb {
      * @return A {@link ResponseEntity} containing the page of project DTOs.
      */
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List projects, paginated and filtered",
             description = "Returns a single page of projects with the paging metadata included, "
@@ -148,7 +173,7 @@ public class ProjectControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of projects returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
     public ResponseEntity<Page<ProjectDto>> readAllProjectsPaginated(
             @Valid @ParameterObject PageQuery20 pageQuery,
@@ -173,7 +198,7 @@ public class ProjectControllerWeb {
      * @return A {@link ResponseEntity} containing the page of project summaries.
      */
     @GetMapping("/summary")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List projects as summaries, paginated and filtered",
             description = "Returns a single page of projects carrying every scalar field of the "
@@ -184,7 +209,7 @@ public class ProjectControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of project summaries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
     public ResponseEntity<Page<ProjectSummaryDto>> readAllProjectSummaries(
             @Valid @ParameterObject PageQuery20 pageQuery,
@@ -200,14 +225,14 @@ public class ProjectControllerWeb {
      * @return A {@link ResponseEntity} containing the project DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a project by id",
             description = "Returns a single project including its assigned employees and attachments."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Project found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
     })
     public ResponseEntity<?> readAProject(@PathVariable Long id) {
@@ -223,7 +248,7 @@ public class ProjectControllerWeb {
      * @return A {@link ResponseEntity} containing a page of trail entries and HTTP status 200 (OK).
      */
     @GetMapping("{id}/status-history")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Read a project's status trail",
             description = "Returns a page of the project's status entries, newest first: what it "
@@ -238,7 +263,7 @@ public class ProjectControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of status entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
     })
     public ResponseEntity<Page<StatusTransitionDto>> readStatusHistory(
@@ -346,14 +371,14 @@ public class ProjectControllerWeb {
     }
 
     @GetMapping("{projectId}/employees")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List a project's employees",
             description = "Returns every employee assigned to the given project."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
     })
     public ResponseEntity<List<EmployeeDto>> getEmployeesByProjectId(@PathVariable Long projectId) {
@@ -361,14 +386,14 @@ public class ProjectControllerWeb {
     }
 
     @GetMapping("employees/{employeeId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List an employee's projects",
             description = "Returns every project the given employee is assigned to."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Projects returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<List<ProjectDto>> getProjectsByEmployeeId(@PathVariable Long employeeId) {

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantFilterTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantFilterTest.java
@@ -219,6 +219,80 @@ class TenantFilterTest {
     }
 
     @Test
+    void anOrgRoleWithoutMembershipResolvesNoTenant() throws Exception {
+        // JwtAuthConverter mints ORG_MEMBER_{id} from the flat group "/org-{id}" and
+        // ORG_{id}_ROLE_{role} from the subgroup "/org-{id}/{role}", independently, so a
+        // user placed only in the subgroup arrives holding the role and not the membership.
+        // The filter resolves an organization from ORG_MEMBER_ authorities alone, so that
+        // caller gets no organization at all.
+        authenticateWith("ORG_7_ROLE_system-admin");
+
+        run("/api/v1/project/web");
+
+        assertThat(observed.orgId()).isNull();
+        assertThat(observed.unscopedReason()).contains("no organization membership");
+    }
+
+    @Test
+    void anOrgRoleWithoutMembershipIsRefusedWhenItNamesTheOrganization() throws Exception {
+        // The other half: naming the organization explicitly does not get the role-holder in
+        // either, because the header branch checks the same ORG_MEMBER_ authority.
+        authenticateWith("ORG_7_ROLE_system-admin");
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/project/web");
+        request.setRequestURI("/api/v1/project/web");
+        request.addHeader("X-Organization-Id", "7");
+        filter.doFilter(request, response, capturingChain());
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(observed).as("the chain is not reached").isNull();
+    }
+
+    @Test
+    void theRoleGuardCannotSucceedWhereTheMembershipGuardFails() throws Exception {
+        // The invariant behind #709. Both guards open on TenantContext.getCurrentOrgId(), and
+        // the filter only ever sets it after confirming ORG_MEMBER_{id}, so
+        // hasAnyOrgRoleForCurrentTenant implies isMemberOfCurrentTenant for every request that
+        // reaches a controller. A guard reading "member OR role" therefore decides on the
+        // membership clause alone; the role clause cannot change the answer. Run against the
+        // real OrganizationSecurityService inside the chain, as #640's test does, because the
+        // claim is about the two of them together rather than either one's internals.
+        OrganizationSecurityService orgSecurity = new OrganizationSecurityService(null, null);
+        authenticateWith("ORG_7_ROLE_system-admin");
+
+        boolean[] guards = new boolean[2];
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/project/web");
+        request.setRequestURI("/api/v1/project/web");
+        filter.doFilter(request, response, (req, res) -> {
+            guards[0] = orgSecurity.isMemberOfCurrentTenant();
+            guards[1] = orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin");
+        });
+
+        assertThat(guards[0]).as("isMemberOfCurrentTenant for a role-holder who is not a member").isFalse();
+        assertThat(guards[1]).as("hasAnyOrgRoleForCurrentTenant for the same caller").isFalse();
+    }
+
+    @Test
+    void aGlobalAdminBypassLeavesBothTenantGuardsRefusing() throws Exception {
+        // The bypass branch sets no organization id, so both guards keep refusing. Worth
+        // pinning next to the invariant above: it is the one caller for whom neither clause of
+        // a "member OR role" guard can ever be true, whatever the clauses say.
+        OrganizationSecurityService orgSecurity = new OrganizationSecurityService(null, null);
+        authenticateWith("organization:admin");
+
+        boolean[] guards = new boolean[2];
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/project/web");
+        request.setRequestURI("/api/v1/project/web");
+        filter.doFilter(request, response, (req, res) -> {
+            guards[0] = orgSecurity.isMemberOfCurrentTenant();
+            guards[1] = orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin");
+        });
+
+        assertThat(guards[0]).isFalse();
+        assertThat(guards[1]).isFalse();
+    }
+
+    @Test
     void everyScopeIsClearedOnTheWayOut() throws Exception {
         authenticateWith(ORG_MEMBER_7);
         run("/api/v1/user/web");

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeReadAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeReadAuthzTest.java
@@ -1,0 +1,131 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Who may read one employee record, on both twins.
+ *
+ * <p>The web twin gated the read on the system-admin, hr-admin or project-manager role while the
+ * PATCH beside it gated on {@code isSelfOrHasAnyOrgRole}, so a person could edit their own record
+ * and then be refused reading it back. That is the shape commit eec6c37 fixed on projects.
+ *
+ * <p>The mobile twin refused everybody: {@code employee:read} and {@code employee:admin} are bare
+ * {@code resource:scope} authorities, which {@code JwtAuthConverter} mints only from the
+ * authorization claim of an RPT, and the realm carries no authorization scopes to put there. Same
+ * phantom-guard mechanism as #684, repaired the same way rather than deleted.
+ */
+@WebMvcTest({EmployeeController.class, EmployeeControllerWeb.class})
+@Import(EmployeeReadAuthzTest.TestSecurityConfig.class)
+class EmployeeReadAuthzTest {
+
+    private static final long SELF = 7L;
+    private static final long SOMEONE_ELSE = 8L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EmployeeService employeeService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** A plain member: no elevated role anywhere, self only on their own record. */
+    private void plainMemberWhoIs(long selfId) {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), any(String[].class))).thenReturn(false);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(eq(selfId), any(String[].class))).thenReturn(true);
+        when(employeeService.displayAnEmployee(anyLong())).thenReturn(new EmployeeDto());
+    }
+
+    @Test
+    void webRead_isOk_forTheEmployeeThemselves() throws Exception {
+        // The read has to be at least as open as the PATCH beside it, which is
+        // isSelfOrHasAnyOrgRole. Before the repair this was 403 while the PATCH was 200.
+        plainMemberWhoIs(SELF);
+
+        mockMvc.perform(get("/api/v1/employee/web/" + SELF).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void webRead_isForbidden_forAPlainMemberReadingAColleague() throws Exception {
+        // The repair adds self and nothing else: a member with no elevated role still cannot
+        // open somebody else's record, which carries salary, date of birth and address.
+        plainMemberWhoIs(SELF);
+
+        mockMvc.perform(get("/api/v1/employee/web/" + SOMEONE_ELSE).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void webRead_isOk_forARoleHolderReadingAColleague() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), any(String[].class))).thenReturn(true);
+        when(employeeService.displayAnEmployee(anyLong())).thenReturn(new EmployeeDto());
+
+        mockMvc.perform(get("/api/v1/employee/web/" + SOMEONE_ELSE).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void mobileRead_isOk_forTheEmployeeThemselves() throws Exception {
+        // Against the phantom guard this was 403 for every caller in every environment.
+        plainMemberWhoIs(SELF);
+
+        mockMvc.perform(get("/api/v1/employee/" + SELF).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void mobileRead_isForbidden_forAPlainMemberReadingAColleague() throws Exception {
+        plainMemberWhoIs(SELF);
+
+        mockMvc.perform(get("/api/v1/employee/" + SOMEONE_ELSE).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDuplicateAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDuplicateAuthzTest.java
@@ -1,0 +1,134 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyDto;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Which organization the duplicate guard is answered against, on both twins.
+ *
+ * <p>Duplicating names two organizations: the one the session is scoped to, which owns the
+ * source policy, and the target the copy is written into. The role check used to be evaluated
+ * against the first only, so an hr-admin in their own organization could write a policy into a
+ * second one on the strength of an employment record there and no role at all. These pin the
+ * repaired shape: a role in the current tenant AND the same role in the organization named.
+ *
+ * <p>{@code hasAnyOrgRole(id, roles)} is the right half of the pair because it reads the
+ * caller's authorities for a named organization directly, without going through
+ * {@code TenantContext}, which by construction only ever holds the current tenant.
+ */
+@WebMvcTest({LeavePolicyController.class, LeavePolicyControllerWeb.class})
+@Import(LeavePolicyDuplicateAuthzTest.TestSecurityConfig.class)
+class LeavePolicyDuplicateAuthzTest {
+
+    private static final long TARGET_ORG = 9L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LeavePolicyService policyService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    private void callerHolds(boolean roleHere, boolean roleThere) {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(roleHere);
+        when(orgSecurity.hasAnyOrgRole(eq(TARGET_ORG), any(String[].class))).thenReturn(roleThere);
+        when(policyService.duplicatePolicy(anyLong(), anyLong())).thenReturn(new LeavePolicyDto());
+    }
+
+    @Test
+    void duplicate_isForbidden_forAnAdminHereWhoHoldsNoRoleInTheTarget() throws Exception {
+        callerHolds(true, false);
+
+        mockMvc.perform(post("/api/v1/leave-policies/4/duplicate")
+                        .param("targetOrganizationId", String.valueOf(TARGET_ORG))
+                        .with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void duplicateOnTheWebTwin_isForbidden_forAnAdminHereWhoHoldsNoRoleInTheTarget() throws Exception {
+        callerHolds(true, false);
+
+        mockMvc.perform(post("/api/v1/leave-policies/web/duplicate")
+                        .param("policyId", "4")
+                        .param("targetOrganizationId", String.valueOf(TARGET_ORG))
+                        .with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void duplicate_isForbidden_forAnAdminInTheTargetWhoHoldsNoRoleHere() throws Exception {
+        // The other side of the pair. The source policy is read out of the current tenant, so
+        // the role there is not made redundant by holding one in the target.
+        callerHolds(false, true);
+
+        mockMvc.perform(post("/api/v1/leave-policies/4/duplicate")
+                        .param("targetOrganizationId", String.valueOf(TARGET_ORG))
+                        .with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void duplicate_isCreated_forAnAdminInBoth() throws Exception {
+        callerHolds(true, true);
+
+        mockMvc.perform(post("/api/v1/leave-policies/4/duplicate")
+                        .param("targetOrganizationId", String.valueOf(TARGET_ORG))
+                        .with(jwt()))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void duplicateOnTheWebTwin_isCreated_forAnAdminInBoth() throws Exception {
+        callerHolds(true, true);
+
+        mockMvc.perform(post("/api/v1/leave-policies/web/duplicate")
+                        .param("policyId", "4")
+                        .param("targetOrganizationId", String.valueOf(TARGET_ORG))
+                        .with(jwt()))
+                .andExpect(status().isCreated());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
@@ -1,0 +1,145 @@
+package org.tornotron.echno_backend.organization;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantIsolationListenerRegistrar;
+import org.tornotron.echno_backend.common.multitenancy.UnscopedAccessGuard;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Whether the Hibernate {@code orgFilter} reaches an entity joined explicitly in HQL, measured
+ * against a real database rather than reasoned about.
+ *
+ * <p>{@code OrganizationRepository.findByIdAndUserEmail} answers "is this caller employed by that
+ * organization" with {@code SELECT o FROM Organization o JOIN o.employees e JOIN e.user u}.
+ * {@code Organization} is the tenant root and carries no filter; {@code Employee} carries
+ * {@code orgFilter}. Whether the filter narrows the joined {@code Employee} decides what the
+ * query means for an organization that is not the current tenant, and therefore whether an
+ * endpoint resolving a caller-named organization through it is exploitable or merely dead. That
+ * question was raised in #698 and could not be settled by reading.
+ *
+ * <p>Either way the guard on such an endpoint has to establish entitlement itself, which is the
+ * point {@code TenantIsolationIT.findById_onTheTenantRootItself_isNotCoveredByEitherMechanism}
+ * makes for the primary-key load. This pins the join-shaped case beside it.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TenantIsolationListenerRegistrar.class, UnscopedAccessGuard.class, SimpleMeterRegistry.class})
+class OrganizationLookupUnderTheOrgFilterIT extends AbstractIntegrationTest {
+
+    private static final String EMAIL = "both.orgs@example.test";
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Long orgAId;
+    private Long orgBId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        Organization orgA = persistOrganization("Org A");
+        Organization orgB = persistOrganization("Org B");
+
+        User user = new User();
+        user.setName("Someone Employed Twice");
+        user.setEmail(EMAIL);
+        user.setKeycloakId("keycloak-" + EMAIL);
+        entityManager.persist(user);
+
+        persistEmployee(orgA, user);
+        persistEmployee(orgB, user);
+
+        entityManager.flush();
+        orgAId = orgA.getId();
+        orgBId = orgB.getId();
+        entityManager.clear();
+    }
+
+    @AfterEach
+    void clearContext() {
+        TenantContext.clear();
+    }
+
+    /** What HibernateFilterConfig does at a transaction boundary, done by hand in this slice. */
+    private void enableOrgFilterFor(Long organizationId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", organizationId);
+    }
+
+    @Test
+    void theCurrentTenantResolvesThroughTheEmployeeJoin() {
+        TenantContext.setCurrentOrgId(orgAId);
+        enableOrgFilterFor(orgAId);
+
+        assertThat(organizationRepository.findByIdAndUserEmail(orgAId, EMAIL)).isPresent();
+    }
+
+    @Test
+    void anotherOrganizationTheCallerIsAlsoEmployedByDoesNotResolveUnderTheFilter() {
+        // The measured answer to #698's open question. With the filter pinned to organization A,
+        // the joined Employee rows are narrowed to A, so no row satisfies the join for
+        // organization B even though the caller genuinely has an employment record there. The
+        // cross-organization duplicate path is therefore dead rather than exploitable: it
+        // resolves nothing and raises a not-found. That is what keeps the guard repair a
+        // correctness fix rather than a live-vulnerability fix, and it is also why moving the
+        // role check to the target cannot be the whole answer on its own.
+        TenantContext.setCurrentOrgId(orgAId);
+        enableOrgFilterFor(orgAId);
+
+        assertThat(organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)).isEmpty();
+    }
+
+    @Test
+    void withNoFilterEnabledTheSameLookupResolvesEitherOrganization() {
+        // The control. Without the filter the query is purely "is this caller employed there",
+        // which is what the endpoint's guard was leaning on and what makes the role check on the
+        // caller's own tenant the wrong question to ask about the target.
+        TenantContext.declareUnscoped("measuring the unfiltered shape of the same query");
+
+        assertThat(organizationRepository.findByIdAndUserEmail(orgAId, EMAIL)).isPresent();
+        assertThat(organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)).isPresent();
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void persistEmployee(Organization organization, User user) {
+        Employee employee = new Employee();
+        employee.setOrganization(organization);
+        employee.setUser(user);
+        employee.setEmployeeName(user.getName());
+        employee.setEmailAddress(user.getEmail());
+        employee.setGender("unspecified");
+        employee.setPhoneNumber("0000000000");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        entityManager.persist(employee);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
@@ -107,8 +107,9 @@ class OrganizationLookupUnderTheOrgFilterIT extends AbstractIntegrationTest {
         // reading predicted. The org filter does NOT narrow an entity joined explicitly in HQL:
         // the join still matches the caller's employment row in organization B, so the query is
         // satisfiable and the row is loaded. What stops it is the other mechanism.
-        // TenantIsolationLoadListener runs on the post-load of that Employee, sees a
-        // tenant-scoped row from organization B under a request scoped to A, and refuses.
+        // TenantIsolationLoadListener runs on the post-load of that row, which is an Employee,
+        // the only tenant-scoped entity this query touches, and refuses it under a request
+        // scoped to organization A.
         //
         // Two consequences worth keeping. The lookup is not a silent cross-tenant read, so an
         // endpoint resolving a caller-named organization through it fails loudly rather than
@@ -119,8 +120,8 @@ class OrganizationLookupUnderTheOrgFilterIT extends AbstractIntegrationTest {
 
         assertThatThrownBy(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL))
                 .isInstanceOf(TenantAccessDeniedException.class)
-                .hasMessageContaining("Employee")
-                .hasMessageContaining("belongs to organization " + orgBId);
+                .hasMessageContaining("Cross-tenant access denied")
+                .hasMessageContaining("the request is scoped to organization " + orgAId);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
@@ -22,7 +22,7 @@ import org.tornotron.echno_backend.user.User;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Whether the Hibernate {@code orgFilter} reaches an entity joined explicitly in HQL, measured
@@ -101,26 +101,51 @@ class OrganizationLookupUnderTheOrgFilterIT extends AbstractIntegrationTest {
         assertThat(organizationRepository.findByIdAndUserEmail(orgAId, EMAIL)).isPresent();
     }
 
+    /**
+     * The foreign-organization lookup, asserted one property per test rather than as a chain.
+     *
+     * <p>The build reports a failure by its exception class and its line, with
+     * {@code exceptionFormat 'short'}, so a chained assertion that fails says only that one link
+     * broke and not which. Each property therefore gets its own method, and the list of failures
+     * is the readout: whether anything is thrown at all, whether it is the cross-tenant denial,
+     * which entity it names, and which organizations it names. Nothing is given up by splitting
+     * them; every assertion that was in the chain is still made.
+     */
     @Test
-    void anotherOrganizationIsStoppedByTheLoadListenerRatherThanByTheFilter() {
-        // The measured answer to #698's open question, and it is not the one either candidate
-        // reading predicted. The org filter does NOT narrow an entity joined explicitly in HQL:
-        // the join still matches the caller's employment row in organization B, so the query is
-        // satisfiable and the row is loaded. What stops it is the other mechanism.
-        // TenantIsolationLoadListener runs on the post-load of that row, which is an Employee,
-        // the only tenant-scoped entity this query touches, and refuses it under a request
-        // scoped to organization A.
-        //
-        // Two consequences worth keeping. The lookup is not a silent cross-tenant read, so an
-        // endpoint resolving a caller-named organization through it fails loudly rather than
-        // succeeding quietly. And the filter cannot be relied on to scope a join, so the
-        // fail-closed listener is doing the work here on its own, with no defence behind it.
+    void foreignOrganization_something_isThrown() {
         TenantContext.setCurrentOrgId(orgAId);
         enableOrgFilterFor(orgAId);
 
-        assertThatThrownBy(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL))
-                .isInstanceOf(TenantAccessDeniedException.class)
-                .hasMessageContaining("Cross-tenant access denied")
+        assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
+                .as("a lookup of an organization that is not the current tenant")
+                .isNotNull();
+    }
+
+    @Test
+    void foreignOrganization_theThrowableIsTheCrossTenantDenial() {
+        TenantContext.setCurrentOrgId(orgAId);
+        enableOrgFilterFor(orgAId);
+
+        assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
+                .isInstanceOf(TenantAccessDeniedException.class);
+    }
+
+    @Test
+    void foreignOrganization_theRefusalNamesTheJoinedEmployee() {
+        TenantContext.setCurrentOrgId(orgAId);
+        enableOrgFilterFor(orgAId);
+
+        assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
+                .hasMessageContaining("Cross-tenant access denied: Employee");
+    }
+
+    @Test
+    void foreignOrganization_theRefusalNamesBothOrganizations() {
+        TenantContext.setCurrentOrgId(orgAId);
+        enableOrgFilterFor(orgAId);
+
+        assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
+                .hasMessageContaining("belongs to organization " + orgBId)
                 .hasMessageContaining("the request is scoped to organization " + orgAId);
     }
 

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantIsolationListenerRegistrar;
 import org.tornotron.echno_backend.common.multitenancy.UnscopedAccessGuard;
@@ -36,13 +35,16 @@ import static org.assertj.core.api.Assertions.catchThrowable;
  * endpoint resolving a caller-named organization through it is exploitable or merely dead. That
  * question was raised in #698 and could not be settled by reading.
  *
- * <p>The measured answer is that the filter does not reach the join. What refuses the foreign
- * organization is the fail-closed load listener, on the post-load of the joined {@code Employee}.
- * So the lookup is not a silent cross-tenant read, and equally it is not scoped by the mechanism
- * that looks like it should scope it. Either way the guard on such an endpoint has to establish
- * entitlement itself, which is the point
- * {@code TenantIsolationIT.findById_onTheTenantRootItself_isNotCoveredByEitherMechanism} makes for
- * the primary-key load. This pins the join-shaped case beside it.
+ * <p>The measured answer is that the filter does reach the join, so the query cannot resolve an
+ * organization that is not the current tenant and answers empty. That makes the lookup a
+ * not-found rather than a cross-tenant read, and it makes any endpoint built on it dead across
+ * organizations rather than exploitable.
+ *
+ * <p>It does not make the guard on such an endpoint optional. This query establishes employment,
+ * never a role, and the organization it is asked about still arrives from the caller.
+ * {@code TenantIsolationIT.findById_onTheTenantRootItself_isNotCoveredByEitherMechanism} makes
+ * the same point for the primary-key load, where nothing scopes the tenant root at all; this pins
+ * the join-shaped case beside it.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -63,6 +65,10 @@ class OrganizationLookupUnderTheOrgFilterIT extends AbstractIntegrationTest {
     @BeforeEach
     void seed() {
         TenantContext.clear();
+        // The filter is session state and each test says for itself whether it wants it on, so
+        // start from off rather than from whatever the previous method left. Without this the
+        // outcome of a test here depends on the order JUnit happens to run them in.
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
         Organization orgA = persistOrganization("Org A");
         Organization orgB = persistOrganization("Org B");
 
@@ -101,52 +107,31 @@ class OrganizationLookupUnderTheOrgFilterIT extends AbstractIntegrationTest {
         assertThat(organizationRepository.findByIdAndUserEmail(orgAId, EMAIL)).isPresent();
     }
 
-    /**
-     * The foreign-organization lookup, asserted one property per test rather than as a chain.
-     *
-     * <p>The build reports a failure by its exception class and its line, with
-     * {@code exceptionFormat 'short'}, so a chained assertion that fails says only that one link
-     * broke and not which. Each property therefore gets its own method, and the list of failures
-     * is the readout: whether anything is thrown at all, whether it is the cross-tenant denial,
-     * which entity it names, and which organizations it names. Nothing is given up by splitting
-     * them; every assertion that was in the chain is still made.
-     */
     @Test
-    void foreignOrganization_something_isThrown() {
+    void anotherOrganizationTheCallerIsAlsoEmployedByDoesNotResolveUnderTheFilter() {
+        // The measured answer to #698's open question. The filter reaches the explicit
+        // JOIN o.employees e: with it pinned to organization A the joined Employee rows are
+        // narrowed to A, so nothing satisfies the join for organization B even though the caller
+        // genuinely holds an employment record there. The lookup resolves nothing and the caller
+        // gets the not-found the service raises.
+        //
+        // Nothing is thrown on the way. The fail-closed load listener never sees a foreign row,
+        // because no foreign row is selected, so the filter is doing this on its own. That makes
+        // the cross-organization duplicate path dead rather than exploitable, which is the branch
+        // #698 named and could not settle by reading, and it is why the guard repair beside this
+        // is a correctness fix rather than the closing of a live hole.
+        //
+        // Asserted as emptiness rather than as a refusal. An earlier form of this test read the
+        // outcome as a TenantAccessDeniedException and said so; splitting the assertion one
+        // property per test showed that no throwable is raised at all, so the refusal reading was
+        // wrong and the claim is corrected here rather than softened.
         TenantContext.setCurrentOrgId(orgAId);
         enableOrgFilterFor(orgAId);
 
         assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
-                .as("a lookup of an organization that is not the current tenant")
-                .isNotNull();
-    }
-
-    @Test
-    void foreignOrganization_theThrowableIsTheCrossTenantDenial() {
-        TenantContext.setCurrentOrgId(orgAId);
-        enableOrgFilterFor(orgAId);
-
-        assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
-                .isInstanceOf(TenantAccessDeniedException.class);
-    }
-
-    @Test
-    void foreignOrganization_theRefusalNamesTheJoinedEmployee() {
-        TenantContext.setCurrentOrgId(orgAId);
-        enableOrgFilterFor(orgAId);
-
-        assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
-                .hasMessageContaining("Cross-tenant access denied: Employee");
-    }
-
-    @Test
-    void foreignOrganization_theRefusalNamesBothOrganizations() {
-        TenantContext.setCurrentOrgId(orgAId);
-        enableOrgFilterFor(orgAId);
-
-        assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
-                .hasMessageContaining("belongs to organization " + orgBId)
-                .hasMessageContaining("the request is scoped to organization " + orgAId);
+                .as("the lookup completes rather than being refused by the load listener")
+                .isNull();
+        assertThat(organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
@@ -19,6 +19,7 @@ import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 import org.tornotron.echno_backend.user.User;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -35,16 +36,17 @@ import static org.assertj.core.api.Assertions.catchThrowable;
  * endpoint resolving a caller-named organization through it is exploitable or merely dead. That
  * question was raised in #698 and could not be settled by reading.
  *
- * <p>The measured answer is that the filter does reach the join, so the query cannot resolve an
- * organization that is not the current tenant and answers empty. That makes the lookup a
- * not-found rather than a cross-tenant read, and it makes any endpoint built on it dead across
- * organizations rather than exploitable.
+ * <p>The measured answer is that it does not. The filter narrows a query root and a filtered
+ * collection; it leaves an entity joined explicitly in HQL alone. So the query resolves any
+ * organization the caller holds an {@code Employee} row in, whatever tenant the request is scoped
+ * to, and it does so silently: the joined {@code Employee} is never selected, so the fail-closed
+ * load listener gets no post-load to judge either. Neither mechanism scopes this query.
  *
- * <p>It does not make the guard on such an endpoint optional. This query establishes employment,
- * never a role, and the organization it is asked about still arrives from the caller.
- * {@code TenantIsolationIT.findById_onTheTenantRootItself_isNotCoveredByEitherMechanism} makes
- * the same point for the primary-key load, where nothing scopes the tenant root at all; this pins
- * the join-shaped case beside it.
+ * <p>An endpoint that resolves a caller-named organization through it therefore reads across a
+ * tenant and learns only that the caller is employed there, which is why such an endpoint has to
+ * establish entitlement in its own guard. That is the same conclusion
+ * {@code TenantIsolationIT.findById_onTheTenantRootItself_isNotCoveredByEitherMechanism} reaches
+ * for the primary-key load, by a different route; this pins the join-shaped case beside it.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -108,30 +110,42 @@ class OrganizationLookupUnderTheOrgFilterIT extends AbstractIntegrationTest {
     }
 
     @Test
-    void anotherOrganizationTheCallerIsAlsoEmployedByDoesNotResolveUnderTheFilter() {
-        // The measured answer to #698's open question. The filter reaches the explicit
-        // JOIN o.employees e: with it pinned to organization A the joined Employee rows are
-        // narrowed to A, so nothing satisfies the join for organization B even though the caller
-        // genuinely holds an employment record there. The lookup resolves nothing and the caller
-        // gets the not-found the service raises.
+    void anotherOrganizationTheCallerIsAlsoEmployedByResolvesRightThroughTheFilter() {
+        // The measured answer to #698's open question, and it is the worse of the two.
         //
-        // Nothing is thrown on the way. The fail-closed load listener never sees a foreign row,
-        // because no foreign row is selected, so the filter is doing this on its own. That makes
-        // the cross-organization duplicate path dead rather than exploitable, which is the branch
-        // #698 named and could not settle by reading, and it is why the guard repair beside this
-        // is a correctness fix rather than the closing of a live hole.
+        // The filter does NOT reach an entity joined explicitly in HQL. Pinned to organization A
+        // it leaves JOIN o.employees e unnarrowed, the caller's employment row in organization B
+        // still satisfies the join, and the query hands back organization B. Nothing is thrown on
+        // the way: the joined Employee is never selected, so the fail-closed load listener gets no
+        // post-load to judge and never sees the row. Neither mechanism scopes this query.
         //
-        // Asserted as emptiness rather than as a refusal. An earlier form of this test read the
-        // outcome as a TenantAccessDeniedException and said so; splitting the assertion one
-        // property per test showed that no throwable is raised at all, so the refusal reading was
-        // wrong and the claim is corrected here rather than softened.
+        // So an endpoint that resolves a caller-named organization through findByIdAndUserEmail
+        // reads across a tenant, silently, and establishes only that the caller is employed there.
+        // That is why the guard on LeavePolicyController.duplicatePolicy has to answer for the
+        // target organization itself, and why doing so closes a live path rather than tidying a
+        // dead one.
+        //
+        // Read the assertions in this order deliberately: no throwable first, then the identity of
+        // what came back. Two earlier forms of this test asserted isEmpty() and were told that a
+        // TenantAccessDeniedException came out of the lookup, which read as the listener refusing
+        // the row. It was not. Organization is a Lombok @Data entity whose generated toString
+        // walks its lazy employees collection, so AssertJ building the failure description for a
+        // present Optional initialized that collection, loaded organization B's Employee rows
+        // under tenant A, and tripped the listener there. The exception came from the assertion's
+        // own error message and hid the result it was reporting on. Nothing here calls toString on
+        // the entity for that reason.
         TenantContext.setCurrentOrgId(orgAId);
         enableOrgFilterFor(orgAId);
 
         assertThat(catchThrowable(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)))
-                .as("the lookup completes rather than being refused by the load listener")
+                .as("the lookup completes rather than being refused")
                 .isNull();
-        assertThat(organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)).isEmpty();
+
+        Optional<Organization> resolved = organizationRepository.findByIdAndUserEmail(orgBId, EMAIL);
+        assertThat(resolved).as("a foreign organization resolves under an active tenant").isPresent();
+        assertThat(resolved.get().getId())
+                .as("and it is the foreign one, not the current tenant")
+                .isEqualTo(orgBId);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationLookupUnderTheOrgFilterIT.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantIsolationListenerRegistrar;
 import org.tornotron.echno_backend.common.multitenancy.UnscopedAccessGuard;
@@ -21,6 +22,7 @@ import org.tornotron.echno_backend.user.User;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Whether the Hibernate {@code orgFilter} reaches an entity joined explicitly in HQL, measured
@@ -34,9 +36,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * endpoint resolving a caller-named organization through it is exploitable or merely dead. That
  * question was raised in #698 and could not be settled by reading.
  *
- * <p>Either way the guard on such an endpoint has to establish entitlement itself, which is the
- * point {@code TenantIsolationIT.findById_onTheTenantRootItself_isNotCoveredByEitherMechanism}
- * makes for the primary-key load. This pins the join-shaped case beside it.
+ * <p>The measured answer is that the filter does not reach the join. What refuses the foreign
+ * organization is the fail-closed load listener, on the post-load of the joined {@code Employee}.
+ * So the lookup is not a silent cross-tenant read, and equally it is not scoped by the mechanism
+ * that looks like it should scope it. Either way the guard on such an endpoint has to establish
+ * entitlement itself, which is the point
+ * {@code TenantIsolationIT.findById_onTheTenantRootItself_isNotCoveredByEitherMechanism} makes for
+ * the primary-key load. This pins the join-shaped case beside it.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -96,18 +102,25 @@ class OrganizationLookupUnderTheOrgFilterIT extends AbstractIntegrationTest {
     }
 
     @Test
-    void anotherOrganizationTheCallerIsAlsoEmployedByDoesNotResolveUnderTheFilter() {
-        // The measured answer to #698's open question. With the filter pinned to organization A,
-        // the joined Employee rows are narrowed to A, so no row satisfies the join for
-        // organization B even though the caller genuinely has an employment record there. The
-        // cross-organization duplicate path is therefore dead rather than exploitable: it
-        // resolves nothing and raises a not-found. That is what keeps the guard repair a
-        // correctness fix rather than a live-vulnerability fix, and it is also why moving the
-        // role check to the target cannot be the whole answer on its own.
+    void anotherOrganizationIsStoppedByTheLoadListenerRatherThanByTheFilter() {
+        // The measured answer to #698's open question, and it is not the one either candidate
+        // reading predicted. The org filter does NOT narrow an entity joined explicitly in HQL:
+        // the join still matches the caller's employment row in organization B, so the query is
+        // satisfiable and the row is loaded. What stops it is the other mechanism.
+        // TenantIsolationLoadListener runs on the post-load of that Employee, sees a
+        // tenant-scoped row from organization B under a request scoped to A, and refuses.
+        //
+        // Two consequences worth keeping. The lookup is not a silent cross-tenant read, so an
+        // endpoint resolving a caller-named organization through it fails loudly rather than
+        // succeeding quietly. And the filter cannot be relied on to scope a join, so the
+        // fail-closed listener is doing the work here on its own, with no defence behind it.
         TenantContext.setCurrentOrgId(orgAId);
         enableOrgFilterFor(orgAId);
 
-        assertThat(organizationRepository.findByIdAndUserEmail(orgBId, EMAIL)).isEmpty();
+        assertThatThrownBy(() -> organizationRepository.findByIdAndUserEmail(orgBId, EMAIL))
+                .isInstanceOf(TenantAccessDeniedException.class)
+                .hasMessageContaining("Employee")
+                .hasMessageContaining("belongs to organization " + orgBId);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebAuthzTest.java
@@ -27,14 +27,17 @@ import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Web-slice authorization tests for the read endpoints on ProjectControllerWeb.
- * They lock in the guard that a caller may read projects when they are either a
- * member of the current tenant OR hold an elevated org role (system-admin /
- * project-manager) for it. The role branch matters because the write endpoints on
- * this same controller gate on the role alone: without it a role-holder who is not
- * recorded as a member (for example the bootstrap admin) could create and edit
- * projects yet get 403 listing them. @orgSecurity is mocked so each branch is
- * exercised independently; if a read @PreAuthorize is ever narrowed back to
- * membership only, the role-without-membership test fails.
+ * They lock in the guard that a caller may read projects when they are a member of
+ * the current tenant.
+ *
+ * <p>These used to assert a second branch, added by {@code eec6c37}, that let a
+ * role-holder who is not recorded as a member read as well. That branch passed only
+ * because @orgSecurity is mocked here, which lets the two guards be set
+ * independently; no real request can be in that state, because TenantFilter resolves
+ * an organization from ORG_MEMBER_ authorities alone and both guards refuse a null
+ * organization. The invariant now lives where it can be measured rather than mocked,
+ * in TenantFilterTest.theRoleGuardCannotSucceedWhereTheMembershipGuardFails, and the
+ * branch it disproved is gone from the controller. See #709.
  */
 @WebMvcTest(ProjectControllerWeb.class)
 @Import({ProjectControllerWebAuthzTest.TestSecurityConfig.class, JsonPartBinder.class,
@@ -71,10 +74,10 @@ class ProjectControllerWebAuthzTest {
     }
 
     @Test
-    void readAllProjects_isOk_forARoleHolderThatIsNotRecordedAsAMember() throws Exception {
-        // The fix: an org system-admin / project-manager can read even without the
-        // ORG_MEMBER_ authority, matching how create/update/delete already gate.
-        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+    void readAllProjects_isOk_forAMemberWhoAlsoHoldsAnElevatedRole() throws Exception {
+        // The ordinary shape of an administrator's request: the role never arrives without the
+        // membership, so this is what the removed second clause was really describing.
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(true);
         when(projectService.getAllProjects(anyInt(), anyInt())).thenReturn(Page.empty());
 
@@ -83,7 +86,7 @@ class ProjectControllerWebAuthzTest {
     }
 
     @Test
-    void readAllProjects_isForbidden_forACallerWithNeitherMembershipNorRole() throws Exception {
+    void readAllProjects_isForbidden_forACallerWithNoMembership() throws Exception {
         when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
 


### PR DESCRIPTION
Closes #698, #709, #710. #695 is answered in its own thread rather than in code.

Four authorization issues taken together because they are all guard changes on the same layer. The tests were pushed as their own commit ahead of the fix, so what each guard decided before it changed is measured rather than assumed.

## #710, the read/write asymmetry — repaired

`GET /employee/web/{id}` was gated on the system-admin, hr-admin or project-manager role while the `PATCH` beside it gates on `isSelfOrHasAnyOrgRole`, so a person could edit their own record and then be refused reading it back. It now carries the same self branch and the same three roles, which widens it by exactly one caller: the employee themselves. A member holding no elevated role still cannot open a colleague's record.

The mobile twin asked for `employee:read` or `employee:admin`, bare `resource:scope` authorities that `JwtAuthConverter` mints only from an RPT's `authorization` claim, which this realm has no scopes to fill. It refused every caller from the day it was written. Same mechanism as #684, repaired the same way rather than deleted. The six other phantom guards on that controller are left alone and filed as #716: four are writes, and moving a phantom write guard from refusing everybody to admitting a role is a widening decision of its own.

## #710, the roles enumeration — closed as a decision, not narrowed

`GET /employee/web/{employeeId}/roles` stays on tenant membership. Knowing who the site manager is, is how work gets routed; the answer crosses no tenant and grants nothing; and the ids it is walked with are already enumerable through the lookup list. Narrowing it would cost the directory something real and buy back only the ordering of a list somebody can otherwise assemble. The reasoning is recorded on the method. Its 403 text said "role" while the guard checked membership, and that is corrected.

## #698, the duplicate target — repaired, and the endpoint is worse than filed

The role was checked against the caller's current tenant while entitlement to the target came from `findByIdAndUserEmail`, which establishes an `Employee` row there and nothing about what the caller may do. Both twins now require the role in the current tenant **and** in the target.

The issue left open whether the target is even reachable. `OrganizationLookupUnderTheOrgFilterIT` settles it against a real database: **the org filter does not reach an entity joined explicitly in HQL**, and the joined `Employee` is never selected so the fail-closed load listener gets no post-load to judge either. Neither mechanism scopes that query, and a foreign organization comes back silently. So this was a live cross-organization write path, and the repair closes it rather than tidying a dead one.

Not fixed here, filed as #718: the duplicate-code check beside it runs against `LeavePolicy`, which *does* carry the filter as a query root, so it is unsatisfiable for any target other than the current tenant and the uniqueness rule is skipped on exactly the path that needs it.

## #709, the dead `or` — clause removed

Seven read guards read "member OR system-admin/project-manager". The second clause could never decide anything: both sides open on `TenantContext.getCurrentOrgId()`, and `TenantFilter` sets it only after confirming an `ORG_MEMBER_` authority, so a role-holder who is not a member arrives with no organization in force and fails both. Removed rather than turned into an `and`, which would have shut out the ordinary members these reads exist for.

The invariant is pinned in `TenantFilterTest`, against the real `OrganizationSecurityService` inside the filter chain. The branch `ProjectControllerWebAuthzTest` used to assert goes with it: it passed only because `@orgSecurity` is mocked there, which lets the two guards be set into a state no request can reach. That also means `eec6c37`'s intent, letting a role-holder read what they may already write, was never achieved; making it work is a change to tenant resolution rather than to a controller, and is left as a decision. The same expression stands on 36 more guards across ten controllers, filed as #717 and sequenced after that decision.

## #695 — not changed

Widening site-transfer reads to `project-manager` is one row of #680's table and settles its direction, so it is left to that decision. Reasoning, the verified severity, and the one option that does not touch #680 are in the #695 thread.

## Tests

| test | what it covers |
|---|---|
| `EmployeeReadAuthzTest` | reads on both employee twins: self, a plain member refused a colleague, a role-holder allowed one |
| `LeavePolicyDuplicateAuthzTest` | the duplicate guard on both leave-policy twins, each side of the pair and both together |
| `OrganizationLookupUnderTheOrgFilterIT` | whether the org filter reaches an explicit HQL join, with an unfiltered control |
| `TenantFilterTest` | a role without membership resolves no tenant, so the role guard cannot outrun the membership guard |

The OpenAPI document is regenerated for the sixteen response and operation descriptions that moved with the guards.