### PR TITLE
Publish the served OpenAPI document from every run

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,12 +42,23 @@ jobs:
       # drifted, so the file cannot quietly stop describing the backend. Its own
       # step, and its own forked JVM, because it boots a web context that does not
       # belong in the main suite's 1 GB heap. See OpenApiSnapshotTest.
+      #
+      # Runs whether or not `Test` passed. A run whose document is stale is by
+      # definition a run where something changed, which is often a run where a test
+      # is red too, and gating this step on the suite made the document unobtainable
+      # in exactly those runs. The two checks report independently now: a red suite
+      # no longer hides a contract drift, and a drift no longer hides a red suite.
       - name: OpenAPI document up to date
+        if: ${{ !cancelled() }}
         run: ./gradlew --no-daemon openApiSnapshot
 
-      # Uploaded on failure so a drift can be diffed without rerunning anything.
+      # OpenApiSnapshotTest writes build/openapi.json before it compares, so this is
+      # the canonical document either way: the drift to diff when the step fails, and
+      # a current copy of the contract when it passes. Published on every run because
+      # regenerating it locally needs a container runtime, and the fallback of taking
+      # it from a build was worth nothing while it existed only on failures.
       - name: Upload the served OpenAPI document
-        if: failure()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: openapi-served


### PR DESCRIPTION
Closes #707.

## The defect

Two things together made `openapi-served` useless:

1. the upload was `if: failure()`, and
2. `Test` ran before `openApiSnapshot`, so a red suite meant the snapshot step never executed and no file was ever produced to upload.

A run whose committed document is stale is by definition a run where something changed, which is frequently a run where a test is red too. The artifact existed exactly where it was not wanted and was absent exactly where it was.

The workaround #694 needed was a throwaway commit with an annotation removed, so `Test` would go green and `openApiSnapshot` would fail into an artifact.

## The fix

Both steps are conditioned on `!cancelled()`.

- The snapshot step no longer sits behind the suite's result. The two checks report independently: a red suite does not hide a contract drift, and a drift does not hide a red suite.
- The upload runs on success too. `OpenApiSnapshotTest` writes `build/openapi.json` before it compares, so the file is present either way: the drifted document to diff when the check fails, the current contract when it passes.

Publishing it from green runs is the part with value beyond this issue. Regenerating the document locally needs a container runtime, and any workstation without Docker can now take a canonical copy from any run.

## Why not the other candidate

Reordering `openApiSnapshot` ahead of `Test` swaps which check gates which: a stale document would then skip the suite, so a branch with both problems would surface one per push. The condition removes the gate in both directions for the same one-line cost.

## Why not a separate job

It would re-run checkout, the JDK setup and a full compile of main and test sources on a second runner, plus another CockroachDB container pull, to buy independence a step condition already gives. The snapshot task already forks its own JVM with its own heap, which was the isolation that mattered.

## Why `!cancelled()` and not `always()`

`always()` also fires after a cancellation. A cancelled job is one somebody stopped; spending another Testcontainers boot and an upload on an abandoned tree is waste.

## Verification

CI on this PR is the check. The workflow change only takes effect for runs of the changed file, and this PR is one, so a green run here that carries an `openapi-served` artifact demonstrates both halves.

https://claude.ai/code/session_018LUw1wk1SqVZN55TQDKRHn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OpenAPI snapshots are now generated unless the workflow is cancelled, regardless of test results.
  * OpenAPI artifacts are uploaded for every non-cancelled workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->