### PR TITLE
Make the normalisation that decides a key locale-independent

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -40,6 +40,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -542,7 +543,7 @@ public class AttendanceService {
                                                                Pageable pageable) {
         String searchPattern = (search == null || search.isBlank())
                 ? null
-                : "%" + search.toLowerCase() + "%";
+                : "%" + search.toLowerCase(Locale.ROOT) + "%";
         return attendanceRepository
                 .findWithFilters(projectId, date, status, searchPattern, pageable)
                 .map(attendance -> attendanceMapper.toResponseDto(attendance)).getContent();

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryNormalizer.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryNormalizer.java
@@ -1,11 +1,17 @@
 package org.tornotron.echno_backend.category;
 
+import java.util.Locale;
+
 public class CategoryNormalizer {
 
     public static String normalize(String input) {
         if (input == null) return null;
 
-        String normalized = input.toLowerCase().trim();
+        // Locale.ROOT, because this value is the uniqueness key and the strip below is
+        // ASCII-only. Under tr-TR the default lowering turns I into a dotless small i,
+        // which [^a-z0-9\s] then deletes rather than folds, so "MIX" would normalise to
+        // "mx" on one host and "mix" on another. See #719.
+        String normalized = input.toLowerCase(Locale.ROOT).trim();
 
         normalized = normalized.replace("&", "and");
 

--- a/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import jakarta.validation.Valid;
 import org.tornotron.echno_backend.common.dto.AttachmentDocumentMetadataDto;
+import org.tornotron.echno_backend.common.dto.AttachmentOwner;
 import org.tornotron.echno_backend.common.dto.PresignedUpload;
 import org.tornotron.echno_backend.common.dto.RegisterUploadRequest;
 import org.tornotron.echno_backend.common.dto.UploadRequest;
@@ -65,7 +66,8 @@ public class AttachmentControllerWeb {
     public ResponseEntity<List<AttachmentDto>> creatAttachment(@RequestParam(value = "attachments",required = true)List<MultipartFile> attachments,
                                                          @PathVariable String entityType,
                                                          @PathVariable Long entityId)  {
-        return ResponseEntity.status(HttpStatus.CREATED).body(attachmentService.uploadAttachments(attachments,entityType,entityId,entityType.split("_",2)[0].toLowerCase())
+        return ResponseEntity.status(HttpStatus.CREATED).body(attachmentService.uploadAttachments(attachments, entityType, entityId,
+                        AttachmentOwner.of(entityType, entityId).folder())
                 .stream()
                 .map(attachment -> {
                     AttachmentDto dto = new AttachmentDto();
@@ -105,7 +107,8 @@ public class AttachmentControllerWeb {
             @PathVariable String entityType,
             @PathVariable Long entityId) {
         return ResponseEntity.ok(attachmentService.presignUploads(
-                uploads, entityType, entityId, entityType.split("_", 2)[0].toLowerCase()));
+                uploads, entityType, entityId,
+                AttachmentOwner.of(entityType, entityId).folder()));
     }
 
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
@@ -127,7 +130,8 @@ public class AttachmentControllerWeb {
             @PathVariable Long entityId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 attachmentService.registerUploads(
-                        uploads, entityType, entityId, entityType.split("_", 2)[0].toLowerCase())
+                        uploads, entityType, entityId,
+                        AttachmentOwner.of(entityType, entityId).folder())
                         .stream()
                         .map(attachment -> {
                             AttachmentDto dto = new AttachmentDto();

--- a/src/main/java/org/tornotron/echno_backend/common/dto/AttachmentOwner.java
+++ b/src/main/java/org/tornotron/echno_backend/common/dto/AttachmentOwner.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.common.dto;
 
+import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -46,10 +47,14 @@ public record AttachmentOwner(String entityType, Long entityId, UUID entityUuid)
      * first underscore, lower-cased. {@code INSPECTION_EVIDENCE} therefore lands under
      * {@code inspection/} with nothing in the storage layer needing to know it exists.
      *
+     * <p>Lower-cased under {@code Locale.ROOT}: this is half of an object-store key, so a
+     * host whose default locale folds differently would write files under a prefix no
+     * other host would look in.
+     *
      * @return The folder name
      */
     public String folder() {
-        return entityType.split("_", 2)[0].toLowerCase();
+        return entityType.split("_", 2)[0].toLowerCase(Locale.ROOT);
     }
 
     /** The key as it reads in a message to the caller. */

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -34,6 +34,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -245,7 +246,7 @@ public class EmployeeService {
     public Page<EmployeeLookupDto> lookupEmployees(String search, int limit) {
         int size = Math.min(Math.max(limit, 1), UnpagedResultCap.MAX_ROWS);
         Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.ASC, "employeeName"));
-        String searchTerm = (search == null || search.isBlank()) ? null : "%" + search.trim().toLowerCase() + "%";
+        String searchTerm = (search == null || search.isBlank()) ? null : "%" + search.trim().toLowerCase(Locale.ROOT) + "%";
         return employeeRepository.searchForLookup(searchTerm, pageable)
                 .map(employee -> new EmployeeLookupDto(
                         employee.getId(),
@@ -272,7 +273,7 @@ public class EmployeeService {
     @Transactional(readOnly = true)
     public Page<EmployeeDto> displayAllEmployees(int pageNo, int pageSize, String search, String status, String department) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "employeeName"));
-        String searchTerm = (search == null || search.isBlank()) ? null : "%" + search.trim().toLowerCase() + "%";
+        String searchTerm = (search == null || search.isBlank()) ? null : "%" + search.trim().toLowerCase(Locale.ROOT) + "%";
         String departmentTerm = (department == null || department.isBlank()) ? null : department;
         EmployeeStatus statusTerm = (status == null || status.isBlank()) ? null : EmployeeStatus.valueOf(status);
         return employeeRepository.search(searchTerm, statusTerm, departmentTerm, pageable)

--- a/src/main/java/org/tornotron/echno_backend/expense/ExpenseService.java
+++ b/src/main/java/org/tornotron/echno_backend/expense/ExpenseService.java
@@ -16,6 +16,8 @@ import org.tornotron.echno_backend.expense.dto.ExpenseUpdateDto;
 import org.tornotron.echno_backend.expense.mapper.ExpenseMapper;
 import org.tornotron.echno_backend.organization.Organization;
 
+import java.util.Locale;
+
 
 /**
  * CRUD + list for expenses. The expense is a flat header scoped to the current tenant;
@@ -139,7 +141,7 @@ public class ExpenseService {
      * bind lands inside a {@code ||}, which CockroachDB mistypes as bytes.
      */
     private static String searchPattern(String value) {
-        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase() + "%";
+        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase(Locale.ROOT) + "%";
     }
 
     private static String blankToNull(String value) {

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -33,6 +33,7 @@ import org.tornotron.echno_backend.task.TaskRepository;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -184,7 +185,7 @@ public class IssueService {
      * so no null bind lands inside a {@code ||}, which CockroachDB mistypes as bytes.
      */
     private static String searchPattern(String value) {
-        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase() + "%";
+        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase(Locale.ROOT) + "%";
     }
 
     // Optional filter parsers: a blank value means "no filter".

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -21,6 +21,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -85,7 +86,12 @@ public class LeavePolicyService {
         //
         // dto.organizationId stays in the payload: clients send it today and removing it is a
         // contract change, not a repair. See issue #700.
-        String leaveTypeCode = dto.getLeaveTypeCode().toUpperCase();
+        // Locale.ROOT, because the casing the row is keyed by has to be a property of the
+        // value rather than of the JVM that received it. The default locale would make it
+        // the latter: under tr-TR a lower-case i uppercases to a dotted capital I, so the
+        // same code entered by the same person is stored under two different keys in two
+        // environments, and the uniqueness constraint is where that would surface. See #719.
+        String leaveTypeCode = dto.getLeaveTypeCode().toUpperCase(Locale.ROOT);
         if (policyRepository.existsByOrganizationIdAndLeaveTypeCode(organizationId, leaveTypeCode)) {
             throw new DuplicateResourceException(
                     "Leave policy with code '" + leaveTypeCode +

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -42,6 +42,7 @@ import org.tornotron.echno_backend.user.UserContextService;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -309,7 +310,7 @@ public class ProjectService {
         if (value == null || value.isBlank()) {
             return null;
         }
-        String escaped = value.trim().toLowerCase()
+        String escaped = value.trim().toLowerCase(Locale.ROOT)
                 .replace("\\", "\\\\")
                 .replace("%", "\\%")
                 .replace("_", "\\_");

--- a/src/main/java/org/tornotron/echno_backend/receipt/ReceiptService.java
+++ b/src/main/java/org/tornotron/echno_backend/receipt/ReceiptService.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.receipt.mapper.ReceiptMapper;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Locale;
 
 /**
  * CRUD + list for receipts. The receipt is a flat header scoped to the current tenant;
@@ -152,7 +153,7 @@ public class ReceiptService {
      * bind lands inside a {@code ||}, which CockroachDB mistypes as bytes.
      */
     private static String searchPattern(String value) {
-        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase() + "%";
+        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase(Locale.ROOT) + "%";
     }
 
     private static String blankToNull(String value) {

--- a/src/main/java/org/tornotron/echno_backend/search/SearchService.java
+++ b/src/main/java/org/tornotron/echno_backend/search/SearchService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Quick search across the records the navigation palette can jump to.
@@ -93,7 +94,7 @@ public class SearchService {
         if (trimmed.length() < MIN_TERM_LENGTH) {
             return null;
         }
-        String escaped = trimmed.toLowerCase()
+        String escaped = trimmed.toLowerCase(Locale.ROOT)
                 .replace("\\", "\\\\")
                 .replace("%", "\\%")
                 .replace("_", "\\_");

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractService.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractService.java
@@ -16,6 +16,7 @@ import org.tornotron.echno_backend.subcontract.dto.SubContractDto;
 import org.tornotron.echno_backend.subcontract.mapper.SubContractMapper;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * CRUD + list for subcontracts. The subcontract is a header plus a list of
@@ -180,7 +181,7 @@ public class SubContractService {
      * so no null bind lands inside a {@code ||}, which CockroachDB mistypes as bytes.
      */
     private static String searchPattern(String value) {
-        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase() + "%";
+        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase(Locale.ROOT) + "%";
     }
 
     private static String blankToNull(String value) {

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -248,7 +248,7 @@ public class TaskService {
         if (value == null || value.isBlank()) {
             return null;
         }
-        String escaped = value.trim().toLowerCase()
+        String escaped = value.trim().toLowerCase(Locale.ROOT)
                 .replace("\\", "\\\\")
                 .replace("%", "\\%")
                 .replace("_", "\\_");

--- a/src/test/java/org/tornotron/echno_backend/common/LocaleIndependentNormalizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/LocaleIndependentNormalizationTest.java
@@ -1,0 +1,70 @@
+package org.tornotron.echno_backend.common;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.category.CategoryNormalizer;
+import org.tornotron.echno_backend.common.dto.AttachmentOwner;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Case folding that decides what a row is keyed by, or which folder a file lands in, must be a
+ * property of the value rather than of the JVM the value happened to pass through.
+ *
+ * <p>Turkish is the case that shows it. Under {@code tr-TR}, {@code "I".toLowerCase()} is the
+ * dotless {@code "ı"} and {@code "i".toUpperCase()} is the dotted {@code "İ"}, so the same input
+ * normalises to two different strings depending on the locale the JVM starts in. A container
+ * inheriting a different locale after a base-image change is enough to switch it.
+ *
+ * <p>Both values below are stored, and both are then matched against: the category's normalised
+ * name is the uniqueness key, and the attachment folder is the object-store key prefix. A value
+ * written under one locale and looked up under another does not agree with itself.
+ *
+ * <p>The category case is the sharper of the two, because the lowering is followed by a
+ * {@code [^a-z0-9\s]} strip. The dotless {@code ı} is not in that set, so it is not merely folded
+ * differently, it is deleted: "Iron" normalises to "ron".
+ */
+class LocaleIndependentNormalizationTest {
+
+    private static final Locale TURKISH = Locale.forLanguageTag("tr-TR");
+
+    private Locale original;
+
+    @BeforeEach
+    void useTurkishDefault() {
+        original = Locale.getDefault();
+        Locale.setDefault(TURKISH);
+    }
+
+    @AfterEach
+    void restoreDefault() {
+        Locale.setDefault(original);
+    }
+
+    @Test
+    void aCategoryNameNormalisesTheSameWhateverTheJvmLocale() {
+        assertThat(CategoryNormalizer.normalize("Iron Fittings")).isEqualTo("iron fittings");
+    }
+
+    @Test
+    void aCategoryNameKeepsItsLettersWhateverTheJvmLocale() {
+        // The dotless i the Turkish lowering produces is outside [a-z0-9\s] and is stripped,
+        // so the failure here is a lost character rather than a differently cased one.
+        assertThat(CategoryNormalizer.normalize("MIX")).isEqualTo("mix");
+    }
+
+    @Test
+    void anAttachmentFolderIsTheSameWhateverTheJvmLocale() {
+        assertThat(AttachmentOwner.of("INSPECTION_EVIDENCE", 1L).folder())
+                .isEqualTo("inspection");
+    }
+
+    @Test
+    void anAttachmentFolderForAnIssueIsTheSameWhateverTheJvmLocale() {
+        assertThat(AttachmentOwner.of("ISSUE_ATTACHMENTS", 1L).folder())
+                .isEqualTo("issue");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyUniqueCodeCheckTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyUniqueCodeCheckTest.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
 
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -99,6 +100,22 @@ class LeavePolicyUniqueCodeCheckTest {
         // check against a value the table never holds.
         assertThatThrownBy(() -> service.createPolicy(policy(TENANT, "sick")))
                 .isInstanceOf(DuplicateResourceException.class);
+    }
+
+    @Test
+    void theCasingTheCodeIsStoredInDoesNotDependOnTheJvmLocale() {
+        // Uppercasing without a Locale uses the JVM default. Under tr-TR "sick" uppercases to
+        // "SİCK" with a dotted capital I, which is not the "SICK" the tenant already holds, so
+        // the check passes and the row is written under a key no other environment would
+        // produce for the same input. See issue #719.
+        Locale original = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+        try {
+            assertThatThrownBy(() -> service.createPolicy(policy(TENANT, "sick")))
+                    .isInstanceOf(DuplicateResourceException.class);
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 
     private static LeavePolicyCreationDto policy(long organizationId, String leaveTypeCode) {


### PR DESCRIPTION
Closes #719.

## What was wrong

`LeavePolicyService` uppercases the leave-type code with no `Locale`, so the casing the row is stored under is a property of the JVM the request reached rather than of the value. The sweep the issue asked for found the same shape in two more places that reach storage, and ten more that reach a comparison.

## The sweep, and what it is worth fixing

Twenty unqualified `toUpperCase()` / `toLowerCase()` calls in `src/main/java`. Sorted by whether the result is ever stored or matched against:

**Keys: stored, and then compared against the stored value (3)**

| Call | Why it matters |
|---|---|
| `LeavePolicyService:88` | The leave-type code. Written to the row and checked for uniqueness. The issue's own case. |
| `CategoryNormalizer:8` | `normalizedName`, persisted and used as the uniqueness key via `existsByNormalizedNameAndOrganization_Id`. Sharper than the leave-policy case: the lowering is followed by a `[^a-z0-9\s]` strip, and the dotless small i Turkish produces is outside that set, so it is deleted rather than folded. "MIX" normalises to "mx" and "Iron Fittings" to "ron fttngs". |
| `AttachmentOwner.folder():52` | The object-store folder a file is written under. Files written under one locale would be looked for under a prefix a different locale never produces. |

**Comparisons: a search term lowered in Java and matched against SQL `LOWER()` (10)**

`ExpenseService:142`, `SubContractService:183`, `TaskService:251`, `SearchService:96`, `IssueService:187`, `ReceiptService:155`, `EmployeeService:248`, `EmployeeService:275`, `AttendanceService:545`, `ProjectService:312`.

Nothing is stored, so no data is at risk, but the two sides of the comparison must fold the same way and only one of them is the JVM's. The database's `LOWER()` does not consult the JVM locale, so under `tr-TR` a search for "I" is sent as the dotless "ı" and matches nothing the database lowered to "i". `AssetService:505` already passes `Locale.ROOT` for exactly this, so this brings the rest in line with the convention already in the tree.

**Display and messages: left alone (4)**

`NotificationService:77` (a notification title), `AttachmentService:392`, `AttendanceRegularizationService:216` and `LeaveRequestService:467` (all three inside exception messages). These are read by a person and never compared or keyed on. `NotificationService:77` is the borderline one, since the title is persisted, but it is persisted as prose rather than as an identity, so nothing looks it up or matches against it and a differently cased first letter changes nothing but how the sentence reads.

Three inlined copies of the attachment folder rule in `AttachmentControllerWeb` now call `AttachmentOwner.folder()` instead, which is the same expression with the same documentation. Qualifying four copies of one rule separately and hoping they stay in step is how they would drift apart again.

## Tests

`LocaleIndependentNormalizationTest` sets the default locale to `tr-TR` and asserts on the two pure functions; `LeavePolicyUniqueCodeCheckTest` gains a case for the service. Pushed as their own commit ahead of the fix, so the red is measured rather than argued: the run on `289671f` failed those five, the run on the fix commit passes.

The ten search-pattern calls are private helpers with no seam to test through, and the failure mode is a query that returns nothing rather than a wrong value, so they are fixed on the reasoning above and not covered by a test of their own.
