### PR TITLE
Classify the response nullability of procurement, receipts and attendance

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1357,10 +1357,13 @@
         "description": "A single day's attendance record for an employee, with its clock events, movements, regularizations and approval state.",
         "properties": {
           "afternoonSessionMinutes": {
-            "description": "Minutes worked in the afternoon session, after the lunch break.",
+            "description": "Minutes worked in the afternoon session, after the lunch break. Null whenever the day's totals have not been computed.",
             "example": 255,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "approvalStatus": {
             "description": "Approval status of the record.",
@@ -1373,21 +1376,30 @@
             "type": "string"
           },
           "approvedAt": {
-            "description": "Timestamp the record was approved or rejected.",
+            "description": "Timestamp the record was approved or rejected. Null until a decision is made, and cleared again when a later out-of-fence punch reopens a decided day.",
             "example": "2026-01-16T10:15:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "approvedBy": {
-            "description": "Name of the employee who approved or rejected the record.",
+            "description": "Name of the employee who approved or rejected the record. Null until a decision is made, and null again when a later out-of-fence punch reopens a day that had already been decided. Reads as system where the decision came from a job with no signed-in user.",
             "example": "Anand Rajashekar",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "approvedById": {
-            "description": "Employee id of the person who approved or rejected the record, for filtering by approver.",
+            "description": "Employee id of the person who approved or rejected the record, for filtering by approver. Null before any decision, and also after a decision made with no signed-in user, where approvedBy reads as system. Absent here does not mean unapproved: read approvalStatus for that.",
             "example": 42,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "attendanceDate": {
             "description": "Calendar date the record covers.",
@@ -1396,23 +1408,29 @@
             "type": "string"
           },
           "breakDurationMinutes": {
-            "description": "Total minutes spent on breaks during the day.",
+            "description": "Total minutes spent on breaks during the day. Null whenever the day's totals have not been computed; a computed zero means no break was punched.",
             "example": 60,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "clockEvents": {
-            "description": "Clock events recorded for the day, in chronological order.",
+            "description": "Clock events recorded for the day, in chronological order. Empty rather than null on a day with no punches.",
             "items": {
               "$ref": "#/components/schemas/ClockEventDto"
             },
             "type": "array"
           },
           "createdAt": {
-            "description": "Timestamp the record was created.",
+            "description": "Timestamp the record was created. Populated on every insert the application makes, but the column permits null, so a row loaded outside the application can carry none.",
             "example": "2026-01-15T09:02:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "employeeId": {
             "description": "Id of the employee.",
@@ -1429,7 +1447,10 @@
             "description": "Employee id of the person expected to decide the geofence exception: the employee's reporting manager, or a project manager assigned to the site. Null when neither could be resolved, in which case the attendance record managers decide as they do for every other record.",
             "example": 42,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "id": {
             "description": "Id of the attendance record.",
@@ -1453,34 +1474,46 @@
             "type": "boolean"
           },
           "leaveId": {
-            "description": "Id of the leave request this record was generated from, if the day is on leave.",
+            "description": "Id of the leave request this record was generated from. Null on any day not taken as leave.",
             "example": 9,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "leaveType": {
-            "description": "Type of leave applied on this date, if any.",
+            "description": "Type of leave applied on this date. Null on any day not taken as leave, and set together with leaveId.",
             "example": "CASUAL",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "morningSessionMinutes": {
-            "description": "Minutes worked in the morning session, before the lunch break.",
+            "description": "Minutes worked in the morning session, before the lunch break. Null whenever the day's totals have not been computed.",
             "example": 225,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "movements": {
-            "description": "Movements logged against this record.",
+            "description": "Movements logged against this record. Empty rather than null where none were logged.",
             "items": {
               "$ref": "#/components/schemas/MovementRecordDto"
             },
             "type": "array"
           },
           "overtimeMinutes": {
-            "description": "Minutes worked beyond the shift's overtime threshold.",
+            "description": "Minutes worked beyond the shift's overtime threshold. Null whenever the day's totals have not been computed, which is different from a computed zero meaning no overtime was earned.",
             "example": 30,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "projectId": {
             "description": "Id of the project the employee was assigned to on this date.",
@@ -1494,16 +1527,19 @@
             "type": "string"
           },
           "regularizations": {
-            "description": "Regularization requests filed against this record.",
+            "description": "Regularization requests filed against this record. Empty rather than null where none were filed.",
             "items": {
               "$ref": "#/components/schemas/AttendanceRegularizationDto"
             },
             "type": "array"
           },
           "remarks": {
-            "description": "Remarks attached to the record, for example an approval or rejection note.",
+            "description": "Remarks attached to the record, for example an approval or rejection note. Null where nobody wrote one.",
             "example": "Confirmed with site supervisor",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "requiresGeofenceApproval": {
             "description": "Whether this day contains a punch the employee marked themselves from outside the project's geofence, having given a reason. Such a record is held for a decision: it is still waiting while the approval status is PENDING.",
@@ -1511,8 +1547,15 @@
             "type": "boolean"
           },
           "shiftTiming": {
-            "$ref": "#/components/schemas/ShiftTimingDto",
-            "description": "Shift the employee was scheduled to work."
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShiftTimingDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Shift the employee was scheduled to work. Null on a record raised by marking someone absent or on leave, which carries no shift. A null shift also means the day's minutes are never computed."
           },
           "status": {
             "description": "Computed attendance status for the day.",
@@ -1532,16 +1575,22 @@
             "type": "string"
           },
           "totalWorkMinutes": {
-            "description": "Total minutes worked across all sessions.",
+            "description": "Total minutes worked across all sessions. Null until the day is computed, which never happens on a record with no shift or one raised by marking someone absent or on leave. Null means nothing was calculated and must not be read as zero minutes worked.",
             "example": 480,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "updatedAt": {
-            "description": "Timestamp the record was last updated.",
+            "description": "Timestamp the record was last updated. Populated on insert as well as update, but the column permits null on the same terms as createdAt.",
             "example": "2026-01-15T18:05:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -2847,22 +2896,28 @@
         "description": "A single clock event within an attendance record.",
         "properties": {
           "attachments": {
-            "description": "Attachments supporting the event, for example a check-in photo.",
+            "description": "Attachments supporting the event, for example a check-in photo. Empty rather than null where no photo was supplied.",
             "items": {
               "$ref": "#/components/schemas/AttachmentDto"
             },
             "type": "array"
           },
           "devicePlatform": {
-            "description": "Platform the event was recorded from.",
+            "description": "Platform the event was recorded from. Null where the client sent none, and always null on an event written by a regularization.",
             "example": "android",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "distanceFromProject": {
-            "description": "Distance from the project site at the time of the event, in metres. Null when the geofence was not evaluated.",
+            "description": "Distance from the project site at the time of the event, in metres. Null when the geofence was not evaluated, which is exactly when isWithinGeofence is null. A null is an absent measurement; a zero asserts the punch was taken on the marker.",
             "example": 45.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "eventTimestamp": {
             "description": "Timestamp of the event.",
@@ -2884,19 +2939,28 @@
           "geofenceExceptionReason": {
             "description": "Why the employee marked their own attendance from outside the site boundary. Null when they did not.",
             "example": "Working from head office today for the client review",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "geofenceRadiusMeters": {
             "description": "The geofence radius the verdict was reached against, in metres, as it stood at the time of the event. Null when the geofence was not evaluated.",
             "example": 100,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "gpsAccuracy": {
-            "description": "GPS accuracy of the captured coordinates, in metres.",
+            "description": "GPS accuracy of the captured coordinates, in metres. Null where the device sent none, and always null on an event written by a regularization.",
             "example": 8.5,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "id": {
             "description": "Id of the clock event.",
@@ -2912,24 +2976,35 @@
           "isWithinGeofence": {
             "description": "Whether the event's coordinates fall within the project's geofence. Null when no verdict was reached, which is the case when the project has no coordinates, the event carries no position, or the event came from a regularization rather than a live punch. Null is not a violation and must not be shown as one.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "latitude": {
-            "description": "Latitude captured for the event.",
+            "description": "Latitude captured for the event. Null where the project does not require a location, and null on an event written by a regularization, which records a punch that was never taken on a device.",
             "example": 13.0827,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "longitude": {
-            "description": "Longitude captured for the event.",
+            "description": "Longitude captured for the event. Null under the same conditions as latitude, and the two are always absent or present together.",
             "example": 80.2707,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "photoUrl": {
-            "description": "URL of the photo captured with the event, if any.",
-            "example": "https://storage.echno.xyz/clock-events/3301-in.jpg",
-            "type": "string"
+            "description": "Always null. The mapper ignores this field and the clock event has no photo of its own; photos taken with a punch are returned in attachments instead, each with its own signed download URL.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectId": {
             "description": "Id of the project the event was recorded against.",
@@ -2943,31 +3018,46 @@
             "type": "string"
           },
           "recordedById": {
-            "description": "Employee id of whoever submitted the punch. Differs from the employee the record belongs to when a supervisor marked attendance for their team, in which case the geofence is not evaluated because the position captured is the supervisor's.",
+            "description": "Employee id of whoever submitted the punch. Differs from the employee the record belongs to when a supervisor marked attendance for their team, in which case the geofence is not evaluated because the position captured is the supervisor's. Null when the caller resolves to no employee in this organization, and on an event written by a regularization.",
             "example": 42,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "regularizationReason": {
-            "description": "Reason given if this event was regularized.",
+            "description": "Reason given if this event was regularized. Null on every punch taken live on a device.",
             "example": "Phone battery died before evening clock-out",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "remarks": {
-            "description": "Optional remarks about the event.",
+            "description": "Optional remarks about the event. Null where none were given, and always null on an event written by a regularization.",
             "example": "Reported directly to the second floor slab pour",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "verifiedAt": {
-            "description": "Timestamp the event was verified.",
+            "description": "When the event was verified. Null on the same terms as verifiedBy, and the two are written together if anything ever writes them.",
             "example": "2026-01-16T11:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "verifiedBy": {
-            "description": "Name or id of the person who verified the event, if regularized.",
+            "description": "Who verified the event. The column exists but no code path in the application writes it, so it is null on every event this server records.",
             "example": "Anand Rajashekar",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -5952,9 +6042,12 @@
         "description": "A goods received note with its vendor, project, storage location and received line items.",
         "properties": {
           "deliveryChallanNumber": {
-            "description": "Vendor delivery challan number.",
+            "description": "Vendor delivery challan number. Null where none was recorded.",
             "example": "DC-88213",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "grnNumber": {
             "description": "Goods received note number.",
@@ -5968,22 +6061,31 @@
             "type": "integer"
           },
           "invoiceAmount": {
-            "description": "Vendor invoice amount for the receipt, if supplied.",
+            "description": "Vendor invoice amount for the receipt. Null where no invoice was supplied, which is not the same as an invoice for zero.",
             "example": 41475.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "invoiceNumber": {
-            "description": "Vendor invoice number for the receipt, if supplied.",
+            "description": "Vendor invoice number for the receipt. Null where none was supplied.",
             "example": "INV-5567",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "items": {
-            "description": "Received line items.",
+            "description": "Received line items. Null rather than an empty array when the receipt has no lines: the mapper clears an empty list deliberately.",
             "items": {
               "$ref": "#/components/schemas/GrnItemDto"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "overReceiptAcknowledged": {
             "description": "True when this receipt took a material past the quantity its purchase order asked for and the excess was acknowledged on the payload.",
@@ -5991,30 +6093,49 @@
             "type": "boolean"
           },
           "projectId": {
-            "description": "Project the goods were received for.",
+            "description": "Project the goods were received for. The column permits null and rows exist without it, although the entity declares the association non-optional.",
             "example": 42,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "projectName": {
-            "description": "Project name.",
+            "description": "Project name. Null whenever projectId is, and also on a project that has no name recorded.",
             "example": "Tower B fit-out",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "purchaseOrderId": {
-            "description": "Purchase order the receipt is matched against, if any.",
+            "description": "Purchase order the receipt is matched against. Null on a receipt booked without one.",
             "example": 108,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "purchaseOrderNumber": {
-            "description": "Purchase order number, if matched.",
+            "description": "Purchase order number. Null whenever purchaseOrderId is.",
             "example": "PO-2026-0311",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "receivedBy": {
-            "$ref": "#/components/schemas/EmployeeDto",
-            "description": "Employee who received the goods."
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EmployeeDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Employee who received the goods. Null where the receipt was not attributed to one."
           },
           "receivedOn": {
             "description": "When the goods were received.",
@@ -6023,26 +6144,38 @@
             "type": "string"
           },
           "storageLocationId": {
-            "description": "Storage location the received quantities were booked into.",
+            "description": "Storage location the received quantities were booked into. Null where the receipt was not booked into one.",
             "example": 7,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "storageLocationName": {
-            "description": "Storage location name.",
+            "description": "Storage location name. Null whenever storageLocationId is.",
             "example": "Site A main store",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "vendorId": {
-            "description": "Vendor the goods were received from.",
+            "description": "Vendor the goods were received from. Null on a receipt booked without one, for example an internal transfer.",
             "example": 17,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "vendorName": {
-            "description": "Vendor name.",
+            "description": "Vendor name. Null whenever vendorId is.",
             "example": "Ambuja Cements Ltd",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -13221,12 +13354,21 @@
             "type": "number"
           },
           "amountPaid": {
-            "type": "number"
+            "description": "Amount settled against this payable so far. Null where no payment has been recorded, which is not the same as a payment of zero.",
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "amountRecorded": {
-            "type": "number"
+            "description": "Amount billed against this payable. Null where nothing has been recorded yet, which is not the same as an amount of zero.",
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "contractType": {
+            "description": "How the work was contracted. Optional on creation, so null where the caller did not classify it.",
             "enum": [
               "MATERIAL_SUPPLY",
               "LABOR_CONTRACT",
@@ -13236,24 +13378,47 @@
               "CONSULTANT",
               "OTHER"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "contractorName": {
             "type": "string"
           },
           "createdAt": {
+            "description": "When the payable was recorded. Populated on every insert the application makes, but the column permits null, unlike the equivalent on purchase orders and receipts, so a row loaded outside the application can carry none.",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "createdBy": {
-            "$ref": "#/components/schemas/EmployeeDto"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EmployeeDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Employee who raised the payable. Null on rows created before the author was recorded, and on any row whose author was not resolved."
           },
           "goodsReceivedNoteId": {
+            "description": "Id of the goods received note this payable was raised from. Null on a payable entered directly rather than from a goods received note.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "grnNumber": {
-            "type": "string"
+            "description": "Number of that goods received note. Null whenever goodsReceivedNoteId is.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "format": "int64",
@@ -13263,18 +13428,34 @@
             "type": "string"
           },
           "projectId": {
+            "description": "Id of the project the amount is charged to. The column permits null and rows exist without it, although the entity declares the association non-optional.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "projectName": {
-            "type": "string"
+            "description": "Name of the project. Null whenever projectId is, and also on a project that has no name recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "vendorId": {
+            "description": "Id of the vendor the amount is owed to. Null on a payable raised against a contractor who is not a registered vendor.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "vendorName": {
-            "type": "string"
+            "description": "Name of the vendor. Null whenever vendorId is.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -14712,14 +14893,24 @@
             "type": "string"
           },
           "createdBy": {
-            "$ref": "#/components/schemas/EmployeeDto",
-            "description": "Employee who raised the purchase order."
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EmployeeDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Employee who raised the purchase order. Null on rows created before the author was recorded, and on any row whose author was not resolved."
           },
           "expectedDeliveryDate": {
-            "description": "Date the vendor is expected to deliver by.",
+            "description": "Date the vendor is expected to deliver by. Null where none was agreed.",
             "example": "2026-02-10T00:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Purchase order id.",
@@ -14728,22 +14919,31 @@
             "type": "integer"
           },
           "indentId": {
-            "description": "Id of the indent this order was converted from, if any.",
+            "description": "Id of the indent this order was converted from. Null on an order raised directly rather than from an indent.",
             "example": 7,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "indentNumber": {
-            "description": "Number of the source indent, if any.",
+            "description": "Number of the source indent. Null whenever indentId is.",
             "example": "IND-2026-0015",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "items": {
-            "description": "Line items on the order.",
+            "description": "Line items on the order. Null rather than an empty array when the order has no lines: the mapper clears an empty list deliberately.",
             "items": {
               "$ref": "#/components/schemas/PurchaseOrderItemDto"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "poNumber": {
             "description": "Purchase order number.",
@@ -14751,20 +14951,29 @@
             "type": "string"
           },
           "projectId": {
-            "description": "Id of the project the materials are for.",
+            "description": "Id of the project the materials are for. The column permits null and rows exist without it, although the entity declares the association non-optional.",
             "example": 3,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "projectName": {
-            "description": "Name of the project.",
+            "description": "Name of the project. Null whenever projectId is, and also on a project that has no name recorded.",
             "example": "Asset Homes Perumbavoor Phase 2",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "remarks": {
-            "description": "Free-text remarks on the order.",
+            "description": "Free-text remarks on the order. Null where none were written.",
             "example": "Deliver to Perumbavoor site, second gate",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "Current lifecycle status of the purchase order.",
@@ -14780,9 +14989,12 @@
             "type": "string"
           },
           "totalAmount": {
-            "description": "Total value of the purchase order in INR.",
+            "description": "Total value of the purchase order in INR, summed from the line totals. The server writes it on every path, seeding zero at creation and treating a sum over no lines as zero, so a zero means no priced lines rather than an order worth nothing. The column still permits null, so a row written outside the application can carry none.",
             "example": 485000.0,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "vendorId": {
             "description": "Id of the vendor the order is raised against.",
@@ -14860,10 +15072,13 @@
             "type": "integer"
           },
           "indentItemId": {
-            "description": "Id of the source indent item this line was converted from, if any.",
+            "description": "Id of the source indent item this line was converted from. Null on a line entered directly rather than from an indent.",
             "example": 31,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "materialId": {
             "description": "Id of the material being ordered.",
@@ -14890,19 +15105,28 @@
             "type": "integer"
           },
           "remarks": {
-            "description": "Free-text remarks on this line item.",
+            "description": "Free-text remarks on this line item. Null where none were written.",
             "example": "IS 1786 grade, mill test certificate required",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "totalPrice": {
-            "description": "Total price for this line in INR.",
+            "description": "Total price for this line in INR. The server computes it on every write, treating a missing unit price as zero, so a zero means no price was agreed rather than a line that costs nothing. The column still permits null, so a row written outside the application can carry none.",
             "example": 31250.0,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "unitPrice": {
-            "description": "Unit price in INR.",
+            "description": "Unit price in INR. Null where no price was agreed when the line was raised, which is not the same as a price of zero.",
             "example": 62.5,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           }
         },
         "required": [
@@ -14921,10 +15145,13 @@
             "type": "integer"
           },
           "indentItemId": {
-            "description": "Id of the source indent item this line was converted from, if any.",
+            "description": "Id of the source indent item this line was converted from. Null on a line entered directly rather than from an indent.",
             "example": 31,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "materialId": {
             "description": "Id of the material being ordered.",
@@ -14961,19 +15188,28 @@
             "type": "integer"
           },
           "remarks": {
-            "description": "Free-text remarks on this line item.",
+            "description": "Free-text remarks on this line item. Null where none were written.",
             "example": "IS 1786 grade, mill test certificate required",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "totalPrice": {
-            "description": "Total price for this line in INR.",
+            "description": "Total price for this line in INR. The server computes it on every write, treating a missing unit price as zero, so a zero means no price was agreed rather than a line that costs nothing. The column still permits null, so a row written outside the application can carry none.",
             "example": 31250.0,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "unitPrice": {
-            "description": "Unit price in INR.",
+            "description": "Unit price in INR. Null where no price was agreed when the line was raised, which is not the same as a price of zero.",
             "example": 62.5,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -15193,9 +15429,12 @@
         "description": "A receipt with its amount, payer details, tax breakdown and optional links to project and finance rows.",
         "properties": {
           "amount": {
-            "description": "Amount received in the given currency.",
+            "description": "Amount received in the given currency. Required by the create and update endpoints, so a null belongs to a row written outside them.",
             "example": 45000.0,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "createdAt": {
             "description": "Timestamp the receipt was created.",
@@ -15204,20 +15443,29 @@
             "type": "string"
           },
           "currency": {
-            "description": "Currency code for the amount.",
+            "description": "Currency code for the amount. New receipts default to INR when the request omits one, so null appears only on rows stored without a currency.",
             "example": "INR",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "customerId": {
-            "description": "Id of the customer the amount was received from.",
+            "description": "Id of the customer the amount was received from. Null where the payer was recorded by name only. The column carries no foreign key, so a value may name a customer that no longer exists.",
             "example": 12,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "description": {
-            "description": "What the amount was received for.",
+            "description": "What the amount was received for. Null where nothing was written.",
             "example": "Advance against Block C interior work",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Receipt id.",
@@ -15226,50 +15474,74 @@
             "type": "integer"
           },
           "invoiceId": {
-            "description": "Id of the invoice this receipt settles.",
+            "description": "Id of the invoice this receipt settles. Null where the money was received against no invoice. The column carries no foreign key, so a value may name an invoice that no longer exists.",
             "example": 44,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "issuedBy": {
-            "description": "Id of the employee who issued the receipt.",
+            "description": "Id of the employee who issued the receipt. Null where it was not captured. The column carries no foreign key, so a value may name an employee that no longer exists.",
             "example": 9,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "notes": {
-            "description": "Free-text notes.",
+            "description": "Free-text notes. Null where nothing was written.",
             "example": "Received at site office against acknowledgement 118",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "organizationId": {
-            "description": "Id of the owning organization.",
+            "description": "Id of the owning organization. Set on every receipt the application creates, so a null belongs to a row written outside it.",
             "example": 1,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "paymentId": {
-            "description": "Id of the payment this receipt records.",
+            "description": "Id of the payment this receipt records. Null where the receipt stands alone. The column carries no foreign key, so a value may name a payment that no longer exists.",
             "example": 51,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "paymentMethod": {
-            "description": "How the amount was received.",
+            "description": "How the amount was received. Null where none was recorded.",
             "example": "Bank Transfer",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectId": {
-            "description": "Id of the project this receipt belongs to.",
+            "description": "Id of the project this receipt belongs to. Null for money received against no project. The column carries no foreign key, so a value may name a project that no longer exists.",
             "example": 3,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "receiptDate": {
-            "description": "Date the amount was received.",
+            "description": "Date the amount was received. Null where none was given, including after an update that omitted the field.",
             "example": "2026-08-20",
             "format": "date",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "receiptNumber": {
             "description": "Generated receipt number.",
@@ -15277,49 +15549,76 @@
             "type": "string"
           },
           "receivedFrom": {
-            "description": "Name of the person or company the amount was received from.",
+            "description": "Name of the person or company the amount was received from. Required by the create and update endpoints, so a null belongs to a row written outside them.",
             "example": "Asset Homes Pvt Ltd",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "receivedFromAddress": {
-            "description": "Address of the payer.",
+            "description": "Address of the payer. Null where none was recorded.",
             "example": 12,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "referenceNumber": {
-            "description": "Cheque or internal reference number.",
+            "description": "Cheque or internal reference number. Null where none was recorded.",
             "example": "CHQ-000231",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
-            "description": "Lifecycle status of the receipt.",
+            "description": "Lifecycle status, as free text the client interprets. Null where none was sent, including after an update that omitted the field, which clears it.",
             "example": "issued",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "taxAmount": {
-            "description": "Tax amount included in the receipt.",
+            "description": "Tax amount included in the receipt. Null where the receipt carries no tax breakdown, which leaves the tax unknown rather than zero.",
             "example": 8100.0,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "taxRate": {
-            "description": "Tax rate applied, as a percentage.",
+            "description": "Tax rate applied, as a percentage. Null where the receipt carries no tax breakdown.",
             "example": 18.0,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "taxType": {
-            "description": "Type of tax applied.",
+            "description": "Type of tax applied. Null where the receipt carries no tax breakdown.",
             "example": "GST",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "transactionId": {
-            "description": "External transaction reference from the bank or gateway.",
+            "description": "External transaction reference from the bank or gateway. Null for money taken outside any such system, such as cash at the site office.",
             "example": "TXN-8842190",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "type": {
-            "description": "Kind of receipt.",
+            "description": "Kind of receipt, as free text the client interprets. Null where none was sent, including after an update that omitted the field, which clears it.",
             "example": "payment",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "updatedAt": {
             "description": "Timestamp the receipt was last updated.",

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
@@ -12,6 +12,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * A day's attendance record as it is served. A field without {@code nullable = true} is one the
+ * schema, the mapper or the entity behind it establishes as always present; see
+ * {@code ReviewedResponseSchemas} for which is which.
+ */
 @Schema(description = "A single day's attendance record for an employee, with its clock events, movements, regularizations and approval state.")
 @Data
 @Builder
@@ -40,25 +45,39 @@ public class AttendanceResponseDto {
     @Schema(description = "Computed attendance status for the day.", example = "PRESENT")
     private AttendanceStatus status;
 
-    @Schema(description = "Shift the employee was scheduled to work.")
+    @Schema(description = "Shift the employee was scheduled to work. Null on a record raised by "
+            + "marking someone absent or on leave, which carries no shift. A null shift also "
+            + "means the day's minutes are never computed.", nullable = true)
     private ShiftTimingDto shiftTiming;
 
-    @Schema(description = "Clock events recorded for the day, in chronological order.")
+    @Schema(description = "Clock events recorded for the day, in chronological order. Empty "
+            + "rather than null on a day with no punches.")
     private List<ClockEventDto> clockEvents;
 
-    @Schema(description = "Total minutes worked across all sessions.", example = "480")
+    @Schema(description = "Total minutes worked across all sessions. Null until the day is "
+            + "computed, which never happens on a record with no shift or one raised by marking "
+            + "someone absent or on leave. Null means nothing was calculated and must not be read "
+            + "as zero minutes worked.", example = "480", nullable = true)
     private Integer totalWorkMinutes;
 
-    @Schema(description = "Minutes worked in the morning session, before the lunch break.", example = "225")
+    @Schema(description = "Minutes worked in the morning session, before the lunch break. Null "
+            + "whenever the day's totals have not been computed.", example = "225",
+            nullable = true)
     private Integer morningSessionMinutes;
 
-    @Schema(description = "Minutes worked in the afternoon session, after the lunch break.", example = "255")
+    @Schema(description = "Minutes worked in the afternoon session, after the lunch break. Null "
+            + "whenever the day's totals have not been computed.", example = "255",
+            nullable = true)
     private Integer afternoonSessionMinutes;
 
-    @Schema(description = "Minutes worked beyond the shift's overtime threshold.", example = "30")
+    @Schema(description = "Minutes worked beyond the shift's overtime threshold. Null whenever "
+            + "the day's totals have not been computed, which is different from a computed zero "
+            + "meaning no overtime was earned.", example = "30", nullable = true)
     private Integer overtimeMinutes;
 
-    @Schema(description = "Total minutes spent on breaks during the day.", example = "60")
+    @Schema(description = "Total minutes spent on breaks during the day. Null whenever the day's "
+            + "totals have not been computed; a computed zero means no break was punched.",
+            example = "60", nullable = true)
     private Integer breakDurationMinutes;
 
     @Schema(description = "Whether the employee clocked in after the shift's grace period.", example = "false")
@@ -70,28 +89,40 @@ public class AttendanceResponseDto {
     @Schema(description = "Whether the employee worked beyond the overtime threshold.", example = "false")
     private Boolean isOvertime;
 
-    @Schema(description = "Id of the leave request this record was generated from, if the day is on leave.", example = "9")
+    @Schema(description = "Id of the leave request this record was generated from. Null on any "
+            + "day not taken as leave.", example = "9", nullable = true)
     private Long leaveId;
 
-    @Schema(description = "Type of leave applied on this date, if any.", example = "CASUAL")
+    @Schema(description = "Type of leave applied on this date. Null on any day not taken as "
+            + "leave, and set together with leaveId.", example = "CASUAL", nullable = true)
     private String leaveType;
 
-    @Schema(description = "Regularization requests filed against this record.")
+    @Schema(description = "Regularization requests filed against this record. Empty rather than "
+            + "null where none were filed.")
     private List<AttendanceRegularizationDto> regularizations;
 
-    @Schema(description = "Movements logged against this record.")
+    @Schema(description = "Movements logged against this record. Empty rather than null where "
+            + "none were logged.")
     private List<MovementRecordDto> movements;
 
     @Schema(description = "Approval status of the record.", example = "APPROVED")
     private ApprovalStatus approvalStatus;
 
-    @Schema(description = "Name of the employee who approved or rejected the record.", example = "Anand Rajashekar")
+    @Schema(description = "Name of the employee who approved or rejected the record. Null until a "
+            + "decision is made, and null again when a later out-of-fence punch reopens a day "
+            + "that had already been decided. Reads as system where the decision came from a job "
+            + "with no signed-in user.", example = "Anand Rajashekar", nullable = true)
     private String approvedBy;
 
-    @Schema(description = "Employee id of the person who approved or rejected the record, for filtering by approver.", example = "42")
+    @Schema(description = "Employee id of the person who approved or rejected the record, for "
+            + "filtering by approver. Null before any decision, and also after a decision made "
+            + "with no signed-in user, where approvedBy reads as system. Absent here does not "
+            + "mean unapproved: read approvalStatus for that.", example = "42", nullable = true)
     private Long approvedById;
 
-    @Schema(description = "Timestamp the record was approved or rejected.", example = "2026-01-16T10:15:00")
+    @Schema(description = "Timestamp the record was approved or rejected. Null until a decision "
+            + "is made, and cleared again when a later out-of-fence punch reopens a decided day.",
+            example = "2026-01-16T10:15:00", nullable = true)
     private LocalDateTime approvedAt;
 
     @Schema(description = "Whether this day contains a punch the employee marked themselves from "
@@ -104,15 +135,21 @@ public class AttendanceResponseDto {
             + "the employee's reporting manager, or a project manager assigned to the site. Null "
             + "when neither could be resolved, in which case the attendance record managers decide "
             + "as they do for every other record.",
-            example = "42")
+            example = "42", nullable = true)
     private Long geofenceApproverId;
 
-    @Schema(description = "Remarks attached to the record, for example an approval or rejection note.", example = "Confirmed with site supervisor")
+    @Schema(description = "Remarks attached to the record, for example an approval or rejection "
+            + "note. Null where nobody wrote one.", example = "Confirmed with site supervisor",
+            nullable = true)
     private String remarks;
 
-    @Schema(description = "Timestamp the record was created.", example = "2026-01-15T09:02:00")
+    @Schema(description = "Timestamp the record was created. Populated on every insert the "
+            + "application makes, but the column permits null, so a row loaded outside the "
+            + "application can carry none.", example = "2026-01-15T09:02:00", nullable = true)
     private LocalDateTime createdAt;
 
-    @Schema(description = "Timestamp the record was last updated.", example = "2026-01-15T18:05:00")
+    @Schema(description = "Timestamp the record was last updated. Populated on insert as well as "
+            + "update, but the column permits null on the same terms as createdAt.",
+            example = "2026-01-15T18:05:00", nullable = true)
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventDto.java
@@ -11,6 +11,11 @@ import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * A clock event as it is served. A field without {@code nullable = true} is one the schema, the
+ * mapper or the entity behind it establishes as always present; see
+ * {@code ReviewedResponseSchemas} for which is which.
+ */
 @Schema(description = "A single clock event within an attendance record.")
 @Data
 @Builder
@@ -27,16 +32,25 @@ public class ClockEventDto {
     @Schema(description = "Timestamp of the event.", example = "2026-01-15T09:02:00")
     private LocalDateTime eventTimestamp;
 
-    @Schema(description = "Latitude captured for the event.", example = "13.0827")
+    @Schema(description = "Latitude captured for the event. Null where the project does not "
+            + "require a location, and null on an event written by a regularization, which "
+            + "records a punch that was never taken on a device.", example = "13.0827",
+            nullable = true)
     private Double latitude;
 
-    @Schema(description = "Longitude captured for the event.", example = "80.2707")
+    @Schema(description = "Longitude captured for the event. Null under the same conditions as "
+            + "latitude, and the two are always absent or present together.", example = "80.2707",
+            nullable = true)
     private Double longitude;
 
-    @Schema(description = "GPS accuracy of the captured coordinates, in metres.", example = "8.5")
+    @Schema(description = "GPS accuracy of the captured coordinates, in metres. Null where the "
+            + "device sent none, and always null on an event written by a regularization.",
+            example = "8.5", nullable = true)
     private Double gpsAccuracy;
 
-    @Schema(description = "URL of the photo captured with the event, if any.", example = "https://storage.echno.xyz/clock-events/3301-in.jpg")
+    @Schema(description = "Always null. The mapper ignores this field and the clock event has "
+            + "no photo of its own; photos taken with a punch are returned in attachments "
+            + "instead, each with its own signed download URL.", nullable = true)
     private String photoUrl;
 
     @Schema(description = "Id of the project the event was recorded against.", example = "12")
@@ -45,52 +59,66 @@ public class ClockEventDto {
     @Schema(description = "Name of the project.", example = "Asset Homes Kovilambakkam Phase 2")
     private String projectName;
 
-    @Schema(description = "Platform the event was recorded from.", example = "android")
+    @Schema(description = "Platform the event was recorded from. Null where the client sent none, "
+            + "and always null on an event written by a regularization.", example = "android",
+            nullable = true)
     private String devicePlatform;
 
     @Schema(description = "Whether the event's coordinates fall within the project's geofence. "
             + "Null when no verdict was reached, which is the case when the project has no "
             + "coordinates, the event carries no position, or the event came from a regularization "
             + "rather than a live punch. Null is not a violation and must not be shown as one.",
-            example = "true")
+            example = "true", nullable = true)
     private Boolean isWithinGeofence;
 
     @Schema(description = "Distance from the project site at the time of the event, in metres. "
-            + "Null when the geofence was not evaluated.", example = "45.0")
+            + "Null when the geofence was not evaluated, which is exactly when isWithinGeofence "
+            + "is null. A null is an absent measurement; a zero asserts the punch was taken on "
+            + "the marker.", example = "45.0", nullable = true)
     private Double distanceFromProject;
 
     @Schema(description = "The geofence radius the verdict was reached against, in metres, as it "
             + "stood at the time of the event. Null when the geofence was not evaluated.",
-            example = "100")
+            example = "100", nullable = true)
     private Integer geofenceRadiusMeters;
 
     @Schema(description = "Why the employee marked their own attendance from outside the site "
             + "boundary. Null when they did not.",
-            example = "Working from head office today for the client review")
+            example = "Working from head office today for the client review", nullable = true)
     private String geofenceExceptionReason;
 
     @Schema(description = "Employee id of whoever submitted the punch. Differs from the employee "
             + "the record belongs to when a supervisor marked attendance for their team, in which "
             + "case the geofence is not evaluated because the position captured is the "
-            + "supervisor's.",
-            example = "42")
+            + "supervisor's. Null when the caller resolves to no employee in this organization, "
+            + "and on an event written by a regularization.",
+            example = "42", nullable = true)
     private Long recordedById;
 
-    @Schema(description = "Optional remarks about the event.", example = "Reported directly to the second floor slab pour")
+    @Schema(description = "Optional remarks about the event. Null where none were given, and "
+            + "always null on an event written by a regularization.",
+            example = "Reported directly to the second floor slab pour", nullable = true)
     private String remarks;
 
-    @Schema(description = "Name or id of the person who verified the event, if regularized.", example = "Anand Rajashekar")
+    @Schema(description = "Who verified the event. The column exists but no code path in the "
+            + "application writes it, so it is null on every event this server records.",
+            example = "Anand Rajashekar", nullable = true)
     private String verifiedBy;
 
-    @Schema(description = "Timestamp the event was verified.", example = "2026-01-16T11:00:00")
+    @Schema(description = "When the event was verified. Null on the same terms as verifiedBy, "
+            + "and the two are written together if anything ever writes them.",
+            example = "2026-01-16T11:00:00", nullable = true)
     private LocalDateTime verifiedAt;
 
     @Schema(description = "Whether this event was added through a regularization request rather than recorded live.", example = "false")
     private Boolean isRegularized;
 
-    @Schema(description = "Reason given if this event was regularized.", example = "Phone battery died before evening clock-out")
+    @Schema(description = "Reason given if this event was regularized. Null on every punch taken "
+            + "live on a device.", example = "Phone battery died before evening clock-out",
+            nullable = true)
     private String regularizationReason;
 
-    @Schema(description = "Attachments supporting the event, for example a check-in photo.")
+    @Schema(description = "Attachments supporting the event, for example a check-in photo. Empty "
+            + "rather than null where no photo was supplied.")
     private List<AttachmentDto> attachments;
 }

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteDto.java
@@ -3,11 +3,15 @@ package org.tornotron.echno_backend.goodsReceivedNote.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
-import org.tornotron.echno_backend.user.dto.UserDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * A goods received note as it is served. A field without {@code nullable = true} is one the
+ * schema, the mapper or the entity behind it establishes as always present; see
+ * {@code ReviewedResponseSchemas} for which is which.
+ */
 @Data
 @Schema(description = "A goods received note with its vendor, project, storage location and received line items.")
 public class GoodsReceivedNoteDto {
@@ -21,43 +25,58 @@ public class GoodsReceivedNoteDto {
     @Schema(description = "When the goods were received.", example = "2026-08-01T10:30:00")
     private LocalDateTime receivedOn;
 
-    @Schema(description = "Employee who received the goods.")
+    @Schema(description = "Employee who received the goods. Null where the receipt was not "
+            + "attributed to one.", nullable = true)
     private EmployeeDto receivedBy;
 
-    @Schema(description = "Vendor the goods were received from.", example = "17")
+    @Schema(description = "Vendor the goods were received from. Null on a receipt booked without "
+            + "one, for example an internal transfer.", example = "17", nullable = true)
     private Long vendorId;
 
-    @Schema(description = "Vendor name.", example = "Ambuja Cements Ltd")
+    @Schema(description = "Vendor name. Null whenever vendorId is.",
+            example = "Ambuja Cements Ltd", nullable = true)
     private String vendorName;
 
-    @Schema(description = "Purchase order the receipt is matched against, if any.", example = "108")
+    @Schema(description = "Purchase order the receipt is matched against. Null on a receipt "
+            + "booked without one.", example = "108", nullable = true)
     private Long purchaseOrderId;
 
-    @Schema(description = "Purchase order number, if matched.", example = "PO-2026-0311")
+    @Schema(description = "Purchase order number. Null whenever purchaseOrderId is.",
+            example = "PO-2026-0311", nullable = true)
     private String purchaseOrderNumber;
 
-    @Schema(description = "Vendor delivery challan number.", example = "DC-88213")
+    @Schema(description = "Vendor delivery challan number. Null where none was recorded.",
+            example = "DC-88213", nullable = true)
     private String deliveryChallanNumber;
 
-    @Schema(description = "Vendor invoice number for the receipt, if supplied.", example = "INV-5567")
+    @Schema(description = "Vendor invoice number for the receipt. Null where none was supplied.",
+            example = "INV-5567", nullable = true)
     private String invoiceNumber;
 
-    @Schema(description = "Vendor invoice amount for the receipt, if supplied.", example = "41475.00")
+    @Schema(description = "Vendor invoice amount for the receipt. Null where no invoice was "
+            + "supplied, which is not the same as an invoice for zero.", example = "41475.00",
+            nullable = true)
     private Double invoiceAmount;
 
-    @Schema(description = "Project the goods were received for.", example = "42")
+    @Schema(description = "Project the goods were received for. The column permits null and rows "
+            + "exist without it, although the entity declares the association non-optional.",
+            example = "42", nullable = true)
     private Long projectId;
 
-    @Schema(description = "Project name.", example = "Tower B fit-out")
+    @Schema(description = "Project name. Null whenever projectId is, and also on a project that "
+            + "has no name recorded.", example = "Tower B fit-out", nullable = true)
     private String projectName;
 
-    @Schema(description = "Storage location the received quantities were booked into.", example = "7")
+    @Schema(description = "Storage location the received quantities were booked into. Null where "
+            + "the receipt was not booked into one.", example = "7", nullable = true)
     private Long storageLocationId;
 
-    @Schema(description = "Storage location name.", example = "Site A main store")
+    @Schema(description = "Storage location name. Null whenever storageLocationId is.",
+            example = "Site A main store", nullable = true)
     private String storageLocationName;
 
-    @Schema(description = "Received line items.")
+    @Schema(description = "Received line items. Null rather than an empty array when the receipt "
+            + "has no lines: the mapper clears an empty list deliberately.", nullable = true)
     private List<GrnItemDto> items;
 
     @Schema(description = "True when this receipt took a material past the quantity its purchase order "

--- a/src/main/java/org/tornotron/echno_backend/payable/dto/PayableDto.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/dto/PayableDto.java
@@ -1,29 +1,73 @@
 package org.tornotron.echno_backend.payable.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.payable.enums.ContractType;
-import org.tornotron.echno_backend.user.dto.UserDto;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
+/**
+ * An amount owed to a vendor or contractor, as it is served. A field without
+ * {@code nullable = true} is one the schema, the mapper or the entity behind it establishes as
+ * always present; see {@code ReviewedResponseSchemas} for which is which.
+ */
 @Data
 public class PayableDto {
 
     private Long id;
+
     private String payableNumber;
+
     private String contractorName;
+
+    @Schema(description = "How the work was contracted. Optional on creation, so null where the "
+            + "caller did not classify it.", nullable = true)
     private ContractType contractType;
+
+    @Schema(description = "Amount billed against this payable. Null where nothing has been "
+            + "recorded yet, which is not the same as an amount of zero.", nullable = true)
     private BigDecimal amountRecorded;
+
+    @Schema(description = "Amount settled against this payable so far. Null where no payment has "
+            + "been recorded, which is not the same as a payment of zero.", nullable = true)
     private BigDecimal amountPaid;
+
     private BigDecimal amountDue;
+
+    @Schema(description = "Id of the vendor the amount is owed to. Null on a payable raised "
+            + "against a contractor who is not a registered vendor.", nullable = true)
     private Long vendorId;
+
+    @Schema(description = "Name of the vendor. Null whenever vendorId is.", nullable = true)
     private String vendorName;
+
+    @Schema(description = "Id of the goods received note this payable was raised from. Null on a "
+            + "payable entered directly rather than from a goods received note.",
+            nullable = true)
     private Long goodsReceivedNoteId;
+
+    @Schema(description = "Number of that goods received note. Null whenever "
+            + "goodsReceivedNoteId is.", nullable = true)
     private String grnNumber;
+
+    @Schema(description = "Id of the project the amount is charged to. The column permits null "
+            + "and rows exist without it, although the entity declares the association "
+            + "non-optional.", nullable = true)
     private Long projectId;
+
+    @Schema(description = "Name of the project. Null whenever projectId is, and also on a project "
+            + "that has no name recorded.", nullable = true)
     private String projectName;
+
+    @Schema(description = "Employee who raised the payable. Null on rows created before the "
+            + "author was recorded, and on any row whose author was not resolved.", nullable = true)
     private EmployeeDto createdBy;
+
+    @Schema(description = "When the payable was recorded. Populated on every insert the "
+            + "application makes, but the column permits null, unlike the equivalent on purchase "
+            + "orders and receipts, so a row loaded outside the application can carry none.",
+            nullable = true)
     private LocalDateTime createdAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderDto.java
@@ -4,12 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
-import org.tornotron.echno_backend.user.dto.UserDto;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * A purchase order as it is served. A field without {@code nullable = true} is one the
+ * schema, the mapper or the service behind it establishes as always present; see
+ * {@code ReviewedResponseSchemas} for which is which.
+ */
 @Schema(description = "A purchase order with its vendor, indent link, line items and totals.")
 @Data
 public class PurchaseOrderDto {
@@ -26,16 +30,22 @@ public class PurchaseOrderDto {
     @Schema(description = "Name of the vendor.", example = "Sri Balaji Steel Traders")
     private String vendorName;
 
-    @Schema(description = "Id of the indent this order was converted from, if any.", example = "7")
+    @Schema(description = "Id of the indent this order was converted from. Null on an order "
+            + "raised directly rather than from an indent.", example = "7", nullable = true)
     private Long indentId;
 
-    @Schema(description = "Number of the source indent, if any.", example = "IND-2026-0015")
+    @Schema(description = "Number of the source indent. Null whenever indentId is.",
+            example = "IND-2026-0015", nullable = true)
     private String indentNumber;
 
-    @Schema(description = "Id of the project the materials are for.", example = "3")
+    @Schema(description = "Id of the project the materials are for. The column permits null and "
+            + "rows exist without it, although the entity declares the association non-optional.",
+            example = "3", nullable = true)
     private Long projectId;
 
-    @Schema(description = "Name of the project.", example = "Asset Homes Perumbavoor Phase 2")
+    @Schema(description = "Name of the project. Null whenever projectId is, and also on a project "
+            + "that has no name recorded.", example = "Asset Homes Perumbavoor Phase 2",
+            nullable = true)
     private String projectName;
 
     @Schema(description = "Current lifecycle status of the purchase order.", example = "SENT_TO_VENDOR")
@@ -44,18 +54,27 @@ public class PurchaseOrderDto {
     @Schema(description = "Timestamp the purchase order was created.", example = "2026-01-15T10:30:00")
     private LocalDateTime createdAt;
 
-    @Schema(description = "Employee who raised the purchase order.")
+    @Schema(description = "Employee who raised the purchase order. Null on rows created before "
+            + "the author was recorded, and on any row whose author was not resolved.",
+            nullable = true)
     private EmployeeDto createdBy;
 
-    @Schema(description = "Date the vendor is expected to deliver by.", example = "2026-02-10T00:00:00")
+    @Schema(description = "Date the vendor is expected to deliver by. Null where none was agreed.",
+            example = "2026-02-10T00:00:00", nullable = true)
     private LocalDateTime expectedDeliveryDate;
 
-    @Schema(description = "Free-text remarks on the order.", example = "Deliver to Perumbavoor site, second gate")
+    @Schema(description = "Free-text remarks on the order. Null where none were written.",
+            example = "Deliver to Perumbavoor site, second gate", nullable = true)
     private String remarks;
 
-    @Schema(description = "Line items on the order.")
+    @Schema(description = "Line items on the order. Null rather than an empty array when the "
+            + "order has no lines: the mapper clears an empty list deliberately.", nullable = true)
     private List<PurchaseOrderItemDto> items;
 
-    @Schema(description = "Total value of the purchase order in INR.", example = "485000.00")
+    @Schema(description = "Total value of the purchase order in INR, summed from the line "
+            + "totals. The server writes it on every path, seeding zero at creation and treating "
+            + "a sum over no lines as zero, so a zero means no priced lines rather than an order "
+            + "worth nothing. The column still permits null, so a row written outside the "
+            + "application can carry none.", example = "485000.00", nullable = true)
     private BigDecimal totalAmount;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderItemDto.java
@@ -7,6 +7,11 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 
+/**
+ * A purchase order line as it is served inside its order. A field without
+ * {@code nullable = true} is one the schema, the mapper or the service behind it establishes
+ * as always present; see {@code ReviewedResponseSchemas} for which is which.
+ */
 @Schema(description = "A purchase order line item as embedded in a purchase order response.")
 @Data
 public class PurchaseOrderItemDto {
@@ -21,7 +26,8 @@ public class PurchaseOrderItemDto {
     @Schema(description = "Name of the material.", example = "TMT Bar Fe 500D, 12mm")
     private String materialName;
 
-    @Schema(description = "Id of the source indent item this line was converted from, if any.", example = "31")
+    @Schema(description = "Id of the source indent item this line was converted from. Null on a "
+            + "line entered directly rather than from an indent.", example = "31", nullable = true)
     private Long indentItemId;
 
     @Schema(description = "Quantity ordered.", example = "500")
@@ -32,12 +38,19 @@ public class PurchaseOrderItemDto {
     @Schema(description = "Quantity received against this line so far.", example = "0")
     private Integer receivedQuantity;
 
-    @Schema(description = "Unit price in INR.", example = "62.50")
+    @Schema(description = "Unit price in INR. Null where no price was agreed when the line was "
+            + "raised, which is not the same as a price of zero.", example = "62.50",
+            nullable = true)
     private BigDecimal unitPrice;
 
-    @Schema(description = "Total price for this line in INR.", example = "31250.00")
+    @Schema(description = "Total price for this line in INR. The server computes it on every "
+            + "write, treating a missing unit price as zero, so a zero means no price was agreed "
+            + "rather than a line that costs nothing. The column still permits null, so a row "
+            + "written outside the application can carry none.", example = "31250.00",
+            nullable = true)
     private BigDecimal totalPrice;
 
-    @Schema(description = "Free-text remarks on this line item.", example = "IS 1786 grade, mill test certificate required")
+    @Schema(description = "Free-text remarks on this line item. Null where none were written.",
+            example = "IS 1786 grade, mill test certificate required", nullable = true)
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemResponseDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemResponseDto.java
@@ -5,6 +5,11 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 
+/**
+ * A purchase order line as the item endpoints serve it. A field without
+ * {@code nullable = true} is one the schema, the mapper or the service behind it establishes
+ * as always present; see {@code ReviewedResponseSchemas} for which is which.
+ */
 @Schema(description = "A purchase order line item, returned standalone by the item endpoints.")
 @Data
 public class PurchaseOrderItemResponseDto {
@@ -24,7 +29,8 @@ public class PurchaseOrderItemResponseDto {
     @Schema(description = "Name of the material.", example = "TMT Bar Fe 500D, 12mm")
     private String materialName;
 
-    @Schema(description = "Id of the source indent item this line was converted from, if any.", example = "31")
+    @Schema(description = "Id of the source indent item this line was converted from. Null on a "
+            + "line entered directly rather than from an indent.", example = "31", nullable = true)
     private Long indentItemId;
 
     @Schema(description = "Quantity ordered.", example = "500")
@@ -33,12 +39,19 @@ public class PurchaseOrderItemResponseDto {
     @Schema(description = "Quantity received against this line so far.", example = "0")
     private Integer receivedQuantity;
 
-    @Schema(description = "Unit price in INR.", example = "62.50")
+    @Schema(description = "Unit price in INR. Null where no price was agreed when the line was "
+            + "raised, which is not the same as a price of zero.", example = "62.50",
+            nullable = true)
     private BigDecimal unitPrice;
 
-    @Schema(description = "Total price for this line in INR.", example = "31250.00")
+    @Schema(description = "Total price for this line in INR. The server computes it on every "
+            + "write, treating a missing unit price as zero, so a zero means no price was agreed "
+            + "rather than a line that costs nothing. The column still permits null, so a row "
+            + "written outside the application can carry none.", example = "31250.00",
+            nullable = true)
     private BigDecimal totalPrice;
 
-    @Schema(description = "Free-text remarks on this line item.", example = "IS 1786 grade, mill test certificate required")
+    @Schema(description = "Free-text remarks on this line item. Null where none were written.",
+            example = "IS 1786 grade, mill test certificate required", nullable = true)
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/receipt/dto/ReceiptDto.java
+++ b/src/main/java/org/tornotron/echno_backend/receipt/dto/ReceiptDto.java
@@ -7,6 +7,15 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+/**
+ * A receipt as it is served. A field without {@code nullable = true} is one the schema, the
+ * mapper or the service behind it establishes as always present; see
+ * {@code ReviewedResponseSchemas} for which is which.
+ *
+ * <p>Almost every column on this table is nullable, and the update path assigns every editable
+ * field unconditionally, so a request that omits a field clears it rather than leaving it alone.
+ * Both facts are why so much of this schema admits null.
+ */
 @Schema(description = "A receipt with its amount, payer details, tax breakdown and optional links to project and finance rows.")
 @Data
 public class ReceiptDto {
@@ -17,72 +26,107 @@ public class ReceiptDto {
     @Schema(description = "Generated receipt number.", example = "RCP-2027-000001")
     private String receiptNumber;
 
-    @Schema(description = "Kind of receipt.", example = "payment")
+    @Schema(description = "Kind of receipt, as free text the client interprets. Null where none "
+            + "was sent, including after an update that omitted the field, which clears it.",
+            example = "payment", nullable = true)
     private String type;
 
-    @Schema(description = "Lifecycle status of the receipt.", example = "issued")
+    @Schema(description = "Lifecycle status, as free text the client interprets. Null where none "
+            + "was sent, including after an update that omitted the field, which clears it.",
+            example = "issued", nullable = true)
     private String status;
 
-    @Schema(description = "Amount received in the given currency.", example = "45000.00")
+    @Schema(description = "Amount received in the given currency. Required by the create and "
+            + "update endpoints, so a null belongs to a row written outside them.",
+            example = "45000.00", nullable = true)
     private BigDecimal amount;
 
-    @Schema(description = "Currency code for the amount.", example = "INR")
+    @Schema(description = "Currency code for the amount. New receipts default to INR when the "
+            + "request omits one, so null appears only on rows stored without a currency.",
+            example = "INR", nullable = true)
     private String currency;
 
-    @Schema(description = "Date the amount was received.", example = "2026-08-20")
+    @Schema(description = "Date the amount was received. Null where none was given, including "
+            + "after an update that omitted the field.", example = "2026-08-20", nullable = true)
     private LocalDate receiptDate;
 
-    @Schema(description = "How the amount was received.", example = "Bank Transfer")
+    @Schema(description = "How the amount was received. Null where none was recorded.",
+            example = "Bank Transfer", nullable = true)
     private String paymentMethod;
 
-    @Schema(description = "External transaction reference from the bank or gateway.", example = "TXN-8842190")
+    @Schema(description = "External transaction reference from the bank or gateway. Null for "
+            + "money taken outside any such system, such as cash at the site office.",
+            example = "TXN-8842190", nullable = true)
     private String transactionId;
 
-    @Schema(description = "Cheque or internal reference number.", example = "CHQ-000231")
+    @Schema(description = "Cheque or internal reference number. Null where none was recorded.",
+            example = "CHQ-000231", nullable = true)
     private String referenceNumber;
 
-    @Schema(description = "Name of the person or company the amount was received from.", example = "Asset Homes Pvt Ltd")
+    @Schema(description = "Name of the person or company the amount was received from. Required "
+            + "by the create and update endpoints, so a null belongs to a row written outside "
+            + "them.", example = "Asset Homes Pvt Ltd", nullable = true)
     private String receivedFrom;
 
-    @Schema(description = "Address of the payer.", example = "12 MG Road, Kochi")
+    @Schema(description = "Address of the payer. Null where none was recorded.",
+            example = "12 MG Road, Kochi", nullable = true)
     private String receivedFromAddress;
 
-    @Schema(description = "Tax amount included in the receipt.", example = "8100.00")
+    @Schema(description = "Tax amount included in the receipt. Null where the receipt carries no "
+            + "tax breakdown, which leaves the tax unknown rather than zero.",
+            example = "8100.00", nullable = true)
     private BigDecimal taxAmount;
 
-    @Schema(description = "Tax rate applied, as a percentage.", example = "18.00")
+    @Schema(description = "Tax rate applied, as a percentage. Null where the receipt carries no "
+            + "tax breakdown.", example = "18.00", nullable = true)
     private BigDecimal taxRate;
 
-    @Schema(description = "Type of tax applied.", example = "GST")
+    @Schema(description = "Type of tax applied. Null where the receipt carries no tax breakdown.",
+            example = "GST", nullable = true)
     private String taxType;
 
-    @Schema(description = "What the amount was received for.", example = "Advance against Block C interior work")
+    @Schema(description = "What the amount was received for. Null where nothing was written.",
+            example = "Advance against Block C interior work", nullable = true)
     private String description;
 
-    @Schema(description = "Free-text notes.", example = "Received at site office against acknowledgement 118")
+    @Schema(description = "Free-text notes. Null where nothing was written.",
+            example = "Received at site office against acknowledgement 118", nullable = true)
     private String notes;
 
-    @Schema(description = "Id of the employee who issued the receipt.", example = "9")
+    @Schema(description = "Id of the employee who issued the receipt. Null where it was not "
+            + "captured. The column carries no foreign key, so a value may name an employee that "
+            + "no longer exists.", example = "9", nullable = true)
     private Long issuedBy;
 
-    @Schema(description = "Id of the project this receipt belongs to.", example = "3")
+    @Schema(description = "Id of the project this receipt belongs to. Null for money received "
+            + "against no project. The column carries no foreign key, so a value may name a "
+            + "project that no longer exists.", example = "3", nullable = true)
     private Long projectId;
 
-    @Schema(description = "Id of the payment this receipt records.", example = "51")
+    @Schema(description = "Id of the payment this receipt records. Null where the receipt stands "
+            + "alone. The column carries no foreign key, so a value may name a payment that no "
+            + "longer exists.", example = "51", nullable = true)
     private Long paymentId;
 
-    @Schema(description = "Id of the invoice this receipt settles.", example = "44")
+    @Schema(description = "Id of the invoice this receipt settles. Null where the money was "
+            + "received against no invoice. The column carries no foreign key, so a value may "
+            + "name an invoice that no longer exists.", example = "44", nullable = true)
     private Long invoiceId;
 
-    @Schema(description = "Id of the customer the amount was received from.", example = "12")
+    @Schema(description = "Id of the customer the amount was received from. Null where the payer "
+            + "was recorded by name only. The column carries no foreign key, so a value may name "
+            + "a customer that no longer exists.", example = "12", nullable = true)
     private Long customerId;
 
-    @Schema(description = "Id of the owning organization.", example = "1")
+    @Schema(description = "Id of the owning organization. Set on every receipt the application "
+            + "creates, so a null belongs to a row written outside it.", example = "1",
+            nullable = true)
     private Long organizationId;
 
     @Schema(description = "Timestamp the receipt was created.", example = "2026-08-20T09:00:00")
     private LocalDateTime createdAt;
 
-    @Schema(description = "Timestamp the receipt was last updated.", example = "2026-08-22T14:20:00")
+    @Schema(description = "Timestamp the receipt was last updated.",
+            example = "2026-08-22T14:20:00")
     private LocalDateTime updatedAt;
 }

--- a/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
@@ -1,5 +1,13 @@
 package org.tornotron.echno_backend.architecture;
 
+import org.tornotron.echno_backend.attendance.dto.AttendanceResponseDto;
+import org.tornotron.echno_backend.attendance.dto.ClockEventDto;
+import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
+import org.tornotron.echno_backend.payable.dto.PayableDto;
+import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderDto;
+import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderItemDto;
+import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemResponseDto;
+import org.tornotron.echno_backend.receipt.dto.ReceiptDto;
 import org.tornotron.echno_backend.vendor.dto.VendorBankAccountDto;
 import org.tornotron.echno_backend.vendor.dto.VendorContactDto;
 import org.tornotron.echno_backend.vendor.dto.VendorDto;
@@ -112,6 +120,98 @@ final class ReviewedResponseSchemas {
      *       {@code COALESCE(..., 0)}, so none of them can come back null.
      * </ul>
      *
+     * <p><b>The procurement chain: purchase order, goods received note, payable.</b> These are
+     * the three schemas {@code VendorDto} already publishes as collections, so vendor's pass
+     * declared the lists non-null while saying nothing about what is inside them. Every one of
+     * them carries money, which is where a wrong answer costs something: a client writing
+     * {@code ?? 0} on an amount turns "nobody recorded this" into a figure someone will act on.
+     *
+     * <ul>
+     *   <li>{@code PayableDto.amountDue} is the one property here that is non-null for a reason
+     *       that is not a constraint, and it is the {@code VendorSummaryDto} shape: it has no
+     *       column at all, and {@code Payable.getAmountDue()} coalesces both operands to
+     *       {@code ZERO} before subtracting. Where a nullable column does exist, the column wins
+     *       even when the application writes the value on every path. That is the line taken for
+     *       {@code PurchaseOrderDto.totalAmount} (seeded at zero on creation, recomputed from a
+     *       coalesced {@code SUM}) and for {@code totalPrice} on both line schemas (computed on
+     *       every write with a missing unit price read as zero): all three are recorded nullable,
+     *       with the computation named in the description, because nothing in the contract can
+     *       promise a row was written through the application. The same line makes
+     *       {@code PayableDto.createdAt} nullable. In each of these a zero means "no figure was
+     *       agreed" rather than "the amount is nothing", which the descriptions say.
+     *   <li>{@code items} on {@code PurchaseOrderDto} and {@code GoodsReceivedNoteDto} is
+     *       nullable because of the mapper, not the schema. Both entity collections are
+     *       initialised and can never be null, and both mappers carry an {@code @AfterMapping}
+     *       that replaces an empty list with null on purpose.
+     *   <li>{@code projectId} and {@code projectName} are nullable on all three schemas, and this
+     *       is the trap the vendor pass warned about. {@code Payable}, {@code PurchaseOrder} and
+     *       {@code GoodsReceivedNote} each declare
+     *       {@code @JoinColumn(name = "project_id", nullable = false)} while the Liquibase column
+     *       is nullable in every case, and no {@code addNotNullConstraint} anywhere in the
+     *       changelog names a {@code project_id}. {@code ddl-auto} is {@code validate}, which
+     *       does not compare nullability, so nothing reports it. The changelog wins.
+     *       {@code projectName} is nullable twice over, since {@code project.project_name} is
+     *       itself a nullable column.
+     *   <li>A flattened name is null exactly when its foreign key is: {@code vendorName},
+     *       {@code grnNumber}, {@code indentNumber}, {@code purchaseOrderNumber},
+     *       {@code storageLocationName} and {@code materialName} all map through an association
+     *       whose own name column is {@code NOT NULL}.
+     *   <li>{@code PayableDto.createdAt} is nullable where the same field on
+     *       {@code PurchaseOrderDto} and {@code ReceiptDto} is not. Its column permits null while
+     *       theirs do not; {@code @CreationTimestamp} fills it on every insert the application
+     *       makes, but the contract cannot promise how a row reached the table. Making
+     *       {@code payable.created_at} {@code NOT NULL} would move it to the non-null half.
+     *   <li>{@code GoodsReceivedNoteDto.overReceiptAcknowledged} is a primitive {@code boolean} on
+     *       the DTO, so Jackson could not emit null for it whatever the source held. The
+     *       {@code NOT NULL} column agrees rather than causes it.
+     * </ul>
+     *
+     * <p><b>Attendance.</b> Picked because a wrong answer here has already cost something: a
+     * client wrote {@code ?? false} against {@code ClockEventDto.isWithinGeofence} on the
+     * strength of the document saying nothing, which turns "the geofence was never evaluated"
+     * into "the worker was outside the site".
+     *
+     * <ul>
+     *   <li>{@code isWithinGeofence} is a boxed {@code Boolean} with three states, and null is
+     *       the ordinary one: {@code AttendanceService.applyGeofence} evaluates only a
+     *       self-marked punch, so every punch a supervisor records for a team member is
+     *       unevaluated, as is one with no position, one on a project with no coordinates, and
+     *       every event written by a regularization. Changeset {@code 087-01} dropped the old
+     *       {@code NOT NULL} and {@code false} default and {@code 087-02} backfilled the existing
+     *       rows to null precisely so that a placeholder {@code false} could not be read as a
+     *       measured verdict. {@code distanceFromProject} and {@code geofenceRadiusMeters} are
+     *       written from the same evaluation, so the three are null together or set together.
+     *   <li>The five session-minute fields are nullable for a reason that is neither the column
+     *       nor the mapper. {@code Attendance} is a {@code @Builder} class and those five fields
+     *       carry an inline {@code = 0} with no {@code @Builder.Default}, so Lombok discards the
+     *       initialiser and the builder writes null. Nothing then fills them until
+     *       {@code AttendanceCalculationService.recalculate} runs, which never happens on a
+     *       record raised by marking someone absent or on leave, or on one with no shift. Null
+     *       there means the day was not computed, which is not zero minutes worked.
+     *   <li>{@code photoUrl}, {@code verifiedBy} and {@code verifiedAt} on
+     *       {@code ClockEventDto} are null on every response ever served. The mapper declares
+     *       {@code @Mapping(target = "photoUrl", ignore = true)} and nothing in {@code src/main}
+     *       writes the other two on a clock event. They are recorded as nullable and their
+     *       descriptions say plainly that they are not populated, rather than implying a flow
+     *       that does not exist.
+     *   <li>The collections ({@code clockEvents}, {@code regularizations}, {@code movements},
+     *       {@code attachments}) are non-null because the entity initialises each and marks it
+     *       {@code @Builder.Default}. They are routinely empty, which is a normal state.
+     *   <li>{@code createdAt} and {@code updatedAt} are nullable on the same reading as
+     *       {@code PayableDto.createdAt}: both columns permit null and only Hibernate's timestamp
+     *       callbacks fill them.
+     * </ul>
+     *
+     * <p><b>Receipts.</b> Money received, and the schema where silence was worth the least: 21 of
+     * its 25 properties admit null. Two reasons compound. Almost every column on {@code receipts}
+     * is nullable, including {@code amount}; and {@code ReceiptService.applyFields} runs on
+     * create and update alike and assigns every editable scalar unconditionally, so an update
+     * that omits a field clears it rather than leaving it alone ({@code currency} is the one
+     * exception, guarded against a null). The five id columns ({@code issuedBy},
+     * {@code projectId}, {@code paymentId}, {@code invoiceId}, {@code customerId}) carry no
+     * foreign key at all, so a value there may name a row that no longer exists, which the
+     * descriptions say.
+     *
      * @return The reviewed schemas.
      */
     static List<ReviewedSchema> schemas() {
@@ -145,6 +245,63 @@ final class ReviewedResponseSchemas {
                         Set.of("vendorId", "vendorName", "purchaseOrderCount",
                                 "totalPurchaseOrderValue", "totalAmountRecorded",
                                 "totalAmountPaid", "outstandingAmount", "grnCount",
-                                "totalInvoiceAmount")));
+                                "totalInvoiceAmount")),
+                new ReviewedSchema(
+                        PurchaseOrderDto.class,
+                        Set.of("indentId", "indentNumber", "projectId", "projectName",
+                                "createdBy", "expectedDeliveryDate", "remarks", "items",
+                                "totalAmount"),
+                        Set.of("id", "poNumber", "vendorId", "vendorName", "status",
+                                "createdAt")),
+                new ReviewedSchema(
+                        PurchaseOrderItemDto.class,
+                        Set.of("indentItemId", "unitPrice", "totalPrice", "remarks"),
+                        Set.of("id", "materialId", "materialName", "orderedQuantity",
+                                "receivedQuantity")),
+                new ReviewedSchema(
+                        PurchaseOrderItemResponseDto.class,
+                        Set.of("indentItemId", "unitPrice", "totalPrice", "remarks"),
+                        Set.of("id", "purchaseOrderId", "poNumber", "materialId", "materialName",
+                                "orderedQuantity", "receivedQuantity")),
+                new ReviewedSchema(
+                        GoodsReceivedNoteDto.class,
+                        Set.of("receivedBy", "vendorId", "vendorName", "purchaseOrderId",
+                                "purchaseOrderNumber", "deliveryChallanNumber", "invoiceNumber",
+                                "invoiceAmount", "projectId", "projectName", "storageLocationId",
+                                "storageLocationName", "items"),
+                        Set.of("id", "grnNumber", "receivedOn", "overReceiptAcknowledged")),
+                new ReviewedSchema(
+                        PayableDto.class,
+                        Set.of("contractType", "amountRecorded", "amountPaid", "vendorId",
+                                "vendorName", "goodsReceivedNoteId", "grnNumber", "projectId",
+                                "projectName", "createdBy", "createdAt"),
+                        Set.of("id", "payableNumber", "contractorName", "amountDue")),
+                new ReviewedSchema(
+                        ReceiptDto.class,
+                        Set.of("type", "status", "amount", "currency", "receiptDate",
+                                "paymentMethod", "transactionId", "referenceNumber",
+                                "receivedFrom", "receivedFromAddress", "taxAmount", "taxRate",
+                                "taxType", "description", "notes", "issuedBy", "projectId",
+                                "paymentId", "invoiceId", "customerId", "organizationId"),
+                        Set.of("id", "receiptNumber", "createdAt", "updatedAt")),
+                new ReviewedSchema(
+                        AttendanceResponseDto.class,
+                        Set.of("shiftTiming", "totalWorkMinutes", "morningSessionMinutes",
+                                "afternoonSessionMinutes", "overtimeMinutes",
+                                "breakDurationMinutes", "leaveId", "leaveType", "approvedBy",
+                                "approvedById", "approvedAt", "geofenceApproverId", "remarks",
+                                "createdAt", "updatedAt"),
+                        Set.of("id", "employeeId", "employeeName", "attendanceDate", "projectId",
+                                "projectName", "status", "clockEvents", "isLateArrival",
+                                "isEarlyCheckout", "isOvertime", "regularizations", "movements",
+                                "approvalStatus", "requiresGeofenceApproval")),
+                new ReviewedSchema(
+                        ClockEventDto.class,
+                        Set.of("latitude", "longitude", "gpsAccuracy", "photoUrl",
+                                "devicePlatform", "isWithinGeofence", "distanceFromProject",
+                                "geofenceRadiusMeters", "geofenceExceptionReason", "recordedById",
+                                "remarks", "verifiedBy", "verifiedAt", "regularizationReason"),
+                        Set.of("id", "eventType", "eventTimestamp", "projectId", "projectName",
+                                "isRegularized", "attachments")));
     }
 }


### PR DESCRIPTION
Contributes to #645. Three more modules through the ratchet #678 built.

## Which modules, and why these

Picked by what a wrong answer costs a client, not by what was quickest to read.

- **The procurement chain** (`PurchaseOrderDto`, `PurchaseOrderItemDto`, `PurchaseOrderItemResponseDto`, `GoodsReceivedNoteDto`, `PayableDto`). These are exactly the schemas `VendorDto` already publishes as collections, so the vendor pass declared `goodsReceivedNotes`, `purchaseOrders` and `payables` non-null while saying nothing about what is inside them. Every one carries money.
- **`ReceiptDto`**, money coming in, and the schema where the silence was worth least: 21 of its 25 properties admit null, including `amount`.
- **Attendance** (`AttendanceResponseDto`, `ClockEventDto`), where a wrong answer has already cost something. A client wrote `?? false` against `isWithinGeofence` on the strength of the document saying nothing, which turns "the geofence was never evaluated" into "the worker was outside the site".

## Counts

| schema | nullable | of |
|---|---|---|
| `PurchaseOrderDto` | 9 | 15 |
| `PurchaseOrderItemDto` | 4 | 9 |
| `PurchaseOrderItemResponseDto` | 4 | 11 |
| `GoodsReceivedNoteDto` | 13 | 17 |
| `PayableDto` | 11 | 15 |
| `ReceiptDto` | 21 | 25 |
| `AttendanceResponseDto` | 15 | 30 |
| `ClockEventDto` | 14 | 21 |
| **total** | **91** | **143** |

## What the derivation turned up

**The entity is wrong about the project in three places.** `Payable`, `PurchaseOrder` and `GoodsReceivedNote` each declare `@JoinColumn(name = "project_id", nullable = false)` while the Liquibase column is nullable in all three, and no `addNotNullConstraint` anywhere in the changelog names a `project_id`. `ddl-auto` is `validate`, which does not compare nullability, so nothing reports it. This is the trap the vendor pass warned the next module about, and it is present three times. `projectName` is nullable twice over, since `project.project_name` is itself a nullable column.

**Five `Attendance` fields are null where the code plainly means zero.** `totalWorkMinutes`, `morningSessionMinutes`, `afternoonSessionMinutes`, `overtimeMinutes` and `breakDurationMinutes` carry an inline `= 0` with no `@Builder.Default` on a `@Builder` class, so Lombok discards the initialiser and the builder writes null. Nothing fills them until `AttendanceCalculationService.recalculate` runs, which never happens on a record raised by marking someone absent or on leave, or on one with no shift. Null there means the day was not computed, which is not zero minutes worked. (`approvalStatus` has the same missing `@Builder.Default`, but its column is `NOT NULL`, so a miss would fail the insert rather than reach the contract.)

**Where the line was drawn on "non-null for a reason that is not a constraint".** Only `PayableDto.amountDue` gets that treatment here, and it is the `VendorSummaryDto` shape exactly: no column at all, and `getAmountDue()` coalesces both operands to zero. Where a nullable column *does* exist, the column wins even though the application writes the value on every path. That applies to `PurchaseOrderDto.totalAmount` (seeded at zero, recomputed from a coalesced `SUM`), `totalPrice` on both line schemas (computed on every write with a missing unit price read as zero), and `createdAt` on `PayableDto` and `AttendanceResponseDto`. Each description names the computation and says what a zero there means, so the weaker claim costs a reader nothing while keeping the contract to what the schema can back.

That distinction matters because a zero in these fields means "no figure was agreed" rather than "the amount is nothing", which is the same confusion `creditLimit` raised this issue over.

**`items` is nullable by mapper, not by column.** Both `PurchaseOrderMapper` and `GoodsReceivedNoteMapper` carry an `@AfterMapping` that replaces an empty list with null on purpose. The entity collections are initialised and can never be null, so a client cannot read a length without a guard.

**Three fields are null on every response ever served.** `ClockEventDto.photoUrl` is `@Mapping(target = "photoUrl", ignore = true)` with no other writer, and nothing in `src/main` writes `verifiedBy` or `verifiedAt` on a clock event. They are recorded as nullable and described as not populated, rather than left implying a flow that does not exist. Worth a separate decision on whether they should stay on the DTO.

**The geofence three move as one.** `isWithinGeofence` is a boxed `Boolean` with three states, and null is the ordinary one: only a self-marked punch is evaluated, so every punch a supervisor records for a team member is unevaluated, as is one with no position, one on a project with no coordinates, and every event a regularization wrote. Changeset `087-01` dropped the old `NOT NULL` and `false` default and `087-02` backfilled the existing rows to null precisely so a placeholder `false` could not read as a measured verdict. `distanceFromProject` and `geofenceRadiusMeters` are written from the same evaluation, so a client can test any one of the three.

**Receipts clear on update.** `ReceiptService.applyFields` runs on create and update alike and assigns every editable scalar unconditionally, so a request that omits a field clears it (`currency` is the one exception). The five id columns carry no foreign key, so a value may name a row that no longer exists. Both facts are in the descriptions.

## What was scoped out, deliberately

- **`finance`** (23 schemas, 239 properties) is the largest response-only module and the obvious next one for money, but it would have doubled this diff. Not touched.
- **The schemas these eight reference** stay unreviewed: `EmployeeDto`, `GrnItemDto`, `ShiftTimingDto`, `MovementRecordDto`, `AttendanceRegularizationDto`, `AttachmentDto`. The ratchet classifies whether the reference itself can be null, which is what a client needs here; it does not require the target schema to be reviewed.
- **The request side** is untouched, as in #670 and #678.

The diff is larger than the vendor pass because these modules are genuinely more nullable, not because the scope drifted: 91 of 143 properties admit null, against vendor's 14 of 48. Descriptions were added only where a property is nullable or where a non-null answer needed its non-obvious reason recorded.

## Verification

There is no container runtime on this workstation, so nothing was run locally and CI is the check. What was verified here:

- The document was updated by applying `NullableSchemaCustomizer`'s exact transformation to the committed file, with a serializer proved byte-faithful by round-tripping `docs/openapi.json` unchanged, and a patcher proved correct by stripping the vendor pass's 14 properties and reproducing the committed document byte for byte.
- Document diff audited semantically: **95 properties changed, 0 added, 0 removed, `paths` byte-identical**, nothing outside the eight schemas touched.
- `ResponseNullabilityRatchetTest` and `OpenApiNullabilityTest` were simulated over all 14 reviewed schemas (table against annotation against document, in both directions): both pass.
- The changed sources parse under `javac 21`; the only errors are classpath resolution.

`openApiSnapshot` in CI is the real check on the document, and thanks to #723 a green run now publishes the canonical document as an artifact either way.

## Follow-ups this surfaced, not fixed here

1. The three `@JoinColumn(nullable = false)` annotations that disagree with their column. Either the annotations are wrong or the columns should be `NOT NULL`; both need a decision and the second needs a null sweep.
2. The six missing `@Builder.Default` annotations on `Attendance`.
3. `payable.created_at` is nullable while `purchase_order.created_at` and `receipts.created_at` are not.
4. Whether `ClockEventDto.photoUrl`, `verifiedBy` and `verifiedAt` should stay on the DTO.

https://claude.ai/code/session_018LUw1wk1SqVZN55TQDKRHn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API response documentation to accurately identify fields that may be returned as `null`.
  - Clarified when attendance, clock event, procurement, payable, and receipt values may be unavailable or unset.
  - Documented null behavior for optional relationships, collections, pricing, approval details, locations, tax information, and lifecycle fields.
  - Improved descriptions for purchase order and goods receipt data, including direct-entry and externally recorded records.
- **API Consistency**
  - Standardized nullability information across supported response schemas for more predictable API integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->