### PR TITLE
Make org role holders members, and sweep the 36 guards whose role clause is dead

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
@@ -55,7 +55,7 @@ public class IssueCommentControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List issue comments",
             description = "Returns a single page of issue comments. The pageNo and pageSize parameters "
@@ -71,7 +71,7 @@ public class IssueCommentControllerWeb {
     }
 
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get an issue comment by id",
             description = "Returns a single issue comment."
@@ -86,7 +86,7 @@ public class IssueCommentControllerWeb {
     }
 
     @GetMapping("/issueId/{issueId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List comments for an issue",
             description = "Returns every comment left on the given issue."

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -45,7 +45,7 @@ public class AssetControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List all assets",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -59,7 +59,7 @@ public class AssetControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List assets, paginated",
             description = "Returns a page of assets for the caller's current tenant organization. The "
@@ -75,7 +75,7 @@ public class AssetControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get an asset by id",
             description = "Returns a single asset, including its resolved vendor and storage location."
@@ -143,7 +143,7 @@ public class AssetControllerWeb {
     }
 
     @GetMapping("/{id}/movements")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Read an asset's movement ledger",
             description = "Returns a page of the asset's movement entries, newest first: what moved, "
@@ -160,7 +160,7 @@ public class AssetControllerWeb {
     }
 
     @GetMapping("/{id}/placement-history")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Read how long an asset spent in each place",
             description = "Turns consecutive ledger entries into the stretches of time the asset "
@@ -181,7 +181,7 @@ public class AssetControllerWeb {
     }
 
     @GetMapping("/{id}/documents")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List an asset's documents",
             description = "Returns the files filed against the asset: purchase invoice, warranty, "
@@ -201,7 +201,7 @@ public class AssetControllerWeb {
     }
 
     @GetMapping("/documents/expiring")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List asset documents that are about to expire",
             description = "Returns every asset document in the organization whose expiry falls on or "

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
@@ -75,7 +75,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the list of category DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List categories",
             description = "Returns a single page of work categories. The pageNo and pageSize parameters "
@@ -99,7 +99,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the category DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a category by id",
             description = "Returns a single work category."

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -924,20 +924,14 @@ public class KeycloakInitializer {
             return 0;
         }
 
-        Set<String> members = new HashSet<>();
-        List<UserRepresentation> parentMembers =
-                admin.realm(REALM_ID).groups().group(orgGroup.getId()).members(0, GROUP_MEMBER_PAGE);
-        if (parentMembers != null) {
-            parentMembers.stream().map(UserRepresentation::getId).filter(java.util.Objects::nonNull).forEach(members::add);
-        }
+        // Every member, not the first page of them. A truncated parent listing would make the
+        // reconcile treat existing members as repairs: harmless in effect, since joinGroup is
+        // idempotent, but it would report work that was not needed and hide work that was.
+        Set<String> members = new HashSet<>(allMembersOf(orgGroup.getId()));
 
         int repaired = 0;
         for (GroupRepresentation roleSubgroup : roleSubgroups) {
-            List<UserRepresentation> roleHolders =
-                    admin.realm(REALM_ID).groups().group(roleSubgroup.getId()).members(0, GROUP_MEMBER_PAGE);
-            if (roleHolders == null) {
-                continue;
-            }
+            List<UserRepresentation> roleHolders = allMemberRepresentationsOf(roleSubgroup.getId());
             for (UserRepresentation roleHolder : roleHolders) {
                 if (roleHolder.getId() == null || !members.add(roleHolder.getId())) {
                     continue;
@@ -949,6 +943,32 @@ public class KeycloakInitializer {
             }
         }
         return repaired;
+    }
+
+    /** Every member of a group, paged, since a group listing returns one page at a time. */
+    private List<UserRepresentation> allMemberRepresentationsOf(String groupId) {
+        List<UserRepresentation> all = new ArrayList<>();
+        int first = 0;
+        while (true) {
+            List<UserRepresentation> page =
+                    admin.realm(REALM_ID).groups().group(groupId).members(first, GROUP_MEMBER_PAGE);
+            if (page == null || page.isEmpty()) {
+                return all;
+            }
+            all.addAll(page);
+            if (page.size() < GROUP_MEMBER_PAGE) {
+                return all;
+            }
+            first += page.size();
+        }
+    }
+
+    /** The ids of every member of a group. */
+    private Set<String> allMembersOf(String groupId) {
+        return allMemberRepresentationsOf(groupId).stream()
+                .map(UserRepresentation::getId)
+                .filter(java.util.Objects::nonNull)
+                .collect(java.util.stream.Collectors.toSet());
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -247,6 +247,8 @@ public class KeycloakInitializer {
         syncRealmSecuritySettings();
         // Ensure admin-only MFA (conditional TOTP) is codified even if realm exists
         ensureAdminMfa();
+        // Repair any org role held without membership of the organization that role names
+        ensureOrgRoleHoldersAreMembers();
         // Ensure service account roles are assigned even if realm exists
         assignServiceAccountRoles();
         // Ensure authorization setup (JS policy, resource, permission) exists
@@ -865,6 +867,91 @@ public class KeycloakInitializer {
     }
 
     /**
+     * Adds the parent organization membership to anyone who holds a role subgroup beneath an
+     * {@code org-*} group without it, on every startup.
+     *
+     * <p>Keycloak stores membership of {@code /org-5} and of {@code /org-5/system-admin} as two
+     * independent rows, so the two can come apart. {@code JwtAuthConverter} then mints
+     * {@code ORG_5_ROLE_system-admin} with no {@code ORG_MEMBER_5} beside it, and
+     * {@code TenantFilter} resolves a tenant from the membership authority alone: the holder is
+     * refused on every endpoint, including the ones their role names. The application no longer
+     * produces that state, since {@code KeycloakGroupService} grants membership with the role and
+     * clears the role subgroups with the membership. This is the other half, for a realm that
+     * already holds it, which the QA seed can carry in because it replays a captured export
+     * verbatim.
+     *
+     * <p>Deliberately one-directional and minimal: it adds the membership the role already
+     * implies and never grants, removes or alters a role, a credential or an account. Membership
+     * is the weaker of the two, so adding it can only widen a caller's access to an organization
+     * they were already recorded as an administrator of. Where a role turns out to be the thing
+     * that should not be there, the fix is to remove the role, which is a decision for whoever
+     * owns the organization rather than for a startup reconcile.
+     *
+     * <p>Guarded like the rest of the reconcile: a failure logs and never aborts startup.
+     */
+    /** Page size for a group's member listing, matching the subgroup walk above. */
+    private static final int GROUP_MEMBER_PAGE = 1000;
+
+    private void ensureOrgRoleHoldersAreMembers() {
+        try {
+            List<GroupRepresentation> orgGroups = admin.realm(REALM_ID).groups().groups().stream()
+                    .filter(group -> group.getName() != null && group.getName().startsWith("org-"))
+                    .toList();
+            if (orgGroups.isEmpty()) {
+                log.info("No 'org-*' groups found yet; no role memberships to reconcile");
+                return;
+            }
+
+            int repaired = 0;
+            for (GroupRepresentation orgGroup : orgGroups) {
+                repaired += ensureRoleHoldersAreMembersOf(orgGroup);
+            }
+            if (repaired == 0) {
+                log.info("Every org role holder is a member of the organization their role names");
+            } else {
+                log.warn("Added the missing organization membership for {} org role holder(s)", repaired);
+            }
+        } catch (Exception e) {
+            log.error("Failed to reconcile org role holders against organization membership: {}", e.getMessage());
+        }
+    }
+
+    /** @return how many users were added to this organization's parent group. */
+    private int ensureRoleHoldersAreMembersOf(GroupRepresentation orgGroup) {
+        List<GroupRepresentation> roleSubgroups =
+                admin.realm(REALM_ID).groups().group(orgGroup.getId()).getSubGroups(0, 1000, false);
+        if (roleSubgroups == null || roleSubgroups.isEmpty()) {
+            return 0;
+        }
+
+        Set<String> members = new HashSet<>();
+        List<UserRepresentation> parentMembers =
+                admin.realm(REALM_ID).groups().group(orgGroup.getId()).members(0, GROUP_MEMBER_PAGE);
+        if (parentMembers != null) {
+            parentMembers.stream().map(UserRepresentation::getId).filter(java.util.Objects::nonNull).forEach(members::add);
+        }
+
+        int repaired = 0;
+        for (GroupRepresentation roleSubgroup : roleSubgroups) {
+            List<UserRepresentation> roleHolders =
+                    admin.realm(REALM_ID).groups().group(roleSubgroup.getId()).members(0, GROUP_MEMBER_PAGE);
+            if (roleHolders == null) {
+                continue;
+            }
+            for (UserRepresentation roleHolder : roleHolders) {
+                if (roleHolder.getId() == null || !members.add(roleHolder.getId())) {
+                    continue;
+                }
+                admin.realm(REALM_ID).users().get(roleHolder.getId()).joinGroup(orgGroup.getId());
+                repaired++;
+                log.warn("User '{}' held '{}' without membership of '{}'; membership added",
+                        roleHolder.getUsername(), roleSubgroup.getPath(), orgGroup.getPath());
+            }
+        }
+        return repaired;
+    }
+
+    /**
      * The fresh-realm content pipeline, run through {@link #admin}. Realm creation itself is handled
      * separately in {@link #bootstrapWithMaster} because it is the one step that needs the master
      * credential.
@@ -874,6 +961,7 @@ public class KeycloakInitializer {
         assignServiceAccountRoles();
         ensureAuthorizationSetup();
         ensureAdminMfa();
+        ensureOrgRoleHoldersAreMembers();
         ensureCompositeJobRoles();
         ensureDevClient();
     }

--- a/src/main/java/org/tornotron/echno_backend/common/service/KeycloakGroupService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/KeycloakGroupService.java
@@ -108,10 +108,28 @@ public class KeycloakGroupService {
         }
     }
 
+    /**
+     * Removes a user from an organization: every role subgroup first, then the parent group.
+     *
+     * <p>The role subgroups have to go too, and that is the whole point of this method rather
+     * than an incidental tidy-up. Keycloak records membership of {@code /org-5} and of
+     * {@code /org-5/system-admin} as two independent rows, so leaving the parent leaves the
+     * subgroup untouched. A user offboarded that way keeps the {@code ORG_5_ROLE_system-admin}
+     * authority and loses only {@code ORG_MEMBER_5}, which is the one state the whole authority
+     * model has no answer for: {@code TenantFilter} resolves a tenant from the membership
+     * authority, so the leftover role decides nothing today, and it would decide everything the
+     * moment anything started reading a role as entitlement on its own.
+     *
+     * <p>Roles are cleared before membership so that a failure part-way through leaves the
+     * weaker state rather than the stronger one. Subgroups are found by path rather than from
+     * {@link OrgRole}, so a subgroup created by hand in Keycloak is removed as well.
+     */
     public void removeUserFromOrganization(String userId, String organizationId) {
         Keycloak keycloak = getKeycloakAdminClient();
 
         try {
+            removeAllOrgRoleSubgroupMemberships(keycloak, userId, organizationId);
+
             String groupId = findOrgGroupId(keycloak, organizationId);
             if (groupId == null) {
                 log.warn("Cannot remove user from organization: organization group 'org-{}' not found in Keycloak", organizationId);
@@ -121,6 +139,26 @@ public class KeycloakGroupService {
             log.info("Removed user {} from organization group 'org-{}'", userId, organizationId);
         } finally {
             keycloak.close();
+        }
+    }
+
+    /**
+     * Takes the user out of every role subgroup beneath {@code org-{organizationId}}.
+     *
+     * <p>Reads the user's own group list and filters it by path, so it covers roles that are no
+     * longer in {@link OrgRole} and subgroups an operator added by hand, neither of which a loop
+     * over the enum would reach.
+     */
+    private void removeAllOrgRoleSubgroupMemberships(Keycloak keycloak, String userId, String organizationId) {
+        String subgroupPathPrefix = "/org-" + organizationId + "/";
+
+        List<GroupRepresentation> roleSubgroups = keycloak.realm(realm).users().get(userId).groups().stream()
+                .filter(group -> group.getPath() != null && group.getPath().startsWith(subgroupPathPrefix))
+                .toList();
+
+        for (GroupRepresentation subgroup : roleSubgroups) {
+            keycloak.realm(realm).users().get(userId).leaveGroup(subgroup.getId());
+            log.info("Removed user {} from role subgroup '{}'", userId, subgroup.getPath());
         }
     }
 
@@ -172,9 +210,18 @@ public class KeycloakGroupService {
      * After this, the user's next JWT will include "/org-5/system-admin" in the
      * groups claim, which JwtAuthConverter converts to authority "ORG_5_ROLE_system-admin".
      *
-     * NOTE: The user must ALSO be a member of the org (via addUserToOrganization).
-     * Role assignment and membership are separate: a user can be a member without
-     * any role, but should not have a role without being a member.
+     * Parent membership is granted here as well, so the "should not" below is enforced rather
+     * than merely documented. A user can be a member with no role; a user with a role is always
+     * a member. That direction is what the rest of the authority model is built on:
+     * {@code TenantFilter} resolves the tenant from {@code ORG_MEMBER_{id}} alone, so a role
+     * held without membership resolves nothing and the holder is refused everywhere, including
+     * on the endpoints their role names. Granting both together is what keeps that a statement
+     * about a state that cannot arise instead of one about a state nobody has hit yet.
+     * {@code joinGroup} is idempotent, so this costs one call on a user who is already a member.
+     *
+     * <p>Role assignment and membership remain separate operations: this adds membership, it
+     * does not make {@link #addUserToOrganization} redundant, and removing a role still leaves
+     * membership alone.
      *
      * A subgroup that does not exist yet is created here rather than refused. The
      * subgroups are created from OrgRole when an organization is created, so an
@@ -195,6 +242,8 @@ public class KeycloakGroupService {
 
             String subgroupId = ensureRoleSubgroup(keycloak, orgGroupId, organizationId, role);
 
+            // Membership before the role, so a failure between the two leaves the weaker state.
+            keycloak.realm(realm).users().get(userId).joinGroup(orgGroupId);
             keycloak.realm(realm).users().get(userId).joinGroup(subgroupId);
             log.info("Assigned role '{}' to user {} in organization {}", role.getGroupName(), userId, organizationId);
 

--- a/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
@@ -229,6 +229,28 @@ public class OrganizationSecurityService {
         return isMember(orgId);
     }
 
+    /**
+     * Whether the caller holds one of these roles in the organization this request is scoped to.
+     *
+     * <p><b>This implies {@link #isMemberOfCurrentTenant()}, so do not write the two with
+     * {@code or}.</b> Both open on {@code TenantContext.getCurrentOrgId()} and refuse a null one,
+     * and {@code TenantFilter} sets it only after confirming an {@code ORG_MEMBER_{id}} authority,
+     * on both the header branch and the inference branch. A role-holder who is not a member
+     * therefore arrives with no organization in force and fails both clauses, so
+     * {@code "member or role"} decides on membership alone and reads as a two-part guard while
+     * behaving as a one-part one. That is what #709 found and #717 swept out of ten more
+     * controllers; anyone restoring the clause as a fix will be restoring the same illusion.
+     *
+     * <p>The split it was written for, a user in {@code /org-5/system-admin} but not
+     * {@code /org-5}, is now prevented rather than tolerated: {@code KeycloakGroupService} grants
+     * parent membership with any role and clears the role subgroups with the membership, and
+     * {@code KeycloakInitializer} repairs a realm that already holds the split on startup. Use
+     * this where the role is what decides, and {@link #isMemberOfCurrentTenant()} where mere
+     * membership is enough. Combining them with {@code and} is meaningful; with {@code or} it is
+     * not.
+     *
+     * @param roles one or more role names, matching the Keycloak subgroup names
+     */
     public boolean hasAnyOrgRoleForCurrentTenant(String... roles) {
         Long orgId = TenantContext.getCurrentOrgId();
         if (orgId == null) {

--- a/src/main/java/org/tornotron/echno_backend/expense/ExpenseControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/expense/ExpenseControllerWeb.java
@@ -39,7 +39,7 @@ public class ExpenseControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List all expenses",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -54,7 +54,7 @@ public class ExpenseControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List expenses, paginated and filterable",
             description = "Returns a single page of expenses. Supports a free-text search over the expense "
@@ -72,7 +72,7 @@ public class ExpenseControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get an expense by id",
             description = "Returns a single expense with its category, amount and optional links."

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -51,7 +51,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List all issues",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -66,7 +66,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List issues, paginated and filtered",
             description = "Returns a single page of issues, optionally filtered by project, a free-text "
@@ -90,7 +90,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("/stats")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get issue counts",
             description = "Returns the total matching issue count and a per-status breakdown, computed "
@@ -109,7 +109,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("/project/{projectId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List issues for a project",
             description = "Returns every issue raised against tasks belonging to the given project."
@@ -124,7 +124,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get an issue by id",
             description = "Returns a single issue including its comments and attachments."
@@ -187,7 +187,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("/taskId/{taskId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List issues for a task",
             description = "Returns every issue raised against the given task."

--- a/src/main/java/org/tornotron/echno_backend/receipt/ReceiptControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/receipt/ReceiptControllerWeb.java
@@ -39,7 +39,7 @@ public class ReceiptControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List all receipts",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -54,7 +54,7 @@ public class ReceiptControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List receipts, paginated and filterable",
             description = "Returns a single page of receipts. Supports a free-text search over the receipt "
@@ -72,7 +72,7 @@ public class ReceiptControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a receipt by id",
             description = "Returns a single receipt with its payer, tax breakdown and optional links."

--- a/src/main/java/org/tornotron/echno_backend/search/SearchController.java
+++ b/src/main/java/org/tornotron/echno_backend/search/SearchController.java
@@ -52,7 +52,7 @@ public class SearchController {
      * @return The matching hits, grouped by kind and ranked within each.
      */
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Search projects, tasks and issues",
             description = "Returns records of any of the three kinds whose name contains the term, "

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -48,7 +48,7 @@ public class StockAdjustmentControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List all stock adjustments",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -62,7 +62,7 @@ public class StockAdjustmentControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List stock adjustments, paginated",
             description = "Returns a single page of stock adjustments ordered by creation time, most recent "
@@ -78,7 +78,7 @@ public class StockAdjustmentControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a stock adjustment by id",
             description = "Returns a single stock adjustment document, including its header fields and line "
@@ -94,7 +94,7 @@ public class StockAdjustmentControllerWeb {
     }
 
     @GetMapping("/by-source-document")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List the stock adjustments raised to answer one document",
             description = "Returns the adjustments naming the given source document, most recently "

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
@@ -38,7 +38,7 @@ public class SubContractControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List all subcontracts",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -53,7 +53,7 @@ public class SubContractControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List subcontracts, paginated and filterable",
             description = "Returns a single page of subcontracts. Supports a free-text search over "
@@ -72,7 +72,7 @@ public class SubContractControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a subcontract by id",
             description = "Returns a single subcontract, including its milestones, ratings and payment totals."

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -104,7 +104,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} containing the task DTOs and the count headers.
      */
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List tasks",
             description = "Returns the current tenant's tasks as a bare array, capped at "
@@ -134,7 +134,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} containing the page of task DTOs.
      */
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List tasks, paginated and filtered",
             description = "Returns a single page of tasks with the paging metadata included, "
@@ -153,7 +153,7 @@ public class TaskControllerWeb {
     }
 
     @GetMapping("/projectId/{projectId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List tasks for a project",
             description = "Returns every task belonging to the given project."
@@ -174,7 +174,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} containing the task DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a task by id",
             description = "Returns a single task including its creator, assignees, category, issues and "

--- a/src/test/java/org/tornotron/echno_backend/architecture/OrgRoleGuardRedundancyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/OrgRoleGuardRedundancyTest.java
@@ -1,0 +1,89 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+/**
+ * Forbids the guard that reads as two checks and decides as one:
+ * {@code isMemberOfCurrentTenant() or hasAnyOrgRoleForCurrentTenant(...)}.
+ *
+ * <p>The role clause cannot change the outcome of that expression. Both sides open on
+ * {@code TenantContext.getCurrentOrgId()} and refuse a null one, and {@code TenantFilter} sets it
+ * only after confirming an {@code ORG_MEMBER_{id}} authority. A role-holder who is not a member
+ * arrives with no organization in force and fails both clauses, so the guard decides on
+ * membership alone while looking as though a role is enforced. #709 found the first, #717 swept
+ * 36 more out of ten controllers, and both were written in good faith by someone reading the
+ * expression rather than the filter.
+ *
+ * <p>The reason this is a rule and not a one-off cleanup is that the expression is easy to write
+ * and its emptiness is invisible at the call site. It is also invisible to the obvious test: a
+ * {@code @WebMvcTest} slice mocks {@code @orgSecurity}, so a {@code @PreAuthorize} test there
+ * exercises the mock and passes on a stub's return value whatever the real beans would decide.
+ * That is how the clause shipped green in {@code eec6c37}. A source-level rule needs no runtime
+ * and cannot be satisfied by a stub.
+ *
+ * <p>Combining the two with {@code and} is meaningful and allowed: that narrows a guard to
+ * members holding a role. Only {@code or} is refused.
+ *
+ * <p>Runs under {@code @AnalyzeClasses} so the imported class graph comes from ArchUnit's shared
+ * cache, as every architecture test in this package does.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class OrgRoleGuardRedundancyTest {
+
+    private static final String MEMBER_CHECK = "isMemberOfCurrentTenant()";
+    private static final String ROLE_CHECK = "hasAnyOrgRoleForCurrentTenant(";
+
+    @ArchTest
+    static final ArchRule noGuardOrsAnOrgRoleAgainstTenantMembership = methods()
+            .that().areAnnotatedWith(PreAuthorize.class)
+            .should(notOrTheRoleCheckAgainstTheMembershipCheck());
+
+    private static ArchCondition<JavaMethod> notOrTheRoleCheckAgainstTheMembershipCheck() {
+        return new ArchCondition<>("not combine a current-tenant role check with the membership "
+                + "check using 'or', because the role clause cannot change the outcome") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                String expression = method.getAnnotationOfType(PreAuthorize.class).value();
+                if (!isRedundantOr(expression)) {
+                    return;
+                }
+                events.add(SimpleConditionEvent.violated(method, String.format(
+                        "%s guards on \"%s\": the role clause is unreachable, because the tenant is "
+                                + "only ever resolved for a member. Keep whichever clause decides "
+                                + "and delete the other, or combine them with 'and'. See #717.",
+                        method.getFullName(), expression)));
+            }
+        };
+    }
+
+    /**
+     * Whether the expression ors the two checks together, in either order.
+     *
+     * <p>Deliberately coarse: it asks whether both checks appear and the word {@code or} appears
+     * between them, rather than parsing SpEL. An expression that mentions both and never ors them
+     * is rare enough that a false positive is cheap to rewrite, and being coarse is what makes the
+     * rule survive reformatting and the addition of further clauses.
+     */
+    private static boolean isRedundantOr(String expression) {
+        int memberAt = expression.indexOf(MEMBER_CHECK);
+        int roleAt = expression.indexOf(ROLE_CHECK);
+        if (memberAt < 0 || roleAt < 0) {
+            return false;
+        }
+        int from = Math.min(memberAt, roleAt);
+        int to = Math.max(memberAt, roleAt);
+        return expression.substring(from, to).contains(" or ");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationIT.java
@@ -150,6 +150,89 @@ class TenantIsolationIT extends AbstractIntegrationTest {
         assertThat(organizationRepository.findById(orgBId)).isPresent();
     }
 
+    @Test
+    void aStrangerIsRefusedOnAReadThroughADerivedQuery() {
+        // The stranger case stated as such: a caller scoped to organization A has no membership
+        // of, no role in and no relationship at all to organization B. #717 removed 36 guards
+        // whose role clause was unreachable and left the tenant resolved from membership alone,
+        // so this is the boundary that has to keep holding for the removal to be safe.
+        //
+        // findById is covered above. This goes through a derived query instead, because the two
+        // reach the listener by different routes: the org filter never covers a primary-key
+        // load, and it is not enabled here either, so what refuses the row is the load listener
+        // on materialization in both cases and it is worth showing on a query as well.
+        TenantContext.setCurrentOrgId(orgAId);
+
+        assertThatThrownBy(() -> categoryRepository.findCategoryByName("Concrete"))
+                .isInstanceOf(TenantAccessDeniedException.class);
+    }
+
+    @Test
+    void aStrangerIsRefusedOnAWrite() {
+        // A write has to load before it can persist: saving a detached instance issues a select
+        // first, which is the load the listener sees. So the refusal arrives before any row is
+        // touched rather than after, which is what makes this a boundary rather than an audit.
+        Category detached = new Category();
+        detached.setId(categoryId);
+        detached.setName("Renamed by a stranger");
+
+        TenantContext.setCurrentOrgId(orgAId);
+
+        assertThatThrownBy(() -> categoryRepository.saveAndFlush(detached))
+                .isInstanceOf(TenantAccessDeniedException.class);
+    }
+
+    @Test
+    void theStrangersWriteLeavesTheRowUnchanged() {
+        // The other half of the write case, asserted separately: a refused write must not have
+        // landed. Read back under the owning tenant, and compare one property rather than the
+        // entity, because Organization is a Lombok @Data entity whose toString walks its lazy
+        // employees, so letting an assertion describe one raises an exception of its own from
+        // inside the failure message.
+        Category detached = new Category();
+        detached.setId(categoryId);
+        detached.setName("Renamed by a stranger");
+
+        TenantContext.setCurrentOrgId(orgAId);
+        assertThatThrownBy(() -> categoryRepository.saveAndFlush(detached))
+                .isInstanceOf(TenantAccessDeniedException.class);
+
+        entityManager.clear();
+        TenantContext.setCurrentOrgId(orgBId);
+
+        assertThat(categoryRepository.findById(categoryId).orElseThrow().getName())
+                .isEqualTo("Concrete");
+    }
+
+    @Test
+    void aStrangerIsRefusedThroughAnHqlJoin() {
+        // A join is the interesting shape, because the tenant condition sits on the joined side
+        // and a reader can convince themselves the join itself scopes the query. It does not:
+        // the org filter is not enabled here, so the query happily selects organization B's row
+        // and the refusal comes when the entity is materialized. Naming organization B in the
+        // where clause is the point, since that is what a caller who knows the id would write.
+        TenantContext.setCurrentOrgId(orgAId);
+
+        assertThatThrownBy(() -> entityManager.createQuery(
+                        "select c from Category c join c.organization o where o.id = :orgId", Category.class)
+                .setParameter("orgId", orgBId)
+                .getResultList())
+                .isInstanceOf(TenantAccessDeniedException.class);
+    }
+
+    @Test
+    void theOwningTenantStillPassesThroughTheSameHqlJoin() {
+        // The join is refused for the stranger and not for everyone: without this the test above
+        // would pass just as well against a query that was broken outright.
+        TenantContext.setCurrentOrgId(orgBId);
+
+        assertThat(entityManager.createQuery(
+                        "select c from Category c join c.organization o where o.id = :orgId", Category.class)
+                .setParameter("orgId", orgBId)
+                .getResultList())
+                .hasSize(1);
+    }
+
     private Organization persistOrganization(String name) {
         Organization org = new Organization();
         org.setOrganizationName(name);

--- a/src/test/java/org/tornotron/echno_backend/common/security/ReadWriteGuardSymmetryTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/security/ReadWriteGuardSymmetryTest.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.common.security;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ import org.tornotron.echno_backend.task.TaskService;
 
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
@@ -48,20 +50,36 @@ import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
- * Locks in read/write guard symmetry across the controllers that carried the asymmetry fixed
- * for projects in #399: their reads gated on tenant membership alone while their writes gated
- * on the system-admin or project-manager org role. A caller holding that role without a
- * recorded ORG_MEMBER_ authority, the bootstrap admin being the known example, could therefore
- * write these resources but got 403 reading them.
+ * Locks in the read guards across the nine controllers that carried the asymmetry fixed for
+ * projects in #399: their reads gated on tenant membership while their writes gated on the
+ * system-admin or project-manager org role.
  *
- * <p>Every read below must accept either branch, membership or the elevated role. The
- * role-without-membership case is the one that was broken; if any of these read guards is
- * narrowed back to membership alone, that parameterized case fails for the offending path.
+ * <p><b>The role-without-membership case this class used to assert has been removed, because it
+ * asserted an outcome for a state the real beans cannot produce.</b> It stubbed
+ * {@code isMemberOfCurrentTenant()} false and {@code hasAnyOrgRoleForCurrentTenant(...)} true.
+ * The real {@code OrganizationSecurityService} answers both from
+ * {@code TenantContext.getCurrentOrgId()} and refuses a null one, and {@code TenantFilter} sets
+ * that only after confirming an {@code ORG_MEMBER_} authority, so a non-member has no
+ * organization in force and the role check returns false as well. The pair could never occur, and
+ * the test passed on the stub rather than on anything the application does. It is the same
+ * mistake as {@code eec6c37}, which shipped a guard clause that decided nothing with a green
+ * test over it, and #709 and #717 then spent two issues establishing that the clause was dead.
+ *
+ * <p>{@code TenantFilterTest.theRoleGuardCannotSucceedWhereTheMembershipGuardFails} is where that
+ * claim belongs, and it is made there against the real {@code OrganizationSecurityService} inside
+ * the real filter chain. The split it depended on is now prevented outright, in
+ * {@code KeycloakGroupService} and {@code KeycloakInitializer}, and pinned by
+ * {@code KeycloakOrgMembershipInvariantIT} against a real Keycloak.
+ *
+ * <p>So that the mistake is harder to repeat here than to catch by review,
+ * {@link #stubTenantGuards} refuses the impossible pair rather than stubbing it. Mocking
+ * {@code @orgSecurity} is still the right call for a slice, since it exercises the guard
+ * expression without building JWT authorities; what was wrong was stubbing a combination the
+ * bean cannot return, and that is now a test failure at the point of stubbing.
  *
  * <p>Deliberately one @WebMvcTest over all nine controllers rather than nine separate slices.
- * Spring caches a context per distinct slice and the test JVM is capped at 1024m, so nine new
- * contexts would be a real cost; this adds exactly one. @orgSecurity is mocked so each branch
- * is exercised without building JWT authorities.
+ * Spring caches a context per distinct slice and the test JVM is capped, so nine new contexts
+ * would be a real cost; this adds exactly one.
  */
 @WebMvcTest({
         AssetControllerWeb.class,
@@ -133,10 +151,9 @@ class ReadWriteGuardSymmetryTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("widenedReadEndpoints")
-    void read_isOk_forARoleHolderThatIsNotRecordedAsAMember(String path) throws Exception {
-        // The case broken before this change: writes were allowed, reads were 403.
-        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+    void read_isOk_forAMemberWithoutAnElevatedRole(String path) throws Exception {
+        // A plain member of the tenant reads these, which is what the guards decide on.
+        stubTenantGuards(true, false);
 
         mockMvc.perform(get(path).with(jwt()))
                 .andExpect(status().isOk());
@@ -144,10 +161,11 @@ class ReadWriteGuardSymmetryTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("widenedReadEndpoints")
-    void read_isOk_forAMemberWithoutAnElevatedRole(String path) throws Exception {
-        // The widening must not cost plain members their existing access.
-        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+    void read_isOk_forAMemberHoldingAnElevatedRole(String path) throws Exception {
+        // An admin reads them as well, by being a member. Worth stating separately: it is the
+        // case the removed test was reaching for, and it is satisfied without the role deciding
+        // anything, because a role holder is a member.
+        stubTenantGuards(true, true);
 
         mockMvc.perform(get(path).with(jwt()))
                 .andExpect(status().isOk());
@@ -156,13 +174,45 @@ class ReadWriteGuardSymmetryTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("widenedReadEndpoints")
     void read_isForbidden_forACallerWithNeitherMembershipNorRole(String path) throws Exception {
-        // Both branches are tenant-scoped, so an outsider is still refused. This is what keeps
-        // the widening from becoming "any authenticated caller may read".
-        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+        // A caller with no relationship to the tenant is refused. The guards are tenant-scoped,
+        // so this is what keeps them from reading "any authenticated caller may read".
+        stubTenantGuards(false, false);
 
         mockMvc.perform(get(path).with(jwt()))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void stubbingARoleWithoutMembershipIsRefusedAsAStateTheBeansCannotProduce() {
+        // The guard on the helper, tested so it cannot quietly stop guarding. Without it, the
+        // one stub combination that proves nothing is also the easiest one to write.
+        assertThatThrownBy(() -> stubTenantGuards(false, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cannot hold an org role");
+    }
+
+    /**
+     * Stubs the two tenant guards together, refusing the pair the real beans cannot return.
+     *
+     * <p>{@code hasAnyOrgRoleForCurrentTenant} implies {@code isMemberOfCurrentTenant}: both read
+     * {@code TenantContext.getCurrentOrgId()} and refuse a null one, and the tenant is only
+     * resolved for a member. A test that stubs a role without membership is asserting behaviour
+     * for a request that cannot reach a controller, so it passes whatever the guard says.
+     *
+     * @param member whether the caller is a member of the tenant in force
+     * @param role   whether the caller holds one of the elevated roles in it
+     */
+    private void stubTenantGuards(boolean member, boolean role) {
+        if (role && !member) {
+            throw new IllegalArgumentException(
+                    "A caller cannot hold an org role for the current tenant without being a member "
+                            + "of it: both checks read TenantContext.getCurrentOrgId(), and TenantFilter "
+                            + "sets it only after confirming an ORG_MEMBER_ authority. Stubbing this pair "
+                            + "asserts an outcome for a request that cannot reach a controller. See "
+                            + "TenantFilterTest.theRoleGuardCannotSucceedWhereTheMembershipGuardFails.");
+        }
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(member);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(role);
     }
 
     @TestConfiguration

--- a/src/test/java/org/tornotron/echno_backend/common/service/KeycloakOrgMembershipInvariantIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/KeycloakOrgMembershipInvariantIT.java
@@ -1,0 +1,266 @@
+package org.tornotron.echno_backend.common.service;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.CreatedResponseUtil;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tornotron.echno_backend.common.configuration.JwtAuthConverter;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the invariant the whole org-scoped authority model rests on, against a real Keycloak:
+ * <b>a user who holds a role subgroup under an organization is a member of that organization</b>.
+ *
+ * <p>Why it needs pinning. Keycloak records membership of {@code /org-5} and of
+ * {@code /org-5/system-admin} as two independent rows, so the two can come apart, and the
+ * authorities they mint come apart with them: {@code JwtAuthConverter} derives
+ * {@code ORG_MEMBER_5} from the first and {@code ORG_5_ROLE_system-admin} from the second.
+ * {@code TenantFilter} resolves the request's organization from the membership authority alone,
+ * on both the header branch and the inference branch, so a role held without membership resolves
+ * no tenant and its holder is refused on every endpoint, including the ones their role names.
+ * That is what made the {@code "member or role"} guards of #709 and #717 decide nothing: the role
+ * clause described a state the model has no answer for.
+ *
+ * <p>The answer taken in #717 is to make the state unreachable rather than to teach
+ * {@code TenantFilter} to honour it. Honouring it would mean a role authority alone resolves a
+ * tenant, which changes what "the current tenant" means for every request in the application, and
+ * the population it would enfranchise is not bootstrap admins: it is users whose membership was
+ * removed while their role subgroup stayed behind, which offboarding did until this change.
+ *
+ * <p>So both directions are proven here, through the real {@link KeycloakGroupService} against a
+ * real server rather than a mock of it:
+ * <ol>
+ *   <li>granting a role also grants membership, even to a user who had none;</li>
+ *   <li>removing membership also removes every role subgroup under that organization;</li>
+ *   <li>and the group paths that result never yield a role authority without its membership
+ *       authority, which is the form the guards actually read.</li>
+ * </ol>
+ *
+ * <p>The third is the one that cannot be faked. A {@code @WebMvcTest} slice mocks
+ * {@code @orgSecurity}, so a {@code @PreAuthorize} test there passes on a stub's return value
+ * whatever the real beans would decide, which is how the dead clause shipped green in
+ * {@code eec6c37}. Running the real Keycloak state through the real converter leaves no stub in
+ * the path.
+ */
+class KeycloakOrgMembershipInvariantIT {
+
+    private static final String TEST_REALM = "echno-group-it-realm";
+    private static final String BACKEND_CLIENT_ID = "echno-backend";
+    // Placeholder for a container that lives for the length of this class, not a real credential.
+    private static final String BACKEND_CLIENT_SECRET = "echno-backend-group-it-secret";
+    private static final String REALM_MANAGEMENT = "realm-management";
+    private static final String REALM_ADMIN = "realm-admin";
+    private static final String ORG_ID = "5";
+    private static final String ORG_GROUP_PATH = "/org-" + ORG_ID;
+
+    // Pinned to the tag matching the keycloak-admin-client version, as the other Keycloak ITs are.
+    private static final KeycloakContainer KEYCLOAK =
+            new KeycloakContainer("quay.io/keycloak/keycloak:26.0.7");
+
+    private static Keycloak master;
+    private static KeycloakGroupService groupService;
+
+    private String userId;
+
+    @BeforeAll
+    static void startKeycloak() {
+        KEYCLOAK.start();
+
+        master = KeycloakBuilder.builder()
+                .serverUrl(KEYCLOAK.getAuthServerUrl())
+                .realm("master")
+                .clientId("admin-cli")
+                .username(KEYCLOAK.getAdminUsername())
+                .password(KEYCLOAK.getAdminPassword())
+                .grantType(OAuth2Constants.PASSWORD)
+                .build();
+
+        RealmRepresentation realm = new RealmRepresentation();
+        realm.setRealm(TEST_REALM);
+        realm.setEnabled(true);
+        master.realms().create(realm);
+
+        createBackendServiceAccountClient();
+
+        // The real bean, wired the way Spring wires it. Its @Value fields are set directly
+        // because there is no context here; everything below then runs through the same
+        // client_credentials path production uses.
+        groupService = new KeycloakGroupService();
+        ReflectionTestUtils.setField(groupService, "authServerUrl", KEYCLOAK.getAuthServerUrl());
+        ReflectionTestUtils.setField(groupService, "realm", TEST_REALM);
+        ReflectionTestUtils.setField(groupService, "clientId", BACKEND_CLIENT_ID);
+        ReflectionTestUtils.setField(groupService, "clientSecret", BACKEND_CLIENT_SECRET);
+
+        groupService.createOrganizationGroup(ORG_ID, "Org Five");
+    }
+
+    @AfterAll
+    static void stopKeycloak() {
+        if (master != null) {
+            master.close();
+        }
+        KEYCLOAK.stop();
+    }
+
+    @BeforeEach
+    void createUser() {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("member-" + System.nanoTime());
+        user.setEnabled(true);
+        try (Response response = master.realm(TEST_REALM).users().create(user)) {
+            userId = CreatedResponseUtil.getCreatedId(response);
+        }
+    }
+
+    @Test
+    void assigningARoleToANonMemberAlsoMakesThemAMember() {
+        // The provisioning half. Before this, a role could be granted to a user who was in no
+        // org group at all, and the grant "succeeded" while leaving them unable to use it.
+        groupService.assignOrgRole(userId, ORG_ID, OrgRole.SYSTEM_ADMIN);
+
+        assertThat(groupPaths()).contains(ORG_GROUP_PATH);
+    }
+
+    @Test
+    void assigningARoleGrantsTheRoleSubgroupToo() {
+        groupService.assignOrgRole(userId, ORG_ID, OrgRole.SYSTEM_ADMIN);
+
+        assertThat(groupPaths()).contains(ORG_GROUP_PATH + "/system-admin");
+    }
+
+    @Test
+    void removingMembershipAlsoRemovesTheRoleSubgroup() {
+        // The offboarding half, and the one that made the split reachable in production:
+        // leaving the parent group leaves the subgroup row untouched, so a removed employee
+        // kept ORG_5_ROLE_system-admin and lost only ORG_MEMBER_5.
+        groupService.addUserToOrganization(userId, ORG_ID);
+        groupService.assignOrgRole(userId, ORG_ID, OrgRole.SYSTEM_ADMIN);
+
+        groupService.removeUserFromOrganization(userId, ORG_ID);
+
+        assertThat(groupPaths()).doesNotContain(ORG_GROUP_PATH + "/system-admin");
+    }
+
+    @Test
+    void removingMembershipAlsoRemovesTheParentGroup() {
+        groupService.addUserToOrganization(userId, ORG_ID);
+        groupService.assignOrgRole(userId, ORG_ID, OrgRole.SYSTEM_ADMIN);
+
+        groupService.removeUserFromOrganization(userId, ORG_ID);
+
+        assertThat(groupPaths()).doesNotContain(ORG_GROUP_PATH);
+    }
+
+    @Test
+    void removingMembershipClearsEveryRoleHeldInThatOrganization() {
+        // More than one role, because the removal walks the user's subgroups rather than one
+        // named role, and a loop that stops after the first would still pass the tests above.
+        groupService.assignOrgRole(userId, ORG_ID, OrgRole.SYSTEM_ADMIN);
+        groupService.assignOrgRole(userId, ORG_ID, OrgRole.HR_ADMIN);
+
+        groupService.removeUserFromOrganization(userId, ORG_ID);
+
+        assertThat(groupPaths()).noneMatch(path -> path.startsWith(ORG_GROUP_PATH));
+    }
+
+    @Test
+    void aRoleAuthorityIsNeverMintedWithoutItsMembershipAuthority() {
+        // The invariant in the form the guards read. The group paths come from the live server
+        // after a real role grant, and the converter is the real one, so nothing here can pass
+        // on a stubbed answer.
+        groupService.assignOrgRole(userId, ORG_ID, OrgRole.PROJECT_MANAGER);
+
+        Set<String> authorities = authoritiesFor(groupPaths());
+
+        assertThat(authorities).contains("ORG_" + ORG_ID + "_ROLE_project-manager");
+        assertThat(authorities).contains("ORG_MEMBER_" + ORG_ID);
+    }
+
+    @Test
+    void anOffboardedUserKeepsNeitherAuthority() {
+        groupService.assignOrgRole(userId, ORG_ID, OrgRole.PROJECT_MANAGER);
+        groupService.removeUserFromOrganization(userId, ORG_ID);
+
+        Set<String> authorities = authoritiesFor(groupPaths());
+
+        assertThat(authorities).doesNotContain("ORG_" + ORG_ID + "_ROLE_project-manager");
+        assertThat(authorities).doesNotContain("ORG_MEMBER_" + ORG_ID);
+    }
+
+    /** The paths of every group the user is currently in, read back from the server. */
+    private List<String> groupPaths() {
+        return master.realm(TEST_REALM).users().get(userId).groups().stream()
+                .map(GroupRepresentation::getPath)
+                .toList();
+    }
+
+    /** The authorities the real converter derives from a token carrying these group paths. */
+    private static Set<String> authoritiesFor(List<String> groupPaths) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .subject("user-1")
+                .claim("groups", groupPaths)
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .build();
+
+        JwtAuthConverter converter = new JwtAuthConverter();
+        ReflectionTestUtils.setField(converter, "resourceId", "echno-backend-client");
+
+        AbstractAuthenticationToken auth = converter.convert(jwt);
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * The confidential client {@link KeycloakGroupService} authenticates as, with a service
+     * account holding realm-admin so it can manage groups.
+     */
+    private static void createBackendServiceAccountClient() {
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId(BACKEND_CLIENT_ID);
+        client.setEnabled(true);
+        client.setPublicClient(false);
+        client.setServiceAccountsEnabled(true);
+        client.setSecret(BACKEND_CLIENT_SECRET);
+        client.setStandardFlowEnabled(false);
+
+        String clientUuid;
+        try (Response response = master.realm(TEST_REALM).clients().create(client)) {
+            clientUuid = CreatedResponseUtil.getCreatedId(response);
+        }
+
+        UserRepresentation serviceAccount =
+                master.realm(TEST_REALM).clients().get(clientUuid).getServiceAccountUser();
+        String realmManagementUuid =
+                master.realm(TEST_REALM).clients().findByClientId(REALM_MANAGEMENT).getFirst().getId();
+        RoleRepresentation realmAdmin = master.realm(TEST_REALM).clients()
+                .get(realmManagementUuid).roles().get(REALM_ADMIN).toRepresentation();
+
+        master.realm(TEST_REALM).users().get(serviceAccount.getId())
+                .roles().clientLevel(realmManagementUuid).add(List.of(realmAdmin));
+    }
+}


### PR DESCRIPTION
## What #717 turned out to be

#717 asked whether a caller holding an org role without the flat membership group should be able to resolve a tenant, and offered relaxing `TenantFilter` as the way to make its 36 dead `or` clauses live.

Tracing it first: the org id is baked into the role authority itself. `JwtAuthConverter` derives `ORG_5_ROLE_system-admin` from the Keycloak subgroup `/org-5/system-admin`, so a role always names its own organization and can never speak for another. The only state those 36 clauses can describe is a user in `/org-5/system-admin` who is not in `/org-5`.

That state is not a design requirement. It is a split the code produced in one place and tolerated in another:

- `assignOrgRole` joined the role subgroup only. It resolves the employee against the tenant first, so membership existed in practice, but nothing enforced it.
- `removeUserFromOrganization` left the parent group and stopped. Keycloak keeps membership of `/org-5` and of `/org-5/system-admin` as independent rows, so **an offboarded employee kept their role authority and lost only their membership authority**. Employee deletion is the reachable route into the split, and it is an offboarding path.

So relaxing tenant resolution would not mainly have enfranchised bootstrap admins. It would mainly have enfranchised removed employees, at their old role, in the organization they were removed from. On the per-client production model that is a client's former administrator keeping administrator access. It would also have changed what "the current tenant" means for all 354 places that read `TenantContext.getCurrentOrgId()`, to accommodate a state that should not exist.

## What this does instead

Makes the invariant hold, so the clauses are provably unreachable rather than merely unreachable today, then removes them.

- `assignOrgRole` joins the parent org group before the role subgroup. `joinGroup` is idempotent, and membership goes first so a failure between the two leaves the weaker state.
- `removeUserFromOrganization` clears every role subgroup under that organization before leaving the parent, found by path so a hand-made subgroup or one dropped from `OrgRole` is covered. Roles go first, for the same reason.
- `KeycloakInitializer` reconciles a realm that already holds the split on every startup. One-directional and minimal: it adds the membership a role implies and never grants, removes or alters a role, a credential or an account. It matters because the QA seed replays a captured export verbatim, so it can carry the split in.
- The 36 guards lose the unreachable role clause and keep the membership check that was deciding them. `hasAnyOrgRoleForCurrentTenant` now documents why the two must not be `or`ed, next to the code someone would read before restoring the clause.

**Tenant resolution itself is untouched.** A caller with no relationship to an organization is refused exactly as before, and a bare realm authority still resolves no tenant, so the phantom authorities of #684 and #716 stay dead.

## Evidence

Tests were pushed one commit ahead of the fix so the red is on the record. Run on the tests-only commit: 2209 tests, 6 failed.

| test | before the fix | after |
|---|---|---|
| `KeycloakOrgMembershipInvariantIT.assigningARoleToANonMemberAlsoMakesThemAMember` | FAILED (measured) | passes |
| `KeycloakOrgMembershipInvariantIT.removingMembershipAlsoRemovesTheRoleSubgroup` | FAILED (measured) | passes |
| `KeycloakOrgMembershipInvariantIT.removingMembershipClearsEveryRoleHeldInThatOrganization` | FAILED (measured) | passes |
| `KeycloakOrgMembershipInvariantIT.aRoleAuthorityIsNeverMintedWithoutItsMembershipAuthority` | FAILED (measured) | passes |
| `KeycloakOrgMembershipInvariantIT.anOffboardedUserKeepsNeitherAuthority` | FAILED (measured) | passes |
| `OrgRoleGuardRedundancyTest.noGuardOrsAnOrgRoleAgainstTenantMembership` | FAILED (measured), 36 occurrences | passes |
| `TenantIsolationIT` stranger cases (read, write, HQL join) | PASSED (measured) | passes |
| `ReadWriteGuardSymmetryTest.read_isOk_forARoleHolderThatIsNotRecordedAsAMember` | passed on a stub | removed, see below |

`KeycloakOrgMembershipInvariantIT` runs the real `KeycloakGroupService` against a real Keycloak container and then feeds the resulting group paths through the real `JwtAuthConverter`, so the invariant is asserted in the form the guards read rather than as a claim about group rows.

The stranger cases were green before the fix and after it, which is the point: they are the boundary the guard removal rests on, and this change does not move it. A caller scoped to one organization is refused another's row on a read, on a write, and through an HQL join that names the other organization, with the owning tenant still passing through the same join.

## The vacuous test underneath

`ReadWriteGuardSymmetryTest.read_isOk_forARoleHolderThatIsNotRecordedAsAMember` failed when the clause came off. It is the clause's own passing test, not a regression: it stubbed `isMemberOfCurrentTenant()` false and `hasAnyOrgRoleForCurrentTenant(...)` true, a pair the real beans cannot return, so it asserted an outcome for a request that cannot reach a controller. Same shape as `eec6c37`.

It is removed rather than rewritten, because the claim belongs in `TenantFilterTest.theRoleGuardCannotSucceedWhereTheMembershipGuardFails`, where it is made against the real beans in the real filter chain. In its place, `stubTenantGuards` refuses the impossible pair with the reason in the exception, and a test holds the helper to it. A scan of the whole test tree found exactly one method stubbing that combination, this one.

Closes #717
