### PR TITLE
Let the project attendance listing be narrowed by approval

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -25454,7 +25454,7 @@
     },
     "/api/v1/attendance/project/{projectId}": {
       "get": {
-        "description": "Returns a page of attendance records for a project on a given date, optionally filtered by status or a search term against the employee name, sorted by employee name.",
+        "description": "Returns a page of attendance records for a project on a given date, optionally filtered by status, by approval status, by whether the day is held for a geofence decision, or by a search term against the employee name, sorted by employee name. The two approval filters answer different questions: every record is created pending and stays there until somebody decides, so approvalStatus=PENDING is close to the whole day's roll, while requiresApproval=true is the small set of days actually waiting on a decision because a punch fell outside the site.",
         "operationId": "getByProject_1",
         "parameters": [
           {
@@ -25493,6 +25493,27 @@
                 "PENDING_REGULARIZATION"
               ],
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approvalStatus",
+            "required": false,
+            "schema": {
+              "enum": [
+                "PENDING",
+                "APPROVED",
+                "REJECTED"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "requiresApproval",
+            "required": false,
+            "schema": {
+              "type": "boolean"
             }
           },
           {
@@ -26488,7 +26509,7 @@
     },
     "/api/v1/attendance/web/project/{projectId}": {
       "get": {
-        "description": "Returns a page of attendance records for a project on a given date, optionally filtered by status or a search term against the employee name, sorted by employee name.",
+        "description": "Returns a page of attendance records for a project on a given date, optionally filtered by status, by approval status, by whether the day is held for a geofence decision, or by a search term against the employee name, sorted by employee name. The two approval filters answer different questions: every record is created pending and stays there until somebody decides, so approvalStatus=PENDING is close to the whole day's roll, while requiresApproval=true is the small set of days actually waiting on a decision because a punch fell outside the site.",
         "operationId": "getByProject",
         "parameters": [
           {
@@ -26527,6 +26548,27 @@
                 "PENDING_REGULARIZATION"
               ],
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approvalStatus",
+            "required": false,
+            "schema": {
+              "enum": [
+                "PENDING",
+                "APPROVED",
+                "REJECTED"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "requiresApproval",
+            "required": false,
+            "schema": {
+              "type": "boolean"
             }
           },
           {

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -20,6 +20,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.attendance.dto.*;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
 import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.response.ApiResponse;
@@ -140,8 +141,12 @@ public class AttendanceController {
     @Operation(
             summary = "List a project's attendance for a date",
             description = "Returns a page of attendance records for a project on a given date, optionally "
-                    + "filtered by status or a search term against the employee name, sorted by employee "
-                    + "name."
+                    + "filtered by status, by approval status, by whether the day is held for a geofence "
+                    + "decision, or by a search term against the employee name, sorted by employee name. "
+                    + "The two approval filters answer different questions: every record is created "
+                    + "pending and stays there until somebody decides, so approvalStatus=PENDING is close "
+                    + "to the whole day's roll, while requiresApproval=true is the small set of days "
+                    + "actually waiting on a decision because a punch fell outside the site."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance records returned"),
@@ -152,11 +157,13 @@ public class AttendanceController {
             @PathVariable Long projectId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @RequestParam(required = false) AttendanceStatus status,
+            @RequestParam(required = false) ApprovalStatus approvalStatus,
+            @RequestParam(required = false) Boolean requiresApproval,
             @RequestParam(required = false) String search,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         return ResponseEntity.ok(attendanceService.getAttendanceByProject(
-                projectId, date, status, search,
+                projectId, date, status, approvalStatus, requiresApproval, search,
                 PageRequest.of(page, size, Sort.by("employeeName"))));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -20,6 +20,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.attendance.dto.*;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
 import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.response.ApiResponse;
@@ -138,8 +139,12 @@ public class AttendanceControllerWeb {
     @Operation(
             summary = "List a project's attendance for a date",
             description = "Returns a page of attendance records for a project on a given date, optionally "
-                    + "filtered by status or a search term against the employee name, sorted by employee "
-                    + "name."
+                    + "filtered by status, by approval status, by whether the day is held for a geofence "
+                    + "decision, or by a search term against the employee name, sorted by employee name. "
+                    + "The two approval filters answer different questions: every record is created "
+                    + "pending and stays there until somebody decides, so approvalStatus=PENDING is close "
+                    + "to the whole day's roll, while requiresApproval=true is the small set of days "
+                    + "actually waiting on a decision because a punch fell outside the site."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance records returned"),
@@ -150,11 +155,13 @@ public class AttendanceControllerWeb {
             @PathVariable Long projectId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @RequestParam(required = false) AttendanceStatus status,
+            @RequestParam(required = false) ApprovalStatus approvalStatus,
+            @RequestParam(required = false) Boolean requiresApproval,
             @RequestParam(required = false) String search,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         return ResponseEntity.ok(attendanceService.getAttendanceByProject(
-                projectId, date, status, search,
+                projectId, date, status, approvalStatus, requiresApproval, search,
                 PageRequest.of(page, size, Sort.by("employeeName"))));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRepository.java
@@ -39,17 +39,31 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long>,
 
     Page<Attendance> findByApprovalStatus(ApprovalStatus status, Pageable pageable);
 
+    /**
+     * The project's day, narrowed by any combination of the optional filters.
+     *
+     * <p>{@code approvalStatus} and {@code requiresGeofenceApproval} are two different questions
+     * and both are here because neither answers the other. Every record is created PENDING and
+     * nothing moves it until somebody decides, so the approval status on its own separates the
+     * decided days from the undecided ones and says nothing about which of the undecided ones
+     * anybody has to look at. The flag is what marks a day held for a punch outside the geofence,
+     * which is the small set. Asked together they are the site's outstanding work for that day.
+     */
     @Query("""
         SELECT a FROM Attendance a
         WHERE a.projectId = :projectId
           AND a.attendanceDate = :date
           AND (:status IS NULL OR a.status = :status)
+          AND (:approvalStatus IS NULL OR a.approvalStatus = :approvalStatus)
+          AND (:requiresApproval IS NULL OR a.requiresGeofenceApproval = :requiresApproval)
           AND (:search IS NULL OR LOWER(a.employeeName) LIKE :search)
         """)
     Page<Attendance> findWithFilters(
             @Param("projectId") Long projectId,
             @Param("date") LocalDate date,
             @Param("status") AttendanceStatus status,
+            @Param("approvalStatus") ApprovalStatus approvalStatus,
+            @Param("requiresApproval") Boolean requiresApproval,
             @Param("search") String search,
             Pageable pageable);
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -523,14 +523,24 @@ public class AttendanceService {
     }
 
     /**
-     * Lists a project's attendance for a day, filtered by status and a name search.
+     * Lists a project's attendance for a day, filtered by status, approval and a name search.
      *
      * <p>A blank search matches all employees; otherwise it matches employee names
      * case-insensitively. Results are drawn from a single page and returned as a list.
      *
+     * <p>The two approval filters narrow different things. {@code approvalStatus} separates the
+     * days somebody has decided from the days nobody has; since a record is created PENDING and
+     * stays there until a decision is made, filtering on PENDING alone is close to the whole day's
+     * roll. {@code requiresApproval} is the flag set when a punch fell outside the project's
+     * geofence, and that is the narrow set: the days actually waiting on somebody. Passing both is
+     * what a screen asking "what is still outstanding on this site today" wants.
+     *
      * @param projectId The project's ID.
      * @param date The attendance date.
      * @param status The status to filter by, or {@code null} for any.
+     * @param approvalStatus The approval status to filter by, or {@code null} for any.
+     * @param requiresApproval Whether to return only the days held for a geofence decision
+     *     ({@code true}), only those not held ({@code false}), or both ({@code null}).
      * @param search An employee-name fragment, or {@code null}/blank for all.
      * @param pageable The pagination and sort parameters.
      * @return The matching attendance records for the page.
@@ -539,13 +549,16 @@ public class AttendanceService {
     public List<AttendanceResponseDto> getAttendanceByProject(Long projectId,
                                                                LocalDate date,
                                                                AttendanceStatus status,
+                                                               ApprovalStatus approvalStatus,
+                                                               Boolean requiresApproval,
                                                                String search,
                                                                Pageable pageable) {
         String searchPattern = (search == null || search.isBlank())
                 ? null
                 : "%" + search.toLowerCase(Locale.ROOT) + "%";
         return attendanceRepository
-                .findWithFilters(projectId, date, status, searchPattern, pageable)
+                .findWithFilters(projectId, date, status, approvalStatus, requiresApproval,
+                        searchPattern, pageable)
                 .map(attendance -> attendanceMapper.toResponseDto(attendance)).getContent();
     }
 

--- a/src/test/java/org/tornotron/echno_backend/attendance/AttendanceProjectApprovalFilterIT.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/AttendanceProjectApprovalFilterIT.java
@@ -1,0 +1,221 @@
+package org.tornotron.echno_backend.attendance;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The approval filters on the project attendance listing, against a real CockroachDB.
+ *
+ * <p>Issue #712. The listing is server-paged, so the narrowing has to happen in the query or the
+ * page count lies: a client-side filter over the current page shows three rows under a footer
+ * reading "1-20 of 137".
+ *
+ * <p>Two filters rather than one, because "pending" means two different things here and only one
+ * of them is small. {@code checkIn} creates every record at {@code approvalStatus = PENDING} and
+ * nothing moves it until somebody decides, so the pending set on a normal day is the site's whole
+ * roll. The set a person means by "what still needs looking at" is the days held for a punch
+ * outside the geofence, which is the {@code requiresGeofenceApproval} flag.
+ *
+ * <p>The seed makes that difference measurable rather than assertable by luck. Eight of the nine
+ * rows on the day are pending, and only two of those are held, so a filter that had quietly
+ * stopped narrowing returns eight where the test wants two.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AttendanceProjectApprovalFilterIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private AttendanceRepository attendanceRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private static final LocalDate THE_DAY = LocalDate.of(2026, 9, 3);
+    private static final LocalDate ANOTHER_DAY = THE_DAY.plusDays(1);
+    private static final long SITE = 8100L;
+    private static final long ANOTHER_SITE = 8200L;
+
+    private Long orgId;
+    private long nextEmployeeId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        disableOrgFilter();
+        nextEmployeeId = 9000L;
+
+        Organization org = persistOrganization("Filter Org");
+        entityManager.flush();
+        orgId = org.getId();
+
+        // Six ordinary days: present, pending because nobody has decided anything, not held.
+        // These are the rows that make a bare pending filter useless on its own.
+        for (int i = 0; i < 6; i++) {
+            persist(org, SITE, THE_DAY, AttendanceStatus.PRESENT, ApprovalStatus.PENDING, false);
+        }
+        // Two held days: a punch fell outside the site and somebody has to decide.
+        persist(org, SITE, THE_DAY, AttendanceStatus.PRESENT, ApprovalStatus.PENDING, true);
+        persist(org, SITE, THE_DAY, AttendanceStatus.LATE, ApprovalStatus.PENDING, true);
+        // One already decided, so it is out of every pending answer.
+        persist(org, SITE, THE_DAY, AttendanceStatus.PRESENT, ApprovalStatus.APPROVED, true);
+
+        // Neighbours that must never appear: the same shape on the next day, and on another site.
+        persist(org, SITE, ANOTHER_DAY, AttendanceStatus.PRESENT, ApprovalStatus.PENDING, true);
+        persist(org, ANOTHER_SITE, THE_DAY, AttendanceStatus.PRESENT, ApprovalStatus.PENDING, true);
+
+        entityManager.flush();
+        entityManager.clear();
+        enableOrgFilter(orgId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        disableOrgFilter();
+        TenantContext.clear();
+    }
+
+    @Test
+    void thePlainListingIsTheWholeDayOnTheSite() {
+        assertThat(page(null, null))
+                .as("nine rows on this site on this day; the next day and the other site are not in it")
+                .hasSize(9);
+    }
+
+    @Test
+    void filteringOnAnApprovalStatusNarrowsToThatDecision() {
+        assertThat(page(ApprovalStatus.APPROVED, null))
+                .as("one day has been decided")
+                .hasSize(1)
+                .allSatisfy(row ->
+                        assertThat(row.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED));
+    }
+
+    @Test
+    void filteringOnPendingIsAlmostTheWholeDay() {
+        // Not a defect, and the reason the flag below exists. A record is born pending, so this
+        // filter separates the decided from the undecided and nothing else. It is worth having
+        // for APPROVED and REJECTED; it is not the "what needs looking at" question.
+        assertThat(page(ApprovalStatus.PENDING, null))
+                .as("eight of the nine rows, which is what a pending filter honestly returns")
+                .hasSize(8);
+    }
+
+    @Test
+    void filteringOnTheHeldFlagIsTheSmallSet() {
+        assertThat(page(null, true))
+                .as("three days were held, one of which has since been decided")
+                .hasSize(3)
+                .allSatisfy(row -> assertThat(row.getRequiresGeofenceApproval()).isTrue());
+    }
+
+    @Test
+    void theTwoFiltersTogetherAreTheSitesOutstandingWork() {
+        assertThat(page(ApprovalStatus.PENDING, true))
+                .as("held and still undecided: the two days somebody has to look at")
+                .hasSize(2)
+                .allSatisfy(row -> {
+                    assertThat(row.getRequiresGeofenceApproval()).isTrue();
+                    assertThat(row.getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING);
+                });
+    }
+
+    @Test
+    void askingForTheDaysNotHeldExcludesTheHeldOnes() {
+        assertThat(page(null, false))
+                .as("false narrows as well as true; it is not read as absent")
+                .hasSize(6)
+                .allSatisfy(row -> assertThat(row.getRequiresGeofenceApproval()).isFalse());
+    }
+
+    @Test
+    void theNarrowingHappensInTheQuerySoTheTotalIsHonest() {
+        // The listing is paged. If the filter were applied after the page was cut, the page would
+        // hold the right rows and the total behind it would still be the unfiltered nine.
+        Page<Attendance> firstPage = attendanceRepository.findWithFilters(
+                SITE, THE_DAY, null, ApprovalStatus.PENDING, true, null,
+                PageRequest.of(0, 1, Sort.by("employeeName")));
+
+        assertThat(firstPage.getContent()).hasSize(1);
+        assertThat(firstPage.getTotalElements())
+                .as("two held pending days, not the nine on the site")
+                .isEqualTo(2);
+    }
+
+    @Test
+    void theOtherFiltersStillCompose() {
+        assertThat(page(AttendanceStatus.LATE, ApprovalStatus.PENDING, true, null))
+                .as("one of the two held days is a late arrival")
+                .hasSize(1);
+    }
+
+    private List<Attendance> page(ApprovalStatus approvalStatus, Boolean requiresApproval) {
+        return page(null, approvalStatus, requiresApproval, null);
+    }
+
+    private List<Attendance> page(AttendanceStatus status, ApprovalStatus approvalStatus,
+                                            Boolean requiresApproval, String search) {
+        return attendanceRepository.findWithFilters(
+                        SITE, THE_DAY, status, approvalStatus, requiresApproval, search,
+                        PageRequest.of(0, 50, Sort.by("employeeName")))
+                .getContent();
+    }
+
+    private void persist(Organization org, long projectId, LocalDate date, AttendanceStatus status,
+                         ApprovalStatus approvalStatus, boolean held) {
+        long employeeId = nextEmployeeId++;
+        Attendance attendance = Attendance.builder()
+                .employeeId(employeeId)
+                .employeeName("Employee " + employeeId)
+                .attendanceDate(date)
+                .projectId(projectId)
+                .projectName("Site " + projectId)
+                .status(status)
+                // Set explicitly: the entity's builder carries no @Builder.Default for this, so
+                // the field initializer is bypassed and the column is NOT NULL.
+                .approvalStatus(approvalStatus)
+                .requiresGeofenceApproval(held)
+                .organization(org)
+                .build();
+        entityManager.persist(attendance);
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void enableOrgFilter(Long organizationId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", organizationId);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+}


### PR DESCRIPTION
Closes #712. Comes out of tornotron/echno-web#402.

## What the useful parameter actually is

`approvalStatus` alone is not it, and shipping only that would have been a filter that looks like it works and filters almost nothing.

`checkIn` creates every attendance record at `approvalStatus = PENDING` and nothing moves it until somebody decides, so on an ordinary day the pending set on a site is the site's whole roll. Filtering the list on PENDING would return the page it was already showing, under a total that had barely moved. The web page shows this from the other side: it draws the approve and reject buttons on every row where `attendance.approvalStatus === 'pending'`, which today is every row.

The set a person means by "show me the pending ones on this site" is the days somebody actually has to look at, and those are the ones marked `requiresGeofenceApproval`: a punch fell outside the site and the day is held. So the listing gains two optional parameters:

- **`requiresApproval`** (boolean) is the narrow one, and the one the filter chip should use. On the seeded day in the test it selects 2 rows of 9 where `approvalStatus=PENDING` selects 8.
- **`approvalStatus`** (enum) is still worth having, because it is the only way to ask for the decided days. `APPROVED` and `REJECTED` are genuinely small sets and a reviewer wants "what did we decide here today". It is PENDING that is the near-no-op, and the operation description now says so rather than leaving the next person to find out.

They are two orthogonal columns, so they stay two orthogonal parameters rather than being folded into one four-valued enum, which would have made "held and already approved" unaskable. Asked together, `approvalStatus=PENDING&requiresApproval=true` is the site's outstanding work for the day.

## Not the queue

This does not overlap `GET /attendance/pending-approvals` from #701 and does not replace it. That endpoint is routed to the signed-in caller, excludes their own days, and is capped rather than paged. This is the project list: one site, one date, paged, and it shows every held day there whoever has to decide it. The two answer different questions and the distinction that made the queue correct is the distinction this change is built on.

## Shape of the change

The filters go into the `findWithFilters` JPQL beside the existing `status` and `search` predicates, in the same `:param IS NULL OR ...` form, so absent means unfiltered exactly as the neighbours do. The narrowing has to be in the query rather than over the returned page, or the total the client pages against stays the unfiltered one.

## Tests

`AttendanceProjectApprovalFilterIT`, a `@DataJpaTest` against the real CockroachDB the queue IT already uses. The seed is built so no assertion passes by accident: nine rows on the site that day, eight of them pending, three held, two both, one already decided, plus a same-shaped row on the next day and another site that must never appear. A filter that had stopped narrowing returns eight where the test wants two.

Two of the cases are the point rather than coverage. `filteringOnPendingIsAlmostTheWholeDay` pins the near-no-op as a measured fact, so nobody later mistakes it for a bug and "fixes" the pending filter into meaning the held set. `theNarrowingHappensInTheQuerySoTheTotalIsHonest` asks for a one-row page and reads `getTotalElements`, which is the assertion a filter applied after paging would fail.

**Measured red:** `docs/openapi.json` was pushed first, on its own commit, declaring the two parameters before the endpoint offered them. CI on `0b6b48e` passed `Test` and failed the `OpenAPI document up to date` step, which is the contract check reporting that the served document has no such parameters. The implementation commit turns it green. Worth noting because that step only produces its `openapi-served` artifact when the run reaches it, and a run failing on `Test` never does (#707).

## What is needed on the client side

Nothing is broken by this, because both parameters are optional and absent behaves exactly as today. To use them, `echno-core` needs two fields on `AttendanceListParams` and two lines in `attendanceListParamsToQuery` (`src/types/attendance/attendance-list-params.ts`), which today emits only `date`, `status`, `search`, `page` and `size`. Then the filter chips on `app/users/dashboard/attendance/page.tsx`, as the issue describes.
