### PR TITLE
Sweep the HQL joins the tenant filter does not scope, and fix the duplicate-code check it hid

### DIFF
--- a/docs/MULTI_TENANCY_FILTER_GUIDE.md
+++ b/docs/MULTI_TENANCY_FILTER_GUIDE.md
@@ -1,6 +1,8 @@
 # Multi-Tenancy via Hibernate @Filter — Implementation Guide
 
-Data-level organization isolation using Hibernate filters that automatically append `WHERE organization_id = :organizationId` to every query on tenant-scoped entities.
+Data-level organization isolation using Hibernate filters that append `WHERE organization_id = :organizationId` to a query whose **root** is a tenant-scoped entity, backed by a fail-closed check at the load boundary for the primary-key loads the filter never sees.
+
+Read [Explicit Joins](#explicit-joins-what-the-filter-does-not-reach) before assuming a query is covered. The filter reaches a query root and a filtered collection; an entity joined explicitly in HQL is scoped by neither mechanism, and that failure is silent.
 
 ---
 
@@ -23,7 +25,8 @@ Data-level organization isolation using Hibernate filters that automatically app
 15. [Entities Covered](#entities-covered)
 16. [Edge Cases](#edge-cases)
 17. [Caller-Supplied Organization Ids: Already Checked](#caller-supplied-organization-ids-already-checked)
-18. [Troubleshooting](#troubleshooting)
+18. [Explicit Joins: What the Filter Does Not Reach](#explicit-joins-what-the-filter-does-not-reach)
+19. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -761,6 +764,152 @@ Recorded so they are not re-derived. Each was traced to the line above the looku
 
 ---
 
+## Explicit Joins: What the Filter Does Not Reach
+
+The `orgFilter` narrows a query **root** and a filtered collection. It does not narrow an entity
+joined explicitly in HQL. `JOIN o.employees e` inside `OrganizationRepository.findByIdAndUserEmail`
+is the worked example: the query resolves any organization the caller holds an `Employee` row in,
+whatever tenant the request is scoped to.
+
+`TenantIsolationLoadListener` does not cover the gap and cannot. It runs on a post-load, and an
+entity that is only joined is never loaded, so there is no event for it to judge. Where both hold
+at once, nothing scopes that part of the query, and it fails silently rather than loudly. That is
+the difference from every other gap in this document: a filter that does not fire produces an empty
+result and a puzzled developer, while this produces a plausible answer about the wrong tenant.
+
+Measured against a database in `OrganizationLookupUnderTheOrgFilterIT`, not reasoned about. It had
+to be, because two readings of the same evidence came out wrong in opposite directions first: see
+the trap at the end of this section.
+
+### The three shapes, and which of them is safe
+
+|  | What it is | Scoped by |
+|---|---|---|
+| **Fetch join** | `LEFT JOIN FETCH u.employees` | The load listener. The rows are loaded, so a foreign one is refused. Fail-closed. |
+| **Association join off a tenant-scoped root** | `FROM CurrentStock cs JOIN cs.material m` | The root's filter, through the foreign key. The root is already in the tenant and the join walks out of it, so the join can narrow the result but not widen it past the tenant. |
+| **Entity join, or any join off an unfiltered root** | `FROM Material m LEFT JOIN CurrentStock cs ON ...`, `FROM Organization o JOIN o.employees e` | Nothing, unless the `ON` clause carries a tenant predicate itself. |
+
+The distinction in the third row is the one to hold on to. `JOIN cs.material m` reaches an
+association from an alias and inherits the root's scoping through the foreign key.
+`JOIN MaterialLocationThreshold t ON ...` names an entity outright and is tied to the root only by
+whatever the `ON` clause says, so rows from any organization can satisfy it. Both spell `JOIN`;
+only one of them is safe by construction.
+
+### The rule that enforces it
+
+`TenantScopedJoinTest` scans every `@Query` in the codebase and requires each explicit join to be
+clear by one of the three structural facts above, or registered in its `CROSS_TENANT_JOINS` map
+with a reason. It has the staleness check `UnboundedRepositoryReadTest` has, so the registry can
+only shrink. A native query is never narrowed at all, so one that joins is always registered.
+
+Reach for a structural fix before an entry: fetch the joined entity so the listener judges it, root
+the query on a tenant-scoped entity and reach the rest through associations, or put the tenant
+predicate in the `ON` clause. `LowStockRepository` does the third and is the pattern to copy:
+
+```java
+FROM Material m
+LEFT JOIN CurrentStock cs ON cs.material = m AND cs.organization.id = :organizationId
+```
+
+The join carries its own scoping, with the same parameter the filtered root is narrowed by, read
+from `TenantContext` at the service. A left join is what the query needs (a material with no stock
+row anywhere still has to appear) and an association join could not have expressed it, so the
+predicate is written out instead of being inherited.
+
+### The sweep: cleared, with why
+
+Issue #718, over all 151 `@Query` annotations in the repository. **41 explicit join clauses across
+25 of them**, counting `countQuery` beside `value`. Also checked and carrying no join at all: the
+five `Specification` classes, every use of the Criteria API, and the three
+`EntityManager.createQuery` calls in `VendorSummaryService`, which reach related rows through path
+expressions off a filtered root.
+
+**Two were genuinely exposed**, both already known: the pair on `OrganizationRepository`, one of
+which is cross-tenant on purpose. Nothing new was found. Everything else was clear on one of the
+three facts above. Recorded so a later pass does not re-derive it.
+
+| Site | Join | Why it is clear |
+|------|------|-----------------|
+| `UserRepository` `findUserWithEmployeesByKeycloakId`, `findUserWithAttachmentsByKeycloakId` | `LEFT JOIN FETCH u.employees` / `u.attachments` | Fetch joins. `User` is unfiltered, but the joined rows are loaded, so the listener refuses a foreign one. |
+| `SubscriptionRepository` `findActiveSubscriptionByUserId`, `PlanRepository` (four queries) | `LEFT JOIN FETCH` throughout | Fetch joins, and nothing in the billing catalogue is tenant-scoped in the first place. |
+| `SearchRepository` `findTasks`, `findIssues` | `LEFT JOIN t.project p`, `LEFT JOIN i.task t` | Roots `Task` and `Issue` are filtered; associations only. The projected `p.id` is the project of a row already in the tenant. |
+| `InventoryTransactionRepository` `findMovementHistoryByMaterial` | three `LEFT JOIN FETCH` | Fetch joins off a filtered root. |
+| `EmployeeRepository` (five queries) | `JOIN e.orgRoles r` | `OrgRole` is an enum element collection, not an entity, so there is no tenancy to lose. Root `Employee` is filtered. |
+| `ProjectRepository` `averageTaskProgressByProjectIds` | `LEFT JOIN p.tasks t` | Filtered root, association join. `AVG(t.progress)` averages the tasks of a project already in the tenant. |
+| `LeaveRequestRepository` `findDistinctByApproverParticipation` | `JOIN lr.approvals la` | Filtered root. The predicate on `la.approver.id` can only narrow the in-tenant result. |
+| `LeaveBalanceRepository` `findActiveBalancesByEmployeeAndYear`, `findByOrganizationIdAndYear` | `JOIN lb.leavePolicy lp`, `JOIN lb.employee e` | Filtered root, associations. The caller-supplied `:orgId` on the second can only narrow further. |
+| `LowStockRepository` `findLowStockForProject` | `JOIN cs.material m` | Filtered root `CurrentStock`, association join, and the tenant is named in the `WHERE` besides. |
+
+Registered rather than cleared, each a deliberate cross-tenant read:
+
+| Site | Why it is registered |
+|------|----------------------|
+| `OrganizationRepository.findAllByUserEmail` | The organization switcher. Listing every organization the signed-in user is employed by is the point, and narrowing it to the current tenant would leave the one they are already in. Keyed on the caller's own email, not on a caller-supplied id. |
+| `OrganizationRepository.findByIdAndUserEmail` | **A membership probe, and it must not be read as a tenant check.** It answers whether the caller has an `Employee` row in the organization they named, for any organization, and establishes nothing about what they may do there. Every caller has to answer for the target in its own guard. See #698. |
+| `LowStockRepository.findLowStockForOrganization`, `findLowStockAtStorageLocation` | Entity joins whose `ON` clauses carry the tenant predicate, as above. |
+| `ComplianceGenerationJobRepository.findSweepCandidates` | The nightly sweep's one scan, cross-tenant by necessity: its job is to find which tenants have work, so it runs before any tenant is known. Native, scalars only, never an entity, and the caller establishes a tenant per project before enqueueing. Declared `@WithoutTenant` at the call site. |
+
+### The second half of #718: a filtered root asked about another organization
+
+The join is one direction of the same blind spot. The other is a query root that **is** filtered,
+asked about an organization that is not the tenant. `LeavePolicyService.duplicatePolicy` called
+`existsByOrganizationIdAndLeaveTypeCode(targetOrganizationId, code)` against `LeavePolicy`, which
+carries `orgFilter` as a root. Hibernate adds `organization_id = <tenant>` beside the caller's
+`organization_id = <target>`, the two name different organizations, and the query matches nothing
+whatever the table holds. So the uniqueness rule was skipped on exactly the path that needs it, and
+a real collision reached `uk_leave_policy_org_type` and came back as a 500 instead of the 409 the
+method raises.
+
+Two things generalise from the repair:
+
+- **A check that cannot match is not a check that passed.** The filter turns a wrong argument into
+  a quiet success, so a predicate naming an organization other than the tenant is always worth a
+  second look at the entity it runs against.
+- **Naming the current tenant instead is not automatically the smaller repair.** Here it would have
+  made the check match the source policy's own code every time, so the endpoint would answer 409 to
+  every input. The question genuinely was about another organization, so it had to be asked in a
+  query the filter does not narrow.
+
+The repair is `countWithLeaveTypeCodeInOrganizationUnfiltered`: native, so nothing narrows it;
+carrying `organization_id = :organizationId` itself, so the tenant predicate is in the query rather
+than left to a filter that will not be applied; returning a count and never an entity, so nothing
+tenant-scoped is loaded and the listener has nothing to judge; and reached only after
+`@orgSecurity.hasAnyOrgRole(#targetOrganizationId, ...)` has established the caller's role in the
+target. `ComplianceGenerationJobRepository`'s dispatcher queries are written the same way for the
+same reason.
+
+Note what that leaves: a native query is uncovered by both mechanisms whether or not it joins, and
+`TenantScopedJoinTest` only takes the part that overlaps its own subject. The
+[Native SQL Queries](#native-sql-queries) section is the rule for the rest, and it is a convention
+rather than a check.
+
+### The trap that cost three CI cycles
+
+**An AssertJ failure description can raise the exception you are reading as the result.**
+`Organization` is a Lombok `@Data` entity whose generated `toString` walks its lazy `employees`
+collection. A test asserted that a foreign lookup came back empty and was told a
+`TenantAccessDeniedException` came out of it, which reads exactly like the listener refusing the row
+under test. It was not. Building the failure description for a *present* `Optional` initialised that
+collection, loaded the foreign organization's employees under the current tenant, and tripped the
+listener inside the error message. The assertion was raising the exception it was reporting on, and
+the first link of the chain, "anything is thrown at all", was already false.
+
+Two habits come out of it, and both apply to any assertion whose failure message could stringify a
+`@Data` entity with a lazy collection:
+
+- **Split assertion chains one property per test.** The build reports failures with
+  `exceptionFormat 'short'`, so a chained assertion names neither the broken link nor the value.
+- **Assert "nothing was thrown" before asserting what came back.** If the second one is what raises,
+  the first has already told you.
+
+A third, from the same family: **a guard test that mocks the guard proves nothing.** `@orgSecurity`
+is mocked in a web slice, so a `@PreAuthorize` test there exercises the mock. That is how a
+permanently dead clause shipped with a passing test. The same holds for the repository in a
+uniqueness check: a stub answers the question the filter would have refused to, so the test for
+this defect had to run against a real schema.
+
+---
+
 ## Troubleshooting
 
 ### "Multiple '@FilterDef' annotations define a filter named 'orgFilter'" error
@@ -817,7 +966,11 @@ public class MyEntity { ... }
 
 ### Filter not applying to custom repository methods
 
-**Check:** Custom queries using `@Query` with JPQL will be filtered. Native queries (`nativeQuery = true`) will NOT be filtered — add the condition manually.
+**Check:** A `@Query` written in JPQL has its **root** filtered, and that is all. An entity joined
+explicitly in it is not narrowed, and because it is never selected the load listener does not see it
+either: see [Explicit Joins](#explicit-joins-what-the-filter-does-not-reach), which is the shape to
+check for before concluding the filter covers a custom query. Native queries (`nativeQuery = true`)
+are not filtered at all — add the condition manually.
 
 ### Bypass not working
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -67055,7 +67055,7 @@
                 }
               }
             },
-            "description": "Conflict"
+            "description": "The target organization already holds a policy with that leave-type code"
           },
           "422": {
             "content": {
@@ -67987,7 +67987,7 @@
                 }
               }
             },
-            "description": "Conflict"
+            "description": "The target organization already holds a policy with that leave-type code"
           },
           "422": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
@@ -209,16 +209,15 @@ public class LeavePolicyController {
      * judge either. A foreign organization comes back silently, and the only thing established
      * about it is that the caller has an employment row there.
      *
-     * <p>What this guard does not fix, and what a reader should know before relying on the
-     * endpoint: the duplicate-code check at the next line asks
-     * {@code existsByOrganizationIdAndLeaveTypeCode} against {@code LeavePolicy}, which does carry
-     * the filter as a query root, so for any target other than the current tenant the predicate is
-     * unsatisfiable and the uniqueness rule is skipped on exactly the path that needs it. A real
-     * collision then reaches {@code uk_leave_policy_org_type} and surfaces as a 500 rather than a
-     * 409. Naming the current tenant instead makes that check match the source policy's own
-     * leave-type code, so it answers 409 always. Whether cross-organization duplication is a
-     * feature at all is a product decision; if it is, that check has to become a deliberate
-     * cross-tenant read. Tracked separately.
+     * <p>The duplicate-code check behind it had the same blind spot from the other side, and is
+     * repaired under #718. It asked {@code existsByOrganizationIdAndLeaveTypeCode} against
+     * {@code LeavePolicy}, which does carry the filter as a query root, so for any target other
+     * than the current tenant the predicate was unsatisfiable and the uniqueness rule was skipped
+     * on exactly the path that needs it; a real collision reached {@code uk_leave_policy_org_type}
+     * and surfaced as a 500 rather than a 409. It now asks
+     * {@code countWithLeaveTypeCodeInOrganizationUnfiltered}, which is native and so is not
+     * narrowed, returns a count rather than a row, and is reached only after this guard has
+     * established the caller's role in the target.
      *
      * @param policyId The ID of the source policy, read from the caller's own organization.
      * @param targetOrganizationId The organization to copy into, in which the caller must hold
@@ -236,7 +235,8 @@ public class LeavePolicyController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Policy duplicated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant or in the target organization"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy or target organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy or target organization with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The target organization already holds a policy with that leave-type code")
     })
     public ResponseEntity<LeavePolicyDto> duplicatePolicy(
             @PathVariable Long policyId,

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
@@ -184,7 +184,8 @@ public class LeavePolicyControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Policy duplicated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant or in the target organization"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy or target organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy or target organization with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The target organization already holds a policy with that leave-type code")
     })
     public ResponseEntity<LeavePolicyDto> duplicatePolicy(
             @RequestParam Long policyId,

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyRepository.java
@@ -20,6 +20,51 @@ public interface LeavePolicyRepository extends JpaRepository<LeavePolicy, Long> 
     boolean existsByOrganizationIdAndLeaveTypeCode(Long organizationId, String leaveTypeCode);
 
     /**
+     * Whether a named organization already holds a policy with this leave-type code, asked
+     * without the tenant filter narrowing it.
+     *
+     * <p>This exists for one caller: {@code duplicatePolicy}, which copies a policy into an
+     * organization other than the one the request is scoped to. {@link #existsByOrganizationIdAndLeaveTypeCode}
+     * cannot answer for that organization and never could. {@code LeavePolicy} carries
+     * {@code orgFilter} as a query root, so Hibernate adds {@code organization_id = <tenant>} to
+     * the query the caller wrote with {@code organization_id = <target>}, the two predicates name
+     * different organizations, and the result is empty whatever the table holds. The uniqueness
+     * rule was therefore skipped on exactly the path that needs it, and a real collision reached
+     * {@code uk_leave_policy_org_type} and surfaced as a 500 rather than a 409. See #718.
+     *
+     * <p>Native, so the filter does not reach it, which is what makes it able to answer. That is a
+     * deliberate cross-tenant read and is written to be as narrow as one can be:
+     *
+     * <ul>
+     *   <li>It returns a count and never an entity, so nothing tenant-scoped is loaded and the
+     *       fail-closed load listener has nothing to judge. The dispatcher queries on
+     *       {@code ComplianceGenerationJobRepository} are scoped the same way and for the same
+     *       reason.
+     *   <li>It carries {@code organization_id = :organizationId} itself, so the tenant predicate
+     *       is in the query rather than left to a filter that will not be applied.
+     *   <li>It answers yes or no about a code the caller already supplied. It returns no row
+     *       content, so a caller learns nothing about the target beyond the answer to the
+     *       uniqueness question the endpoint exists to ask.
+     * </ul>
+     *
+     * <p>The entitlement to read that organization at all is established before this is reached:
+     * both duplicate endpoints require the caller to hold {@code system-admin} or {@code hr-admin}
+     * in the target through {@code @orgSecurity.hasAnyOrgRole(#targetOrganizationId, ...)}. This
+     * method assumes that and does not re-check it, so do not call it from anywhere that has not.
+     *
+     * @param organizationId The organization to ask about, which need not be the current tenant.
+     * @param leaveTypeCode The code as it is stored, which is upper case.
+     * @return How many policies that organization holds with that code; zero or one, since
+     *         {@code uk_leave_policy_org_type} allows no more.
+     */
+    @Query(value = "SELECT count(*) FROM leave_policy "
+            + "WHERE organization_id = :organizationId AND leave_type_code = :leaveTypeCode",
+            nativeQuery = true)
+    long countWithLeaveTypeCodeInOrganizationUnfiltered(
+            @Param("organizationId") Long organizationId,
+            @Param("leaveTypeCode") String leaveTypeCode);
+
+    /**
      * The active policies an employee is eligible for, by gender and length of service.
      *
      * <p>The gender comparison is case-insensitive: a policy is configured as {@code FEMALE}

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -367,8 +367,21 @@ public class LeavePolicyService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Target organization with ID " + targetOrganizationId + " was not found"));
 
-        if (policyRepository.existsByOrganizationIdAndLeaveTypeCode(
-                targetOrganizationId, source.getLeaveTypeCode())) {
+        // Asked without the filter, because the filter is what made the old form unanswerable.
+        //
+        // This used to call existsByOrganizationIdAndLeaveTypeCode, which runs against LeavePolicy
+        // as a query root and therefore carries orgFilter. For any target other than the current
+        // tenant the filter's predicate and the argument named two different organizations, so the
+        // query matched nothing whatever the table held and the uniqueness rule was skipped on the
+        // one path that needs it. A real collision then reached uk_leave_policy_org_type and came
+        // back as a 500 rather than the 409 written here.
+        //
+        // Naming the current tenant instead is not the repair, though it looks like the smaller
+        // one: the check would then match the source policy's own code every time and the endpoint
+        // would answer 409 to every input. The question genuinely is about another organization,
+        // so it has to be asked in a query the filter does not narrow. See #718.
+        if (policyRepository.countWithLeaveTypeCodeInOrganizationUnfiltered(
+                targetOrganizationId, source.getLeaveTypeCode()) > 0) {
             throw new DuplicateResourceException(
                     "Leave policy with code '" + source.getLeaveTypeCode() +
                     "' already exists in target organization");

--- a/src/test/java/org/tornotron/echno_backend/architecture/TenantScopedJoinTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/TenantScopedJoinTest.java
@@ -1,0 +1,273 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import org.springframework.data.jpa.repository.Query;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ratchet on the one shape the tenant filter does not cover: an entity joined explicitly in a
+ * query, whose rows are never selected.
+ *
+ * <h2>What the two isolation mechanisms actually reach</h2>
+ *
+ * <p>The Hibernate {@code orgFilter} narrows a query <em>root</em> and a filtered collection. It
+ * does not narrow {@code JOIN o.employees e}. {@code TenantIsolationLoadListener} cannot cover the
+ * gap either, and not by oversight: it runs on a post-load, and an entity that is only joined is
+ * never loaded, so there is no event to judge. Where both of those hold at once, nothing is
+ * scoping that part of the query, and it fails silently rather than loudly.
+ *
+ * <p>{@code OrganizationLookupUnderTheOrgFilterIT} measured that against a database rather than
+ * reasoning about it, after two readings of the same evidence came out wrong in opposite
+ * directions. It is the fact this rule is built on. #698 was the first live consequence found and
+ * #718 the sweep that followed; this exists so the sweep does not have to be redone from scratch,
+ * and so a new query of the same shape is answered for when it is written rather than years later.
+ *
+ * <h2>What the rule asks</h2>
+ *
+ * <p>A query carrying an explicit join is clear when any one of three structural facts holds, and
+ * otherwise has to appear in {@link #CROSS_TENANT_JOINS} with a reason:
+ *
+ * <ol>
+ *   <li><b>Every join is a fetch join.</b> A fetched entity is loaded, so the load listener sees
+ *       it and refuses a foreign row. Fail-closed rather than silent, which is the whole
+ *       difference.
+ *   <li><b>The root is tenant-scoped and every non-fetch join is an association join.</b> The
+ *       filter has narrowed the root to the tenant, and an association join walks a foreign key
+ *       out of a row that is already in it, so the join can narrow the result further but cannot
+ *       widen it past the tenant.
+ *   <li>Neither, and it is registered below.
+ * </ol>
+ *
+ * <p>The distinction the second point turns on is between {@code JOIN cs.material m}, which is an
+ * association reached from an alias, and {@code JOIN MaterialLocationThreshold t ON ...}, which
+ * names an entity and is tied to the root only by whatever the {@code ON} clause says. The first
+ * inherits the root's scoping through the foreign key. The second inherits nothing, so if its
+ * {@code ON} clause does not carry a tenant predicate of its own, rows from any organization can
+ * satisfy it. Both spell the word {@code JOIN}; only one of them is safe by construction.
+ *
+ * <p>A native query is never narrowed at all, so it is registered whenever it joins. The
+ * uncovered-native-query problem is wider than joins and is documented in
+ * {@code docs/MULTI_TENANCY_FILTER_GUIDE.md}; this rule takes only the part that overlaps its own
+ * subject.
+ *
+ * <h2>What the rule does not claim</h2>
+ *
+ * <p>It does not decide whether a registered query is a defect. A deliberate cross-tenant read is
+ * a legitimate thing to write, and three of the entries below are exactly that. What it refuses is
+ * an <em>undeclared</em> one: the shape has to be recognised and answered for by whoever writes
+ * it, in the place a reviewer will look.
+ *
+ * <p>It also does not analyse subqueries or projections. The root of the outermost query is what
+ * it reads, which is what decides whether the result is tenant-scoped.
+ *
+ * <p>Runs under {@code @AnalyzeClasses} for the reason {@link UnboundedRepositoryReadTest} gives:
+ * a private import of a graph this size does not fit beside the Spring context cache in the test
+ * JVM's heap, and the annotation routes through ArchUnit's shared, softly-referenced cache.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class TenantScopedJoinTest {
+
+    /**
+     * Queries whose joins the tenant filter does not scope, each with why that is acceptable.
+     *
+     * <p>Do NOT add an entry to make a build pass. Reach for one of the three structural fixes
+     * first: fetch the joined entity so the load listener judges it, root the query on a
+     * tenant-scoped entity and reach the rest through associations, or put the tenant predicate in
+     * the {@code ON} clause so the join carries its own scoping. An entry belongs here only when
+     * the query is deliberately answering a question about an organization other than the one the
+     * request is scoped to, and something outside the query establishes the caller's right to ask
+     * it.
+     */
+    private static final Map<String, String> CROSS_TENANT_JOINS = Map.of(
+            "OrganizationRepository#findAllByUserEmail",
+            "The organization switcher. Its whole purpose is to list every organization the "
+                    + "signed-in user is employed by, so being narrowed to the current tenant "
+                    + "would reduce it to the one the user is already in. Scoped by the user's "
+                    + "own email rather than by a caller-supplied id, and it is a caller reading "
+                    + "their own memberships.",
+
+            "OrganizationRepository#findByIdAndUserEmail",
+            "A membership probe, and it must not be read as a tenant check. It answers whether "
+                    + "the caller has an Employee row in the organization they named, for any "
+                    + "organization, and establishes nothing about what they may do there. "
+                    + "Organization is the tenant root, so it carries no filter and the load "
+                    + "listener has nothing to say about it either. Every caller has to answer "
+                    + "for the target in its own guard: see LeavePolicyController.duplicatePolicy "
+                    + "and @orgSecurity.hasAnyOrgRole(#targetOrganizationId, ...). See #698.",
+
+            "LowStockRepository#findLowStockForOrganization",
+            "The join onto CurrentStock is an entity join and carries its own tenant predicate: "
+                    + "ON cs.organization.id = :organizationId, with the same parameter the "
+                    + "filtered root is narrowed by and read from TenantContext by LowStockService. "
+                    + "It is a left join specifically so a material with no stock row anywhere "
+                    + "still appears, which an association join could not express.",
+
+            "LowStockRepository#findLowStockAtStorageLocation",
+            "Same shape and same reason for MaterialLocationThreshold: the ON clause carries "
+                    + "t.organization.id = :organizationId. The override is left-joined so a "
+                    + "material without one falls back to its global reorder level.",
+
+            "ComplianceGenerationJobRepository#findSweepCandidates",
+            "The nightly sweep's one scan, and cross-tenant by necessity: its job is to work out "
+                    + "which tenants have work to do, so it runs before any tenant is known. "
+                    + "Native, scalars only, never an entity, and the caller establishes a tenant "
+                    + "per project before anything is enqueued. Declared with @WithoutTenant at "
+                    + "the call site.");
+
+    /**
+     * The rule. A query whose joins the filter does not reach has to be registered above.
+     */
+    @ArchTest
+    static void everyUnscopedJoinIsAccountedFor(JavaClasses productionClasses) {
+        Set<String> unaccounted = new TreeSet<>(findUnscopedJoins(productionClasses));
+        unaccounted.removeAll(CROSS_TENANT_JOINS.keySet());
+
+        assertThat(unaccounted)
+                .as("the orgFilter does not narrow an entity joined explicitly, and the load "
+                        + "listener never sees one that is not selected, so a query of this shape "
+                        + "is scoped by nothing. Fetch the joined entity, root the query on a "
+                        + "tenant-scoped entity and reach the rest through associations, or put "
+                        + "the tenant predicate in the ON clause. If the cross-tenant reach is "
+                        + "deliberate, register it in CROSS_TENANT_JOINS with the reason")
+                .isEmpty();
+    }
+
+    /**
+     * Keeps the registry honest in the other direction, the way
+     * {@link UnboundedRepositoryReadTest} does: an entry whose query no longer has the shape has
+     * to go, so the list can only shrink and never silently outlives what it excused.
+     */
+    @ArchTest
+    static void theRegistryHasNoStaleEntries(JavaClasses productionClasses) {
+        assertThat(CROSS_TENANT_JOINS.keySet())
+                .as("every registered query must still join across the tenant boundary; remove "
+                        + "the entries that no longer do")
+                .isSubsetOf(findUnscopedJoins(productionClasses));
+    }
+
+    /**
+     * Every reason is written out, so an entry cannot be added as a bare name.
+     *
+     * <p>Takes the imported classes it does not read because ArchUnit requires exactly that
+     * parameter on an {@code @ArchTest} method.
+     */
+    @ArchTest
+    static void everyRegistryEntryGivesAReason(JavaClasses productionClasses) {
+        assertThat(CROSS_TENANT_JOINS)
+                .allSatisfy((query, reason) -> assertThat(reason)
+                        .describedAs("the reason recorded for %s", query)
+                        .hasSizeGreaterThan(60));
+    }
+
+    // -------------------------------------------------------------------------------------
+    // The scan.
+    // -------------------------------------------------------------------------------------
+
+    private static Set<String> findUnscopedJoins(JavaClasses productionClasses) {
+        Set<String> tenantScopedEntities = productionClasses.stream()
+                .filter(javaClass -> javaClass.isAssignableTo(TenantScopedEntity.class))
+                .map(javaClass -> javaClass.getSimpleName().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
+
+        Set<String> found = new LinkedHashSet<>();
+        for (var javaClass : productionClasses) {
+            for (JavaMethod method : javaClass.getMethods()) {
+                method.tryGetAnnotationOfType(Query.class).ifPresent(query -> {
+                    boolean unscoped = isUnscoped(query.value(), query.nativeQuery(), tenantScopedEntities)
+                            || isUnscoped(query.countQuery(), query.nativeQuery(), tenantScopedEntities);
+                    if (unscoped) {
+                        found.add(javaClass.getSimpleName() + "#" + method.getName());
+                    }
+                });
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Whether one query string carries a join the tenant filter does not reach.
+     *
+     * @param jpql The query, which may be empty: {@code countQuery} usually is.
+     * @param nativeQuery Whether the query bypasses Hibernate's mapping entirely, and with it the
+     *         filter.
+     * @param tenantScopedEntities Lower-cased simple names of the entities that carry the filter.
+     */
+    private static boolean isUnscoped(String jpql, boolean nativeQuery, Set<String> tenantScopedEntities) {
+        if (jpql == null || jpql.isBlank()) {
+            return false;
+        }
+        List<String> tokens = tokenize(jpql);
+        List<String> joinTargets = nonFetchJoinTargets(tokens);
+        if (joinTargets.isEmpty()) {
+            return false;
+        }
+        if (nativeQuery) {
+            // Nothing narrows a native query, so a join in one is always the caller's to answer for.
+            return true;
+        }
+        if (!tenantScopedEntities.contains(rootEntity(tokens))) {
+            return true;
+        }
+        // A tenant-scoped root scopes what hangs off it through a foreign key, and nothing else.
+        return joinTargets.stream().anyMatch(target -> !target.contains("."));
+    }
+
+    /** Lower-cased words and the punctuation that separates them, so keywords can be matched. */
+    private static List<String> tokenize(String jpql) {
+        List<String> tokens = new ArrayList<>();
+        for (String raw : jpql.toLowerCase(Locale.ROOT).split("[\\s(),]+")) {
+            if (!raw.isBlank()) {
+                tokens.add(raw);
+            }
+        }
+        return tokens;
+    }
+
+    /**
+     * The target of every join that is not a fetch join, in order. A target containing a dot is an
+     * association reached from an alias; one without is an entity named outright.
+     */
+    private static List<String> nonFetchJoinTargets(List<String> tokens) {
+        List<String> targets = new ArrayList<>();
+        for (int i = 0; i < tokens.size() - 1; i++) {
+            if (!"join".equals(tokens.get(i))) {
+                continue;
+            }
+            String next = tokens.get(i + 1);
+            if ("fetch".equals(next)) {
+                continue;
+            }
+            targets.add(next);
+        }
+        return targets;
+    }
+
+    /**
+     * The entity the outermost query selects from, lower-cased. The first {@code from} is the
+     * outer one in every query here; a subquery's root cannot precede it.
+     */
+    private static String rootEntity(List<String> tokens) {
+        int from = tokens.indexOf("from");
+        if (from < 0 || from + 1 >= tokens.size()) {
+            return "";
+        }
+        return tokens.get(from + 1);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDuplicateAcrossOrganizationsIT.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDuplicateAcrossOrganizationsIT.java
@@ -171,6 +171,30 @@ class LeavePolicyDuplicateAcrossOrganizationsIT extends AbstractIntegrationTest 
     }
 
     @Test
+    void theUnfilteredProbeAnswersForTheTargetWhileTheTenantIsSomewhereElse() {
+        // The mechanism the refusal rests on. Native, so nothing narrows it, and it carries the
+        // organization predicate itself rather than leaving it to a filter that names the tenant.
+        TenantContext.setCurrentOrgId(sourceOrgId);
+        enableOrgFilterFor(sourceOrgId);
+
+        assertThat(policyRepository.countWithLeaveTypeCodeInOrganizationUnfiltered(targetOrgId, CODE))
+                .as("the target's own row is visible to a query the filter does not narrow")
+                .isEqualTo(1L);
+    }
+
+    @Test
+    void theUnfilteredProbeStillDistinguishesOneOrganizationFromAnother() {
+        // Unfiltered is not unscoped. The predicate is in the query, so an organization that does
+        // not hold the code answers zero rather than the count of everyone who does.
+        TenantContext.setCurrentOrgId(sourceOrgId);
+        enableOrgFilterFor(sourceOrgId);
+
+        assertThat(policyRepository.countWithLeaveTypeCodeInOrganizationUnfiltered(targetOrgId, "CASUAL"))
+                .as("a code no organization holds is not found in one that holds a different code")
+                .isZero();
+    }
+
+    @Test
     void aCodeTheTargetDoesNotHoldStillDuplicates() {
         // The other half of the rule: refusing everything would be as wrong as refusing nothing,
         // and naming the current tenant as the target is what would produce that.

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDuplicateAcrossOrganizationsIT.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDuplicateAcrossOrganizationsIT.java
@@ -1,0 +1,221 @@
+package org.tornotron.echno_backend.leave;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantIsolationListenerRegistrar;
+import org.tornotron.echno_backend.common.multitenancy.UnscopedAccessGuard;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.mapper.LeavePolicyMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The uniqueness rule on the cross-organization duplicate path, measured against a real database
+ * rather than against a mock of the check it is asking about.
+ *
+ * <p>{@code LeavePolicyService.duplicatePolicy} means to refuse a copy whose leave-type code the
+ * target organization already holds, and says so with a 409 naming the code. It asked
+ * {@code existsByOrganizationIdAndLeaveTypeCode(targetOrganizationId, code)} against
+ * {@code LeavePolicy}, which carries {@code orgFilter} as a query root. Under a request scoped to
+ * one organization the filter's predicate and the argument then name two different organizations,
+ * the query can match no row whatever the table holds, and the rule is skipped on exactly the path
+ * that needs it. What the caller gets instead is whatever the unique constraint does to the
+ * insert, which is a 500.
+ *
+ * <p>A mocked repository cannot show any of that: the service calls the method it calls either
+ * way, and a stub answers the question the filter would have refused to. So this runs the real
+ * repository against the real schema, with the filter enabled by hand the way
+ * {@link org.tornotron.echno_backend.organization.OrganizationLookupUnderTheOrgFilterIT} does, and
+ * asserts on what comes out of the service.
+ *
+ * <p>The service is assembled by hand rather than through the application context. What is under
+ * test is one method's use of two repositories, and a {@code @DataJpaTest} slice already has both
+ * of those wired to the database; the rest of the service's collaborators do not participate.
+ *
+ * <p>Assertions are one per test and none of them stringifies an entity. {@code Organization} is a
+ * Lombok {@code @Data} entity whose generated {@code toString} walks its lazy {@code employees}
+ * collection, so an AssertJ failure description built around one loads a foreign organization's
+ * employees under the current tenant and raises {@code TenantAccessDeniedException} from inside the
+ * error message, which then reads as the result being reported on. See #718.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TenantIsolationListenerRegistrar.class, UnscopedAccessGuard.class, SimpleMeterRegistry.class})
+class LeavePolicyDuplicateAcrossOrganizationsIT extends AbstractIntegrationTest {
+
+    private static final String EMAIL = "hr.admin.both@example.test";
+    private static final String CODE = "SICK";
+
+    @Autowired
+    private LeavePolicyRepository policyRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private EmployeeRepository employeeRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private LeavePolicyService service;
+
+    private Long sourceOrgId;
+    private Long targetOrgId;
+    private Long sourcePolicyId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        // The filter is session state and each test says for itself what it wants, so start from
+        // off rather than from whatever ran before.
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+
+        Organization source = persistOrganization("Duplicate Source Org");
+        Organization target = persistOrganization("Duplicate Target Org");
+
+        User user = new User();
+        user.setName("Admin In Both");
+        user.setEmail(EMAIL);
+        user.setKeycloakId("keycloak-" + EMAIL);
+        entityManager.persist(user);
+
+        persistEmployee(source, user);
+        persistEmployee(target, user);
+
+        LeavePolicy sourcePolicy = persistPolicy(source, CODE, "Sick Leave");
+        // The collision. The target already holds the same leave-type code, which is precisely
+        // what the duplicate check exists to refuse.
+        persistPolicy(target, CODE, "Sick Leave");
+
+        entityManager.flush();
+        sourceOrgId = source.getId();
+        targetOrgId = target.getId();
+        sourcePolicyId = sourcePolicy.getId();
+        entityManager.clear();
+
+        UserContextService userContextService = mock(UserContextService.class);
+        when(userContextService.getCurrentUserEmail()).thenReturn(EMAIL);
+        service = new LeavePolicyService(policyRepository, organizationRepository,
+                employeeRepository, userContextService, mock(LeavePolicyMapper.class));
+    }
+
+    @AfterEach
+    void clearContext() {
+        TenantContext.clear();
+    }
+
+    /** What HibernateFilterConfig does at a transaction boundary, done by hand in this slice. */
+    private void enableOrgFilterFor(Long organizationId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", organizationId);
+    }
+
+    @Test
+    void aCodeTheTargetAlreadyHoldsIsRefusedRatherThanLeftToTheUniqueConstraint() {
+        TenantContext.setCurrentOrgId(sourceOrgId);
+        enableOrgFilterFor(sourceOrgId);
+
+        assertThatThrownBy(() -> {
+            service.duplicatePolicy(sourcePolicyId, targetOrgId);
+            entityManager.flush();
+        }).isInstanceOf(DuplicateResourceException.class);
+    }
+
+    @Test
+    void theFilteredExistenceCheckCannotSeeTheRowThatCollides() {
+        // Why the refusal above has to be asked for differently. The row is in the table and the
+        // arguments name it exactly; the filter's own predicate is what makes the query
+        // unsatisfiable, because it names the organization the request is scoped to instead.
+        TenantContext.setCurrentOrgId(sourceOrgId);
+        enableOrgFilterFor(sourceOrgId);
+
+        assertThat(policyRepository.existsByOrganizationIdAndLeaveTypeCode(targetOrgId, CODE))
+                .as("a filtered query root cannot answer for an organization other than the tenant")
+                .isFalse();
+    }
+
+    @Test
+    void withNoFilterEnabledTheSameCheckFindsIt() {
+        // The control. The row is there and the check is right about everything except the one
+        // thing it cannot see.
+        TenantContext.declareUnscoped("measuring the unfiltered shape of the same check");
+
+        assertThat(policyRepository.existsByOrganizationIdAndLeaveTypeCode(targetOrgId, CODE))
+                .as("the collision is real; only the filter was hiding it")
+                .isTrue();
+    }
+
+    @Test
+    void aCodeTheTargetDoesNotHoldStillDuplicates() {
+        // The other half of the rule: refusing everything would be as wrong as refusing nothing,
+        // and naming the current tenant as the target is what would produce that.
+        TenantContext.setCurrentOrgId(sourceOrgId);
+        enableOrgFilterFor(sourceOrgId);
+
+        LeavePolicy onlyInTheSource = persistPolicy(
+                entityManager.getReference(Organization.class, sourceOrgId), "CASUAL", "Casual Leave");
+        entityManager.flush();
+
+        assertThat(catchThrowable(() -> service.duplicatePolicy(onlyInTheSource.getId(), targetOrgId)))
+                .as("a code the target does not hold is copied rather than refused")
+                .isNull();
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void persistEmployee(Organization organization, User user) {
+        Employee employee = new Employee();
+        employee.setOrganization(organization);
+        employee.setUser(user);
+        employee.setEmployeeName(user.getName());
+        employee.setEmailAddress(user.getEmail());
+        employee.setGender("unspecified");
+        employee.setPhoneNumber("0000000000");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        entityManager.persist(employee);
+    }
+
+    private LeavePolicy persistPolicy(Organization organization, String code, String name) {
+        LeavePolicy policy = new LeavePolicy();
+        policy.setOrganization(organization);
+        policy.setLeaveTypeCode(code);
+        policy.setLeaveTypeName(name);
+        policy.setAnnualQuota(12.0);
+        policy.setIsActive(true);
+        entityManager.persist(policy);
+        return policy;
+    }
+}


### PR DESCRIPTION
Closes #718.

## The defect class

The `orgFilter` narrows a query **root** and a filtered collection. It does not narrow an entity joined explicitly in HQL. `TenantIsolationLoadListener` cannot cover the gap either, and not by oversight: it runs on a post-load, and an entity that is only joined is never loaded, so there is no event to judge. Where both hold at once nothing scopes that part of the query, and unlike the other gaps in this area it fails quietly, with a plausible answer about the wrong tenant rather than an empty result.

`OrganizationLookupUnderTheOrgFilterIT` measured that in #698. This is the sweep that was owed.

## The sweep

**All 151 `@Query` annotations read. 41 explicit join clauses across 25 of them**, counting `countQuery` beside `value`. Also checked and carrying no join at all: the five `Specification` classes, every use of the Criteria API, and the three `EntityManager.createQuery` calls in `VendorSummaryService`, which reach related rows through path expressions off a filtered root.

**Two were genuinely exposed**, both on `OrganizationRepository` and both already known from #698. Nothing new was found. Everything else is clear on one of three structural facts, and the reason for each is now written into the guide, which is the expensive half and the part a later sweep would otherwise re-derive:

- a **fetch join** loads the rows, so the listener refuses a foreign one (fail-closed);
- an **association join off a tenant-scoped root** walks a foreign key out of a row already in the tenant, so it can narrow the result but not widen it;
- an **entity join** (`JOIN MaterialLocationThreshold t ON ...`) inherits nothing and is safe only if the `ON` clause carries the tenant predicate itself, which `LowStockRepository` does and is the pattern to copy.

The count is deliberately not inflated. Neither of the two exposed sites is new, and one of them (`findAllByUserEmail`, the organization switcher) is cross-tenant on purpose.

## The structural fix

`TenantScopedJoinTest` scans every `@Query` and requires each explicit join to be clear by one of the three facts above, or registered in `CROSS_TENANT_JOINS` with a written reason. Any join in a native query is always registered, since nothing narrows a native query. It carries the staleness check `UnboundedRepositoryReadTest` has, so the registry can only shrink, and a third check refuses a bare entry with no reason.

Five entries today, matching the sweep exactly. This is worth more than five guards: the next join of this shape is answered for when it is written, by whoever writes it, in the place a reviewer looks.

## The second item: the duplicate-code check

The same blind spot from the other side. `LeavePolicyService.duplicatePolicy` asked `existsByOrganizationIdAndLeaveTypeCode(targetOrganizationId, code)` against `LeavePolicy`, whose root **does** carry the filter. Hibernate added `organization_id = <tenant>` beside the caller's `organization_id = <target>`, the two named different organizations, and the query matched nothing whatever the table held. The uniqueness rule was skipped on the one path that needs it, and a real collision reached `uk_leave_policy_org_type` as a 500.

Naming the current tenant instead is not the smaller repair it looks like: the check would then match the source policy's own leave-type code every time and the endpoint would answer 409 to every input.

The question genuinely is about another organization, so it is now asked with `countWithLeaveTypeCodeInOrganizationUnfiltered`: native so nothing narrows it, carrying `organization_id` itself rather than relying on a filter that will not be applied, returning a count and never a row, and reached only after `@orgSecurity.hasAnyOrgRole(#targetOrganizationId, ...)` has established the caller's role in the target. The compliance dispatcher's cross-tenant reads are written the same way and were the precedent.

The 409 is documented on both twins now that it is reachable, so `docs/openapi.json` moves with it.

## Tests

| Test | What it holds | Measured? |
|---|---|---|
| `LeavePolicyDuplicateAcrossOrganizationsIT.aCodeTheTargetAlreadyHoldsIsRefusedRatherThanLeftToTheUniqueConstraint` | a collision in the target is a `DuplicateResourceException`, not a constraint violation | **Measured red** on the first commit, run 34117399559, the only failure in the suite |
| `theFilteredExistenceCheckCannotSeeTheRowThatCollides` | the old check answers false while the row is in the table: the defect, asserted directly | Passes before and after; it is the measurement, not the fix |
| `withNoFilterEnabledTheSameCheckFindsIt` | the control: the collision is real and only the filter was hiding it | Passes |
| `theUnfilteredProbeAnswersForTheTargetWhileTheTenantIsSomewhereElse` | the new probe sees the target's row under a foreign tenant | Green after the fix |
| `theUnfilteredProbeStillDistinguishesOneOrganizationFromAnother` | unfiltered is not unscoped: the predicate is in the query | Green after the fix |
| `aCodeTheTargetDoesNotHoldStillDuplicates` | the endpoint is not made to refuse everything | Passes before and after |
| `TenantScopedJoinTest` (three rules) | no undeclared unscoped join; no stale registry entry; no reasonless entry | Green |

The first commit is the measurement, pushed ahead of the fix so the red was read rather than reasoned about. A mocked repository could not have shown any of it: the service calls the same method either way and a stub answers the question the filter would have refused.

## Guide

`docs/MULTI_TENANCY_FILTER_GUIDE.md` gains a section for the sweep: what each mechanism actually reaches, the three shapes and which are safe, the cleared list with the reason for each site, the registered list with why, the filtered-root-asked-about-another-organization case, and the AssertJ trap that cost #698 three CI cycles. Two claims already in that document were wider than the mechanism and are corrected: that a JPQL `@Query` is filtered, and that the filter reaches every query on a tenant-scoped entity.
