### PR TITLE
Make the leave-balance recalculate endpoint recalculate

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -63185,7 +63185,7 @@
     },
     "/api/v1/leave-balances/employee/{employeeId}/recalculate": {
       "post": {
-        "description": "Recomputes every policy balance held by the employee for the given year and returns the refreshed list, defaulting to the current year when none is given.",
+        "description": "Rebuilds every policy balance held by the employee for the given year and returns the result, defaulting to the current year when none is given. Unlike a read, which recomputes only when a month has turned since the balance was last touched, this recomputes unconditionally: used and pending days are rebuilt from the leave requests, manual adjustments are folded back in from the ledger, and any monthly accrual the balance is missing is posted. A monthly accrual already recorded is taken as it stands, and the opening balance carried forward from the previous year is not recomputed.",
         "operationId": "recalculateBalances_1",
         "parameters": [
           {
@@ -63785,7 +63785,7 @@
     },
     "/api/v1/leave-balances/web/recalculate": {
       "post": {
-        "description": "Recomputes every policy balance held by the employee for the given year and returns the refreshed list, defaulting to the current year when none is given.",
+        "description": "Rebuilds every policy balance held by the employee for the given year and returns the result, defaulting to the current year when none is given. Unlike a read, which recomputes only when a month has turned since the balance was last touched, this recomputes unconditionally: used and pending days are rebuilt from the leave requests, manual adjustments are folded back in from the ledger, and any monthly accrual the balance is missing is posted. A monthly accrual already recorded is taken as it stands, and the opening balance carried forward from the previous year is not recomputed.",
         "operationId": "recalculateBalances",
         "parameters": [
           {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceController.java
@@ -98,8 +98,14 @@ public class LeaveBalanceController {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Recalculate an employee's leave balances",
-            description = "Recomputes every policy balance held by the employee for the given year and "
-                    + "returns the refreshed list, defaulting to the current year when none is given."
+            description = "Rebuilds every policy balance held by the employee for the given year and "
+                    + "returns the result, defaulting to the current year when none is given. Unlike a "
+                    + "read, which recomputes only when a month has turned since the balance was last "
+                    + "touched, this recomputes unconditionally: used and pending days are rebuilt from the "
+                    + "leave requests, manual adjustments are folded back in from the ledger, and any "
+                    + "monthly accrual the balance is missing is posted. A monthly accrual already recorded "
+                    + "is taken as it stands, and the opening balance carried forward from the previous "
+                    + "year is not recomputed."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balances recalculated"),
@@ -110,7 +116,7 @@ public class LeaveBalanceController {
             @PathVariable Long employeeId,
             @RequestParam(required = false) Integer year) {
         int targetYear = year != null ? year : LocalDate.now().getYear();
-        return ResponseEntity.ok(balanceService.getAllBalancesForEmployee(employeeId, targetYear));
+        return ResponseEntity.ok(balanceService.recalculateBalances(employeeId, targetYear));
     }
 
     @PostMapping("/adjust")

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
@@ -97,8 +97,14 @@ public class LeaveBalanceControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Recalculate an employee's leave balances",
-            description = "Recomputes every policy balance held by the employee for the given year and "
-                    + "returns the refreshed list, defaulting to the current year when none is given."
+            description = "Rebuilds every policy balance held by the employee for the given year and "
+                    + "returns the result, defaulting to the current year when none is given. Unlike a "
+                    + "read, which recomputes only when a month has turned since the balance was last "
+                    + "touched, this recomputes unconditionally: used and pending days are rebuilt from the "
+                    + "leave requests, manual adjustments are folded back in from the ledger, and any "
+                    + "monthly accrual the balance is missing is posted. A monthly accrual already recorded "
+                    + "is taken as it stands, and the opening balance carried forward from the previous "
+                    + "year is not recomputed."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balances recalculated"),
@@ -109,7 +115,7 @@ public class LeaveBalanceControllerWeb {
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {
         int targetYear = year != null ? year : LocalDate.now().getYear();
-        return ResponseEntity.ok(balanceService.getAllBalancesForEmployee(employeeId, targetYear));
+        return ResponseEntity.ok(balanceService.recalculateBalances(employeeId, targetYear));
     }
 
     @PostMapping("/adjust")

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceService.java
@@ -207,6 +207,48 @@ public class LeaveBalanceService {
     }
 
     /**
+     * Forces a rebuild of every balance the employee holds under an applicable policy for a year.
+     *
+     * <p>The difference from {@link #getAllBalancesForEmployee} is the guard, not the work. That
+     * method recomputes a balance only when a month has turned since the row was last touched,
+     * which keeps a read cheap; this one recomputes unconditionally, because a caller reaching for
+     * a recalculation believes the stored figures are wrong and that is the case the guard skips.
+     *
+     * <p>What the rebuild reaches: {@code used} and {@code pending} are recomputed from the leave
+     * requests themselves, the manual adjustments are folded back in from the ledger, and any
+     * monthly accrual the balance is missing is posted. What it does not reach: an ACCRUAL
+     * transaction already written for a month is taken as it stands, so a policy quota edited
+     * mid-year or attendance backfilled afterwards leaves the months already accrued alone, and
+     * the opening balance carried forward from the previous year is not recomputed either.
+     *
+     * <p>Years before the employee joined return transient zero balances and persist nothing, the
+     * same way the read path treats them. Forcing a rebuild must not be the one route that creates
+     * rows for years the employee was not employed in.
+     *
+     * @param employeeId The employee's ID.
+     * @param year The calendar year of the balances.
+     * @return One rebuilt balance per applicable policy.
+     * @throws ResourceNotFoundException if the employee is not found in this organization.
+     */
+    @Transactional
+    public List<LeaveBalanceDto> recalculateBalances(Long employeeId, Integer year) {
+        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Employee with ID " + employeeId + " was not found in this organization"));
+
+        List<LeavePolicy> policies = policyRepository.findApplicablePolicies(
+                employee.getOrganization().getId(),
+                employee.getGender(),
+                calculateServiceMonths(employee));
+
+        return policies.stream()
+                .map(policy -> isBeforeJoiningYear(employee, year)
+                        ? leaveBalanceMapper.toDto(zeroBalance(employee, policy, year))
+                        : recalculateBalance(employeeId, policy.getId(), year))
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Applies a manual balance adjustment for the current year and records it in the ledger.
      *
      * <p>Locks the balance row so concurrent adjustments serialize. A positive day count increases

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveBalanceRecalculationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveBalanceRecalculationTest.java
@@ -1,0 +1,163 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeaveBalanceDto;
+import org.tornotron.echno_backend.leave.mapper.LeaveBalanceMapper;
+import org.tornotron.echno_backend.leave.mapper.LeaveTransactionMapper;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What the recalculate endpoint has to do that the balance read does not.
+ *
+ * <p>Reading a balance recomputes it only when {@code needsRecalculation} says a month has turned
+ * since the row was last touched. That is the right rule for a read: it keeps the figures current
+ * without rebuilding them on every page load. It is the wrong rule for a caller who has come to
+ * this endpoint precisely because they believe the stored figures are wrong, because the case they
+ * are reaching for is the one the guard answers "no" to.
+ *
+ * <p>The row below is deliberately fresh: calculated this month, in the current year, so the read
+ * path leaves it alone. Both twins of the recalculate route must still rebuild it.
+ *
+ * <p>The second pair of cases is the constraint that comes with forcing. The read path refuses to
+ * persist a row for a year the employee had not joined in, returning a transient zero balance
+ * instead, and a forced rebuild must not lose that: recalculating 2019 for somebody who joined in
+ * 2024 would otherwise create rows for years that never existed.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeaveBalanceRecalculationTest {
+
+    private static final long ORG = 42L;
+    private static final long EMPLOYEE = 7L;
+    private static final long POLICY = 3L;
+
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private LeavePolicyRepository policyRepository;
+    @Mock private LeaveTransactionRepository transactionRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private LeaveTransactionMapper leaveTransactionMapper;
+    @Mock private LeaveBalanceMapper leaveBalanceMapper;
+    @Mock private LeaveAccrualService leaveAccrualService;
+
+    private LeaveBalanceService service;
+    private LeaveBalanceController controller;
+    private LeaveBalanceControllerWeb webController;
+
+    private LeaveBalance freshBalance;
+
+    @BeforeEach
+    void setUp() {
+        service = new LeaveBalanceService(balanceRepository, policyRepository, transactionRepository,
+                employeeRepository, leaveTransactionMapper, leaveBalanceMapper, leaveAccrualService);
+        controller = new LeaveBalanceController(service);
+        webController = new LeaveBalanceControllerWeb(service);
+
+        TenantContext.setCurrentOrgId(ORG);
+
+        Organization organization = new Organization();
+        organization.setId(ORG);
+
+        Employee employee = new Employee();
+        employee.setId(EMPLOYEE);
+        employee.setOrganization(organization);
+        employee.setGender("Male");
+        employee.setJoiningDate(LocalDateTime.of(2024, 1, 15, 9, 0));
+
+        LeavePolicy policy = new LeavePolicy();
+        policy.setId(POLICY);
+        policy.setOrganization(organization);
+        policy.setAnnualQuota(12.0);
+
+        LocalDate today = LocalDate.now();
+        freshBalance = new LeaveBalance();
+        freshBalance.setEmployee(employee);
+        freshBalance.setOrganization(organization);
+        freshBalance.setLeavePolicy(policy);
+        freshBalance.setYear(today.getYear());
+        freshBalance.setOpeningBalance(0.0);
+        freshBalance.setAccrued(5.0);
+        freshBalance.setUsed(0.0);
+        freshBalance.setPending(0.0);
+        freshBalance.setCarryForwardFromPrevious(0.0);
+        // Already recomputed this month, which is exactly what makes the read path skip it.
+        freshBalance.setLastCalculatedAt(LocalDateTime.now());
+        freshBalance.setLastCalculationMonth(today.getMonthValue());
+
+        when(employeeRepository.findByIdAndOrganizationId(EMPLOYEE, ORG))
+                .thenReturn(Optional.of(employee));
+        when(policyRepository.findByIdAndOrganization_Id(POLICY, ORG))
+                .thenReturn(Optional.of(policy));
+        when(policyRepository.findApplicablePolicies(eq(ORG), anyString(), anyInt()))
+                .thenReturn(List.of(policy));
+        when(balanceRepository.findByEmployeeIdAndLeavePolicyIdAndYear(EMPLOYEE, POLICY, today.getYear()))
+                .thenReturn(Optional.of(freshBalance));
+        when(leaveBalanceMapper.toDto(any(LeaveBalance.class))).thenReturn(new LeaveBalanceDto());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void theReadPathLeavesAFreshBalanceAlone() {
+        // Not the defect, the baseline. The read is allowed to skip; the endpoint below is not.
+        controller.getEmployeeBalances(EMPLOYEE, null);
+
+        verify(leaveAccrualService, never()).recalculate(any());
+    }
+
+    @Test
+    void recalculateRebuildsABalanceTheReadPathWouldHaveSkipped() {
+        controller.recalculateBalances(EMPLOYEE, null);
+
+        verify(leaveAccrualService).recalculate(freshBalance);
+    }
+
+    @Test
+    void theWebTwinRebuildsItToo() {
+        webController.recalculateBalances(EMPLOYEE, null);
+
+        verify(leaveAccrualService).recalculate(freshBalance);
+    }
+
+    @Test
+    void recalculatingAYearBeforeTheEmployeeJoinedPersistsNothing() {
+        // The employee joined in 2024. 2019 has no row and must not gain one.
+        controller.recalculateBalances(EMPLOYEE, 2019);
+
+        verify(balanceRepository, never()).save(any());
+        verify(leaveAccrualService, never()).recalculate(any());
+    }
+
+    @Test
+    void aYearBeforeTheEmployeeJoinedStillAnswersWithABalancePerPolicy() {
+        List<LeaveBalanceDto> balances = controller.recalculateBalances(EMPLOYEE, 2019).getBody();
+
+        assertThat(balances).hasSize(1);
+    }
+}


### PR DESCRIPTION
Closes #708.

Build it rather than delete it. The reasoning is below, because "delete the route" was the other honest answer and the issue is right that nothing calls it today.

## Can a stored balance drift from its inputs

Yes, and by construction rather than by accident. `used` and `pending` are maintained two independent ways at once.

They are **derived** in `LeaveAccrualService.recalculate`, which rebuilds them from `sumApprovedDaysByEmployeePolicyYear` and `sumPendingDaysByEmployeePolicyYear`, and they are **incremented in place** by four helpers on the write paths: `LeaveRequestService.updatePendingBalance` and `restoreUsedBalance`, `LeaveApprovalService.transferPendingToUsed` and `restorePendingBalance`. Three things make the incremental half disagree with the derived half:

1. **All four are `.ifPresent(...)`.** A balance row is created lazily, on first read. Until somebody looks at an employee's balances, the row does not exist and every increment against it is a silent no-op, while the request rows the derived sum reads are written regardless.
2. **All four clamp with `Math.max(0, ...)`.** A decrement that lands on a row whose figure was never incremented is swallowed rather than going negative, so the row cannot even carry evidence that it is out of step.
3. **`needsRecalculation` stops reconciling a past year entirely.** It returns false as soon as `now.getYear() != year`, so once a year turns, the read path never rebuilds that year's balances again. A leave request for last December approved this January moves the incremental figures and nothing recomputes them, for the rest of the row's life.

So drift is not hypothetical: (3) in particular guarantees a class of it that no other code path repairs, and (1) and (2) mean the incremental figures are only as good as the order the row happened to be created in.

## What a forced recalculate does and does not repair

Worth being exact, because the endpoint's current description over-promises and this change should not repeat that.

It **does** rebuild `used` and `pending` from the request rows, fold the ADJUSTMENT ledger back in, and post any monthly ACCRUAL transaction the balance is missing.

It does **not** rewrite an ACCRUAL transaction already posted for a month, so a policy quota edited mid-year, or attendance backfilled after the fact, leaves the months already accrued as they were. It also does not recompute `openingBalance` or `carryForwardFromPrevious`, which are written once when the row is created. Both descriptions now say so.

## The change

`LeaveBalanceService.recalculateBalances(employeeId, year)` iterates the policies applicable to the employee and calls the existing per-policy `recalculateBalance` for each, which is the shape `getAllBalancesForEmployee` already uses over `getOrCalculateBalance`. Both twins point at it.

One constraint comes with forcing. `recalculateBalance` has no pre-joining-year guard, because the only caller until now passed a policy id and a year the caller had chosen together. Iterating every policy for an arbitrary year would have made a bulk recalculate of 2019 create rows for an employee who joined in 2024, which is exactly what the read path refuses to do. The bulk method carries the same `isBeforeJoiningYear` check the read path uses and answers with the transient zero balance.

The role gate is unchanged: #689 left this route with the administrators on the grounds that it is written as a command, and that reading is now true rather than aspirational.

## Contract

No route added or removed, so nothing to check in `echno-core` or `echno-web`. For the record, the callers are where the issue said: `useRecalculateBalances` is declared in `echno-core` (`src/hooks/leave/use-leave-mutations.ts:319`) and in `echno-web`'s own copy (`hooks/leave/use-leave-mutations.ts:258`), and `recalculateBalances` in both leave services, but no component, button or handler in `echno-web` invokes the hook. That is what made deleting the route thinkable; it is also why deleting it would have been the wrong trade, since the working implementation is a dozen lines and the drift above is real.

`docs/openapi.json` changes only in the two `description` strings.

## Tests

`LeaveBalanceRecalculationTest` builds a balance already recomputed this month, so the read path's `needsRecalculation` guard skips it, and asserts both twins rebuild it anyway. Pushed as its own commit ahead of the fix: the two forcing cases failed on that commit and pass on the fix.

Three further cases pass on both commits and are regression guards rather than measurements: one pins the read path's own skip as the baseline the endpoint has to differ from, and two pin the pre-joining-year rule that the naive version of this fix would have broken.
