### PR TITLE
Clear the remainder of the #687 sweep

### DIFF
--- a/docs/MULTI_TENANCY_FILTER_GUIDE.md
+++ b/docs/MULTI_TENANCY_FILTER_GUIDE.md
@@ -22,7 +22,8 @@ Data-level organization isolation using Hibernate filters that automatically app
 14. [Database Migrations](#database-migrations)
 15. [Entities Covered](#entities-covered)
 16. [Edge Cases](#edge-cases)
-17. [Troubleshooting](#troubleshooting)
+17. [Caller-Supplied Organization Ids: Already Checked](#caller-supplied-organization-ids-already-checked)
+18. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -682,6 +683,70 @@ User, Organization, Plan, Feature, PlanFeature, Subscription, SubscriptionItem, 
 | **Native SQL query** | Filter does NOT apply automatically. Add `AND organization_id = :orgId` manually |
 | **New entity without `@Filter` annotation** | Not filtered at all — visible to all orgs. Only add filter to org-scoped entities |
 | **Duplicate `@FilterDef` on entity** | **Application fails to start** with error: `Multiple '@FilterDef' annotations define a filter named 'orgFilter'`. Remove from entity — it should only exist in `package-info.java` |
+
+---
+
+## Caller-Supplied Organization Ids: Already Checked
+
+A handler that takes an organization id from the caller and looks something up with it is the
+shape worth auditing, because it can mean the caller chose which tenant's data was read. Most
+occurrences are not that. They are a redundant parameter beside a `TenantContext` read, or a
+parameter the entity's `orgFilter` renders inert.
+
+Telling the two apart is slow, and it is the same work every time. This section records the
+answers already arrived at, so a later pass can skip them and spend its time on what is new.
+Sources: issues #687, #691, #696, #697, #698, #699, #700, and the commits that closed them.
+
+### How to tell them apart, in order
+
+1. **Is the entity a `TenantScopedEntity`?** If it carries `orgFilter`, a foreign id yields an
+   empty result, and `TenantIsolationLoadListener` refuses a load by id outright. The parameter
+   then decides nothing, and the finding is tidiness rather than exposure.
+2. **Is it `Organization` itself?** The tenant root carries neither defence. A caller-supplied id
+   reaching an unfiltered `Organization` lookup is the dangerous form. `OrganizationService`
+   `batchUpdateOrganization` is the worked example: an explicit per-id `isMemberOrAdmin` loop,
+   with a comment saying why it has to be there.
+3. **Does the guard read the same id the service reads?** A guard on `TenantContext` beside a
+   service on `#organizationId` is a mismatch even when the filter neutralises it. The repair is
+   `@orgSecurity.isCurrentTenant(#organizationId)` alongside the role check, which makes the
+   segment binding instead of decorative.
+4. **Trace the whole workflow, not the call that refused.** A read gated a tier above the write
+   beside it strands the caller who is entitled to finish the job (#666).
+
+### Confirmed non-defects
+
+Recorded so they are not re-derived. Each was traced to the line above the lookup.
+
+| Site | Why it is fine |
+|------|----------------|
+| `AttendanceService` 227, 369, 618, 672 | reads `TenantContext.getCurrentOrgId()` on the line above; loads the caller's own tenant root |
+| `ShiftTimingService:37`, `AttendanceSettingsService:56` | same shape |
+| `MovementRecordService:92`, `AttendanceRegularizationService:99` | same shape |
+| `ProjectService:164`, `LeavePolicyService.createPolicy`, `TenantEntityHelper:20` | same shape |
+| `OrganizationController` 142, 200 | guard bound to the caller-supplied id (`isMember(#id)`, `hasAnyOrgRole(#id, ...)`); the correct pattern for the family |
+| `OrganizationWebController` 146, 169, 201 | same, including `hasOrgRole(#id,'system-admin')` |
+| `OrganizationService.batchUpdateOrganization:419` | explicit per-id `isMemberOrAdmin` loop, with the reason written down; the precedent to copy |
+| `EmployeeController:149` (`GET /employee/organization/{id}`) | binds `@orgSecurity.isMember(#id)`; the correctly-written member of the family |
+
+### Repaired, with the repair to copy
+
+| Site | What it was | What it became |
+|------|-------------|----------------|
+| `EmployeeControllerWeb` managers by organization | guard on `TenantContext`, service on `#organizationId` | `isCurrentTenant(#organizationId)` and the role check |
+| `LeavePolicyController` policies by organization (#691) | plus an existence check that read as a tenant check | same pair; the service now says why its `existsById` is not one |
+| `LeaveRequestController` requests by organization (#700) | segment published and bound to nothing at all | same pair; the segment now means what the contract says |
+| `LeavePolicyService.createPolicy` (#700) | uniqueness checked against `dto.organizationId` and the raw casing | checked against the tenant and the code as stored |
+| `AttachmentService.linkToEntity` (#700) | an `Organization` arm loading by a caller-supplied id, overwritten one line later | arm removed, and the repository with it |
+
+### Two traps worth keeping in mind
+
+- **An empty result is not proof of a defence.** It can equally be an id that matches nothing.
+  Check the entity for `orgFilter` rather than inferring from an empty list.
+- **Retiring a route or a path segment is a separate decision from repairing its guard.** The
+  `echno-core` contract is hand-maintained with no code generation, so a route change breaks the
+  web app at runtime rather than at compile time. Repair the guard now; retire the segment in a
+  deliberate release. As of #700, no client calls any of the three org-segmented routes above:
+  `echno-core` and `echno-web` both reach the `/web` twins, which take no segment.
 
 ---
 

--- a/docs/MULTI_TENANCY_FILTER_GUIDE.md
+++ b/docs/MULTI_TENANCY_FILTER_GUIDE.md
@@ -738,10 +738,21 @@ Recorded so they are not re-derived. Each was traced to the line above the looku
 | `LeavePolicyService.createPolicy` (#700) | uniqueness checked against `dto.organizationId` and the raw casing | checked against the tenant and the code as stored |
 | `AttachmentService.linkToEntity` (#700) | an `Organization` arm loading by a caller-supplied id, overwritten one line later | arm removed, and the repository with it |
 
-### Two traps worth keeping in mind
+### Three traps worth keeping in mind
 
 - **An empty result is not proof of a defence.** It can equally be an id that matches nothing.
   Check the entity for `orgFilter` rather than inferring from an empty list.
+- **A check on the request as received is not a check on the row that will be written.** Every
+  argument to a guard has to be the value the row will actually hold, and an organization id is
+  only the most obvious of them. `LeavePolicyService.createPolicy` is the worked example, and it
+  was wrong on both arguments at once for two unrelated reasons. The organization came from the
+  request body while the row went to the tenant. And the leave-type code was checked as it
+  arrived while the row stores it uppercased, so a lower-case code was compared against a value
+  the table never holds, and slipped the uniqueness rule from the caller's own organization with
+  no foreign id involved at all. The second one was found only because the first was being
+  repaired, and nothing about tenancy would have surfaced it: any normalisation applied on the
+  way in (case, trimming, a canonical form) opens the same gap wherever a guard runs before it.
+  So when a value is transformed between the request and the write, check the transformed one.
 - **Retiring a route or a path segment is a separate decision from repairing its guard.** The
   `echno-core` contract is hand-maintained with no code generation, so a route change breaks the
   web app at runtime rather than at compile time. Repair the guard now; retire the segment in a

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -68613,8 +68613,19 @@
     },
     "/api/v1/leave-requests/organizationId/{organizationId}": {
       "get": {
-        "description": "Returns every leave request raised within the caller's current tenant.",
+        "description": "Returns every leave request raised within the given organization, which has to be the caller's own. Identical to the /web twin beside it, which takes the organization from the session instead.",
         "operationId": "getOrganizationRequests_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organizationId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -68657,7 +68668,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not entitled to the organization named, or lacks the required role in it"
           },
           "404": {
             "content": {
@@ -68710,7 +68721,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "List the current tenant's leave requests",
+        "summary": "List an organization's leave requests",
         "tags": [
           "Leave Requests"
         ]

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
@@ -18,7 +18,6 @@ import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.attendance.AttendanceRepository;
 import org.tornotron.echno_backend.issue.IssueRepository;
-import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.task.TaskRepository;
 import org.tornotron.echno_backend.user.UserRepository;
@@ -47,7 +46,6 @@ public class AttachmentService {
 
     private final AttachmentRepository attachmentRepository;
     private final FileStorageService fileStorageService;
-    private final OrganizationRepository organizationRepository;
     private final ProjectRepository projectRepository;
     private final TaskRepository taskRepository;
     private final IssueRepository issueRepository;
@@ -56,11 +54,10 @@ public class AttachmentService {
     private final TenantEntityHelper tenantEntityHelper;
     private final AttachmentMapper attachmentMapper;
 
-    public AttachmentService(AttachmentRepository attachmentRepository, FileStorageService fileStorageService, OrganizationRepository organizationRepository, ProjectRepository projectRepository, TaskRepository taskRepository, IssueRepository issueRepository, UserRepository userRepository, AttendanceRepository attendanceRepository, TenantEntityHelper tenantEntityHelper, AttachmentMapper attachmentMapper) {
+    public AttachmentService(AttachmentRepository attachmentRepository, FileStorageService fileStorageService, ProjectRepository projectRepository, TaskRepository taskRepository, IssueRepository issueRepository, UserRepository userRepository, AttendanceRepository attendanceRepository, TenantEntityHelper tenantEntityHelper, AttachmentMapper attachmentMapper) {
         this.attachmentMapper = attachmentMapper;
         this.attachmentRepository = attachmentRepository;
         this.fileStorageService = fileStorageService;
-        this.organizationRepository = organizationRepository;
         this.projectRepository = projectRepository;
         this.taskRepository = taskRepository;
         this.issueRepository = issueRepository;
@@ -333,10 +330,17 @@ public class AttachmentService {
      * Associates an attachment with its owning entity. Extracted so both the
      * streaming upload and the pre-signed upload paths record the association
      * the same way.
+     *
+     * <p>Every arm loads a {@code TenantScopedEntity}, so a caller-supplied id that belongs to
+     * another organization is refused at the load boundary by {@code TenantIsolationLoadListener}
+     * rather than quietly linked. There is deliberately no {@code organization} arm: the
+     * attachment's organization is written by the caller of this method, from the tenant, on the
+     * next line. The arm that used to be here loaded an {@code Organization} by the same
+     * caller-supplied id and had its result overwritten immediately, so it changed nothing and
+     * still had to be cleared as a suspect on every pass through this family. See issue #700.
      */
     private void linkToEntity(Attachment attachment, String folder, Long entityId) {
         switch (folder) {
-            case "organization" -> attachment.setOrganization(organizationRepository.findById(entityId).orElse(null));
             case "project", "projects" -> attachment.setProject(projectRepository.findById(entityId).orElse(null));
             case "task" -> attachment.setTask(taskRepository.findById(entityId).orElse(null));
             case "issue" -> attachment.setIssue(issueRepository.findById(entityId).orElse(null));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -68,20 +68,33 @@ public class LeavePolicyService {
      */
     @Transactional
     public LeavePolicyDto createPolicy(LeavePolicyCreationDto dto) {
-        Organization organization = organizationRepository.findByIdAndUserEmail(TenantContext.getCurrentOrgId(), userContextService.getCurrentUserEmail())
+        Long organizationId = TenantContext.getCurrentOrgId();
+        Organization organization = organizationRepository.findByIdAndUserEmail(organizationId, userContextService.getCurrentUserEmail())
                 .orElseThrow(() -> new ResourceNotFoundException(
-                        "Organization with ID " + dto.getOrganizationId() + " was not found"));
+                        "Organization with ID " + organizationId + " was not found"));
 
-        if (policyRepository.existsByOrganizationIdAndLeaveTypeCode(
-                dto.getOrganizationId(), dto.getLeaveTypeCode())) {
+        // Both arguments are the values the row will actually carry, and neither used to be.
+        //
+        // The organization was taken from dto.organizationId, which is a caller-supplied field
+        // that decides nothing else here: the policy is written into the tenant regardless. Since
+        // LeavePolicy carries the orgFilter, any other value made the predicate unsatisfiable, so
+        // the rule was skipped rather than applied. The code was taken as it arrived while the
+        // row stores it uppercased, so a lower-case code was checked against a value the table
+        // never holds. Either way uk_leave_policy_org_type still refused the insert, and the
+        // caller was told only that some constraint failed instead of which code clashed.
+        //
+        // dto.organizationId stays in the payload: clients send it today and removing it is a
+        // contract change, not a repair. See issue #700.
+        String leaveTypeCode = dto.getLeaveTypeCode().toUpperCase();
+        if (policyRepository.existsByOrganizationIdAndLeaveTypeCode(organizationId, leaveTypeCode)) {
             throw new DuplicateResourceException(
-                    "Leave policy with code '" + dto.getLeaveTypeCode() +
+                    "Leave policy with code '" + leaveTypeCode +
                     "' already exists for this organization");
         }
 
         LeavePolicy policy = new LeavePolicy();
         policy.setOrganization(organization);
-        policy.setLeaveTypeCode(dto.getLeaveTypeCode().toUpperCase());
+        policy.setLeaveTypeCode(leaveTypeCode);
         policy.setLeaveTypeName(dto.getLeaveTypeName());
         policy.setDescription(dto.getDescription());
         policy.setAnnualQuota(dto.getAnnualQuota());

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -123,16 +123,27 @@ public class LeaveRequestController {
 
     @GetMapping("/organizationId/{organizationId}")
 //    @PreAuthorize("hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isCurrentTenant(#organizationId) "
+            + "and @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
-            summary = "List the current tenant's leave requests",
-            description = "Returns every leave request raised within the caller's current tenant."
+            summary = "List an organization's leave requests",
+            description = "Returns every leave request raised within the given organization, which has to "
+                    + "be the caller's own. Identical to the /web twin beside it, which takes the "
+                    + "organization from the session instead."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Requests returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not entitled to the organization named, or lacks the required role in it")
     })
-    public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests() {
+    // organizationId is bound for the guard rather than for the service. The published path
+    // promises the id decides what is returned, and nothing read it: the handler answered the
+    // caller's own tenant whatever was in the segment, so a caller who named another organization
+    // was handed their own requests as though the id had been honoured. Binding it makes the
+    // segment mean what the contract says by refusing anything but the tenant in force, after
+    // which the service's TenantContext read is the same organization. Whether the route should
+    // keep the segment at all is a contract decision; no client calls this route today, both
+    // reach the /web twin. See issue #700.
+    public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests(@PathVariable Long organizationId) {
         return ResponseEntity.ok(requestService.getRequestsByOrganization());
     }
 

--- a/src/test/java/org/tornotron/echno_backend/common/service/AttachmentDocumentMetadataTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/AttachmentDocumentMetadataTest.java
@@ -16,7 +16,6 @@ import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.repository.AttachmentRepository;
 import org.tornotron.echno_backend.issue.IssueRepository;
-import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.task.TaskRepository;
 import org.tornotron.echno_backend.user.UserRepository;
@@ -49,7 +48,6 @@ class AttachmentDocumentMetadataTest {
 
     @Mock private AttachmentRepository attachmentRepository;
     @Mock private FileStorageService fileStorageService;
-    @Mock private OrganizationRepository organizationRepository;
     @Mock private ProjectRepository projectRepository;
     @Mock private TaskRepository taskRepository;
     @Mock private IssueRepository issueRepository;
@@ -63,7 +61,7 @@ class AttachmentDocumentMetadataTest {
     @BeforeEach
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
-        service = new AttachmentService(attachmentRepository, fileStorageService, organizationRepository,
+        service = new AttachmentService(attachmentRepository, fileStorageService,
                 projectRepository, taskRepository, issueRepository, userRepository, attendanceRepository,
                 tenantEntityHelper, attachmentMapper);
         lenient().when(attachmentRepository.save(any(Attachment.class))).thenAnswer(inv -> inv.getArgument(0));

--- a/src/test/java/org/tornotron/echno_backend/common/service/AttachmentOrganizationLinkTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/AttachmentOrganizationLinkTest.java
@@ -1,0 +1,39 @@
+package org.tornotron.echno_backend.common.service;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+
+import java.lang.reflect.Constructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The attachment service used to load an {@link org.tornotron.echno_backend.organization.Organization}
+ * by the entity id in the request path, and then throw the result away: all three write paths
+ * overwrite the field on the next line with the tenant's own organization. The load could not
+ * change the row, and because it ended in {@code orElse(null)} the outcome did not differ by
+ * whether the id existed either.
+ *
+ * <p>It still mattered. {@code Organization} is the tenant root, so it carries neither the
+ * {@code orgFilter} nor the fail-closed load listener, and a caller-supplied id reaching an
+ * unfiltered {@code findById} is the shape of #687. Anyone auditing this family had to work out
+ * that this particular one was inert before moving on. Removing the load removes the question,
+ * and removing the repository with it is what keeps the answer from having to be worked out
+ * again: there is nothing left in this service that can reach an organization by an id a caller
+ * chose.
+ *
+ * <p>Asserted on the constructor rather than on behaviour because there was no behaviour to
+ * assert on. That is the whole reason the line went.
+ */
+class AttachmentOrganizationLinkTest {
+
+    @Test
+    void theServiceCannotReachAnOrganizationByACallerSuppliedId() {
+        Constructor<?>[] constructors = AttachmentService.class.getDeclaredConstructors();
+
+        assertThat(constructors).hasSize(1);
+        assertThat(constructors[0].getParameterTypes())
+                .as("the organization repository was held for one dead switch arm and nothing else")
+                .doesNotContain(OrganizationRepository.class);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/service/AttachmentServiceTenancyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/AttachmentServiceTenancyTest.java
@@ -18,7 +18,6 @@ import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.repository.AttachmentRepository;
 import org.tornotron.echno_backend.issue.IssueRepository;
 import org.tornotron.echno_backend.organization.Organization;
-import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.task.TaskRepository;
 import org.tornotron.echno_backend.user.UserRepository;
@@ -45,7 +44,6 @@ class AttachmentServiceTenancyTest {
 
     @Mock private AttachmentRepository attachmentRepository;
     @Mock private FileStorageService fileStorageService;
-    @Mock private OrganizationRepository organizationRepository;
     @Mock private ProjectRepository projectRepository;
     @Mock private TaskRepository taskRepository;
     @Mock private IssueRepository issueRepository;
@@ -59,7 +57,7 @@ class AttachmentServiceTenancyTest {
 
     @BeforeEach
     void setUp() {
-        service = new AttachmentService(attachmentRepository, fileStorageService, organizationRepository,
+        service = new AttachmentService(attachmentRepository, fileStorageService,
                 projectRepository, taskRepository, issueRepository, userRepository, attendanceRepository,
                 tenantEntityHelper, attachmentMapper);
     }

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyUniqueCodeCheckTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyUniqueCodeCheckTest.java
@@ -1,0 +1,112 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyCreationDto;
+import org.tornotron.echno_backend.leave.mapper.LeavePolicyMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * One leave-type code per organization is the rule the create path is meant to keep. It asked
+ * the wrong question twice, and each way of asking it lets a caller past.
+ *
+ * <p>The policy is written into the organization {@code TenantContext} names, but the duplicate
+ * check was keyed on the {@code organizationId} the caller put in the body. {@code LeavePolicy}
+ * carries the {@code orgFilter}, so any other value makes the predicate unsatisfiable and the
+ * check silently passes. And the code is stored uppercased while the check ran against the
+ * casing as it arrived, so the same code in lower case also passes.
+ *
+ * <p>Neither produces a duplicate row. {@code uk_leave_policy_org_type} is a real constraint and
+ * the insert fails on it. What is lost is the refusal the service was written to give: instead of
+ * a 409 naming the code that clashed, the caller gets the generic data-integrity 409 the handler
+ * emits for any constraint, which says nothing about which field was wrong. That is a smaller
+ * defect than the issue recorded, and it is still a defect: the check exists precisely so the
+ * answer names the problem.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeavePolicyUniqueCodeCheckTest {
+
+    private static final long TENANT = 100L;
+    private static final long SOMEONE_ELSES = 200L;
+    private static final String EMAIL = "hr@example.test";
+
+    @Mock private LeavePolicyRepository policyRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private LeavePolicyMapper leavePolicyMapper;
+
+    private LeavePolicyService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LeavePolicyService(policyRepository, organizationRepository,
+                employeeRepository, userContextService, leavePolicyMapper);
+
+        TenantContext.setCurrentOrgId(TENANT);
+
+        Organization tenant = new Organization();
+        tenant.setId(TENANT);
+        when(userContextService.getCurrentUserEmail()).thenReturn(EMAIL);
+        when(organizationRepository.findByIdAndUserEmail(TENANT, EMAIL))
+                .thenReturn(Optional.of(tenant));
+
+        // The tenant already holds a SICK policy. Every case below tries to add a second.
+        lenient().when(policyRepository.existsByOrganizationIdAndLeaveTypeCode(TENANT, "SICK"))
+                .thenReturn(true);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void aSecondPolicyForTheSameCodeIsRefused() {
+        assertThatThrownBy(() -> service.createPolicy(policy(TENANT, "SICK")))
+                .isInstanceOf(DuplicateResourceException.class);
+    }
+
+    @Test
+    void namingSomeoneElsesOrganizationInTheBodyDoesNotSkipTheCheck() {
+        // The policy is written into the tenant either way, so the id in the body decides
+        // nothing except, before this, whether the rule was applied at all.
+        assertThatThrownBy(() -> service.createPolicy(policy(SOMEONE_ELSES, "SICK")))
+                .isInstanceOf(DuplicateResourceException.class);
+    }
+
+    @Test
+    void sendingTheCodeInLowerCaseDoesNotSkipTheCheckEither() {
+        // The stored value is uppercased on the way in, so a check against the raw input is a
+        // check against a value the table never holds.
+        assertThatThrownBy(() -> service.createPolicy(policy(TENANT, "sick")))
+                .isInstanceOf(DuplicateResourceException.class);
+    }
+
+    private static LeavePolicyCreationDto policy(long organizationId, String leaveTypeCode) {
+        LeavePolicyCreationDto dto = new LeavePolicyCreationDto();
+        dto.setOrganizationId(organizationId);
+        dto.setLeaveTypeCode(leaveTypeCode);
+        dto.setLeaveTypeName("Sick leave");
+        dto.setAnnualQuota(12.0);
+        return dto;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveRequestOrganizationSegmentTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveRequestOrganizationSegmentTest.java
@@ -1,0 +1,99 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The organization-wide leave-request listing publishes an {@code organizationId} in its path and
+ * bound no parameter for it at all. The handler read {@code TenantContext} and answered the
+ * caller's own tenant whatever the segment said, so a caller who put another organization there
+ * was handed their own leave requests as though the id had been honoured. That is worse for the
+ * caller than a refusal, and it is a claim the published contract makes and the handler does not
+ * keep.
+ *
+ * <p>The segment now binds and is checked against the tenant in force, which is the treatment the
+ * manager directory and the leave-policy listing took in the same family. Nothing in
+ * {@code echno-core} or {@code echno-web} calls this route: both reach the {@code /web} twin
+ * beside it, which takes no segment. So the check costs no screen, and whether the route should
+ * keep the segment at all is a contract decision for a deliberate release rather than part of
+ * repairing the guard.
+ */
+@WebMvcTest(LeaveRequestController.class)
+@Import(LeaveRequestOrganizationSegmentTest.TestSecurityConfig.class)
+class LeaveRequestOrganizationSegmentTest {
+
+    private static final long OWN_ORG = 100L;
+    private static final long FOREIGN_ORG = 200L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LeaveRequestService requestService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** An hr-admin of their own organization and of no other. */
+    private void callerIsAnHrAdmin() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(OWN_ORG)).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(FOREIGN_ORG)).thenReturn(false);
+    }
+
+    @Test
+    void theListingStillAnswersForTheCallersOwnOrganization() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(get("/api/v1/leave-requests/organizationId/" + OWN_ORG).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void namingAnotherOrganizationIsRefusedRatherThanIgnored() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(get("/api/v1/leave-requests/organizationId/" + FOREIGN_ORG).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(requestService);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Closes #700.

The remainder of the #687 sweep. None of the three leaks anything, and each was still costing the next pass over this family the same work. Two of them are also wrong in ways a caller can see, and one of those is wrong differently from how the issue recorded it.

## 1. A dead unfiltered organization load

`AttachmentService.linkToEntity` loaded an `Organization` by the entity id in the request path, and all three write paths overwrote the field on the next line with `tenantEntityHelper.resolveCurrentOrganization()`. The load could not change the row, and `.orElse(null)` meant the outcome did not differ by whether the id existed either.

It still mattered, because `Organization` is the tenant root and carries neither the `orgFilter` nor the fail-closed load listener, so a caller-supplied id reaching an unfiltered `findById` is the shape of #687. Establishing that this one was inert is exactly the work the sweep did. The arm goes and `OrganizationRepository` goes with it, so there is nothing left in the service that can reach an organization by an id a caller chose.

Asserted on the constructor rather than on behaviour, because a load whose result is discarded has none. That is the whole reason the line went.

## 2. A uniqueness check that asked about the wrong row, twice

`LeavePolicyService.createPolicy` writes the policy into `TenantContext.getCurrentOrgId()` and checked for a duplicate against `dto.getOrganizationId()`. `LeavePolicy` carries the `orgFilter`, so any other value made the predicate unsatisfiable and the rule was skipped rather than applied.

Checking it turned up a second way past the same guard, not in the issue: the code is stored uppercased (`setLeaveTypeCode(dto.getLeaveTypeCode().toUpperCase())`) and the check ran against the casing as it arrived. So a lower-case code was checked against a value the table never holds, from the caller's own organization, with no foreign id involved at all.

**And a correction to what either one costs.** The issue says a client can create duplicate leave-type codes inside its own organization. It cannot. `uk_leave_policy_org_type` is a real unique constraint on `(organization_id, leave_type_code)`, declared on the entity and in the changelog, so the insert is refused whichever way the check was skipped. What is lost is the answer. Instead of the 409 the service was written to give, which names the code that clashed, `GlobalExceptionHandler` catches the `DataIntegrityViolationException` and answers a 409 reading "Database operation failed, Data Integrity violation", which names nothing. That is a smaller defect than recorded and still worth fixing: the check exists so the answer says which field was wrong.

Both arguments now carry the values the row will actually hold. `dto.organizationId` stays in the payload, because clients send it and removing it is a contract change rather than a repair.

## 3. Path segments that are ignored

Three were listed. **Two are already fixed on `development`**, by 50a7da2 ("Make the directory and leave-policy reads check the id they are given"), which landed the same evening #700 was filed and closed #691. `EmployeeControllerWeb` managers-by-organization and `LeavePolicyController` policies-by-organization both carry `@orgSecurity.isCurrentTenant(#organizationId)` beside the role check. Nothing to do; recorded rather than re-derived.

The third is live and is the worst of the three. `GET /api/v1/leave-requests/organizationId/{organizationId}` published the segment and **the handler bound no parameter for it at all**, so a caller who named another organization was handed their own leave requests as though the id had been honoured. Silently answering the wrong question is worse for a caller than a refusal, and the published contract makes a claim the handler does not keep.

It takes the same pair the other two took: `isCurrentTenant(#organizationId)` and the role check, which makes the segment binding rather than decorative. The service still reads `TenantContext`, which the guard has just established is the same organization.

**Retiring the segment is a separate decision and is not made here.** Measured while deciding: **no client calls any of the three routes.** `echno-core` and `echno-web` reach the `/web` twins, which take no segment. `echno-core` `leave-service.ts` `getOrganizationRequests()` hits `/leave-requests/web/organization` with no argument; `employee-service.ts` `getManagers()` hits `/employee/web/managers` with no argument; every policy call goes to `/leave-policies/web`. There is even a `managersByOrg` query key in `echno-core` that no hook or service uses, which suggests the org-scoped variant was planned and abandoned. So the segments could be retired cheaply, but the `echno-core` contract is hand-maintained with no code generation, so removing a published route breaks a client at runtime rather than at compile time. That belongs in a deliberate core release, not in a commit repairing a guard.

## The negative results

The sweep's confirmed non-defects move into `docs/MULTI_TENANCY_FILTER_GUIDE.md`, as a new section: the order to check a caller-supplied organization id in, the table of sites already cleared and why, the table of repairs and which to copy, and three traps. They are the expensive half of this work and an issue is not where they survive. The guide is the file someone reads before touching this family, which is where they will be looked for.

The middle trap is the one that generalises furthest, and it is the casing bypass above written as a rule rather than as an instance: **a check on the request as received is not a check on the row that will be written.** An organization id is only the most obvious argument that can be wrong. Any normalisation applied on the way in, case here but equally trimming or a canonical form, opens the same gap wherever the guard runs before it, and nothing about tenancy would surface it. That belongs somewhere a later reader will look, not in a test name.

## Tests

| Test | What it holds | Red before |
|---|---|---|
| `AttachmentOrganizationLinkTest.theServiceCannotReachAnOrganizationByACallerSuppliedId` | the repository the dead arm needed is gone, so the question cannot recur | **measured** (run 34056379146, `AssertionError` at line 37) |
| `LeavePolicyUniqueCodeCheckTest.aSecondPolicyForTheSameCodeIsRefused` | the ordinary duplicate is still refused, and refused by the service | passes before and after; it is the case the other two must not break |
| `LeavePolicyUniqueCodeCheckTest.namingSomeoneElsesOrganizationInTheBodyDoesNotSkipTheCheck` | the id in the body cannot switch the rule off | **measured** (same run, line 92) |
| `LeavePolicyUniqueCodeCheckTest.sendingTheCodeInLowerCaseDoesNotSkipTheCheckEither` | the check runs against the value the row will hold | **measured** (same run, line 100) |
| `LeaveRequestOrganizationSegmentTest.theListingStillAnswersForTheCallersOwnOrganization` | the ordinary read is not narrowed by the repair | passes before and after |
| `LeaveRequestOrganizationSegmentTest.namingAnotherOrganizationIsRefusedRatherThanIgnored` | the segment is refused rather than ignored, and the service is never reached | **measured** (same run, line 84) |

Four measured reds on the commit before the fixes, which is why the tests are their own commit.

This workstation has no container runtime and cannot run the Testcontainers-backed suite, so every result above is CI's.

## OpenAPI

One operation changed, `getOrganizationRequests_1`. Hand-applied rather than copied wholesale: the `parameters` block is taken byte for byte from `/api/v1/employee/web/managers/organizationId/{organizationId}`, which springdoc generated from an identical `@PathVariable Long organizationId`, and the summary, description and 403 text follow the annotations in this diff. CI's `openApiSnapshot` step is the check that it matches what the build serves.
