### PR TITLE
Give the stores function a role of its own

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5175,7 +5175,8 @@
                 "PROJECT_MANAGER",
                 "QA_ENGINEER",
                 "SAFETY_OFFICER",
-                "SITE_ENGINEER"
+                "SITE_ENGINEER",
+                "STORE_KEEPER"
               ],
               "type": "string"
             },
@@ -11361,7 +11362,8 @@
               "PROJECT_MANAGER",
               "QA_ENGINEER",
               "SAFETY_OFFICER",
-              "SITE_ENGINEER"
+              "SITE_ENGINEER",
+              "STORE_KEEPER"
             ],
             "type": "string"
           }
@@ -35552,7 +35554,8 @@
                       "PROJECT_MANAGER",
                       "QA_ENGINEER",
                       "SAFETY_OFFICER",
-                      "SITE_ENGINEER"
+                      "SITE_ENGINEER",
+                      "STORE_KEEPER"
                     ],
                     "type": "string"
                   },
@@ -35797,7 +35800,8 @@
                 "PROJECT_MANAGER",
                 "QA_ENGINEER",
                 "SAFETY_OFFICER",
-                "SITE_ENGINEER"
+                "SITE_ENGINEER",
+                "STORE_KEEPER"
               ],
               "type": "string"
             }
@@ -108982,7 +108986,7 @@
       "name": "Goods Received Notes"
     },
     {
-      "description": "Goods received notes (GRNs) record materials received against a vendor, capturing the delivery and its line items. This is the web-console API, restricted to the system-admin role for the current tenant rather than flat authorities. Endpoints cover creating, browsing, filtering by vendor or date range, and updating GRNs.",
+      "description": "Goods received notes (GRNs) record materials received against a vendor, capturing the delivery and its line items. This is the web-console API, gated by organization role for the current tenant rather than by flat authorities. Recording a receipt and reading one are open to the system-admin and store-keeper roles, because booking a delivery in is the store's own work and used to require administering the whole organization. Endpoints cover creating, browsing, filtering by vendor or date range, and updating GRNs.",
       "name": "Goods Received Notes (Web)"
     },
     {
@@ -109010,7 +109014,7 @@
       "name": "Inventory Transactions"
     },
     {
-      "description": "Movements of material stock, such as receipts, issues and usage, together with derived stock levels by storage location or material. This is the web-console API for the current tenant, and every endpoint is read-only: fetching a transaction, browsing and filtering by material, project, type, date range, storage location or task, and reading current stock and task usage totals. Access is split by what a read is anchored to. A read that names a material, a storage location, a project or a task is open to the system-admin and project-manager roles, because a project manager raises and approves stock adjustments and approving one writes the ADJUST rows carrying the reason the stock moved; all four of those objects are already readable by a project manager, so a ledger read anchored to one of them shows the movements behind something the caller can already open. The four listings that name nothing and range over the whole organization stay with system-admin: the unpaginated and paginated listings of every transaction, the listing by transaction type and the listing by date range. Those are the movement report rather than the history behind a document, and no part of the stock-adjustment workflow reaches them.",
+      "description": "Movements of material stock, such as receipts, issues and usage, together with derived stock levels by storage location or material. This is the web-console API for the current tenant, and every endpoint is read-only: fetching a transaction, browsing and filtering by material, project, type, date range, storage location or task, and reading current stock and task usage totals. Access is split by what a read is anchored to. A read that names a material, a storage location, a project or a task is open to the system-admin and project-manager roles, because a project manager raises and approves stock adjustments and approving one writes the ADJUST rows carrying the reason the stock moved; all four of those objects are already readable by a project manager, so a ledger read anchored to one of them shows the movements behind something the caller can already open. The four listings that name nothing and range over the whole organization stay closed to a project manager: the unpaginated and paginated listings of every transaction, the listing by transaction type and the listing by date range. Those are the movement report rather than the history behind a document, and no part of the stock-adjustment workflow reaches them. The store-keeper role reads all of it, anchored or not, because this ledger is the record of the receipts, issues and transfers a storekeeper posts and answering for it means being able to read it back.",
       "name": "Inventory Transactions (Web)"
     },
     {
@@ -109098,7 +109102,7 @@
       "name": "Material Consumptions"
     },
     {
-      "description": "Web-console counterpart of the material consumptions API, restricted to the system-admin role for the current tenant. Covers the same recording and lookup operations as the standard material consumption endpoints, for use from the admin web console rather than the mobile app.",
+      "description": "Web-console counterpart of the material consumptions API, gated by organization role for the current tenant. Recording an issue and looking issues up are open to the system-admin and store-keeper roles: handing material out over the counter is the store's own work. Covers the same recording and lookup operations as the standard material consumption endpoints, for use from the admin web console rather than the mobile app.",
       "name": "Material Consumptions (Web)"
     },
     {
@@ -109106,7 +109110,7 @@
       "name": "Materials"
     },
     {
-      "description": "Web-console counterpart of the materials API, gated by organization role for the current tenant. Covers the same create, browse, search, update, stock lookup and delete operations as the standard materials endpoints, for use from the admin web console rather than the mobile app. Reads, including the stock lookup, are open to the system-admin and project-manager roles, because a project manager raises and approves stock adjustments and those are documents about a material's balance. Changing the catalogue, its thresholds included, stays with system-admin.",
+      "description": "Web-console counterpart of the materials API, gated by organization role for the current tenant. Covers the same create, browse, search, update, stock lookup and delete operations as the standard materials endpoints, for use from the admin web console rather than the mobile app. Reads, including the stock lookup, are open to the system-admin, project-manager and store-keeper roles, because a project manager raises and approves stock adjustments and those are documents about a material's balance, and a storekeeper cannot name a material on a receipt, an issue or a count without reading the catalogue first. Changing the catalogue, its thresholds included, stays with system-admin.",
       "name": "Materials (Web)"
     },
     {
@@ -109174,7 +109178,7 @@
       "name": "Projects"
     },
     {
-      "description": "Line items belonging to a purchase order: the material, ordered and received quantities, unit price and totals. Items can be created independently of the parent order create call and looked up by purchase order or by material. Access is restricted to the system-admin role for the current tenant.",
+      "description": "Line items belonging to a purchase order: the material, ordered and received quantities, unit price and totals. Items can be created independently of the parent order create call and looked up by purchase order or by material. Writing an item is restricted to the system-admin role for the current tenant. Reading one is also open to store-keeper, who needs the ordered quantities to check a delivery against them.",
       "name": "Purchase Order Items"
     },
     {
@@ -109182,7 +109186,7 @@
       "name": "Purchase Order Items (Web)"
     },
     {
-      "description": "Purchase orders raised against a vendor, optionally converted from an indent. A purchase order carries line items, a status lifecycle from draft through fully received or cancelled, and the totals used for payables. Access is restricted to the system-admin role for the current tenant.",
+      "description": "Purchase orders raised against a vendor, optionally converted from an indent. A purchase order carries line items, a status lifecycle from draft through fully received or cancelled, and the totals used for payables. Raising and changing an order is restricted to the system-admin role for the current tenant. Reading one is also open to store-keeper, which is what a goods receipt is booked against: the receiving end has to see what was ordered without being able to alter the order.",
       "name": "Purchase Orders"
     },
     {
@@ -109210,11 +109214,11 @@
       "name": "Site Transfers"
     },
     {
-      "description": "Web-app view of site transfers: the same movement of materials between two projects and their storage locations as the mobile-facing site-transfer endpoints, restricted to the system-admin role for the caller's current tenant. Creating a transfer checks that the sending location holds enough stock before the items are recorded.",
+      "description": "Web-app view of site transfers: the same movement of materials between two projects and their storage locations as the mobile-facing site-transfer endpoints, gated by organization role for the caller's current tenant. Raising a transfer, confirming what the receiving site took delivery of, and cancelling one that never arrived are open to the system-admin and store-keeper roles, since both ends of a transfer are worked by a store. Creating a transfer checks that the sending location holds enough stock before the items are recorded.",
       "name": "Site Transfers (Web)"
     },
     {
-      "description": "Documents that correct the recorded on-hand quantity of materials at a storage location against a physical count, capturing the variance, its reason and justification per line item. This is the controlled way to set or correct a stock balance: approving a document posts its lines to the inventory ledger and moves the balance, so the resulting figure stays explainable. Endpoints cover creating, updating, browsing, approving, rejecting and deleting stock adjustment documents for the caller's current tenant. A draft is either approved, which posts it, or rejected with a stated reason, which posts nothing and keeps the refused correction on the record; both decisions freeze the document. Read endpoints require tenant membership; write and decision endpoints require the system-admin or project-manager role, and approval additionally has to come from someone other than whoever raised the document.",
+      "description": "Documents that correct the recorded on-hand quantity of materials at a storage location against a physical count, capturing the variance, its reason and justification per line item. This is the controlled way to set or correct a stock balance: approving a document posts its lines to the inventory ledger and moves the balance, so the resulting figure stays explainable. Endpoints cover creating, updating, browsing, approving, rejecting and deleting stock adjustment documents for the caller's current tenant. A draft is either approved, which posts it, or rejected with a stated reason, which posts nothing and keeps the refused correction on the record; both decisions freeze the document. Read endpoints require tenant membership. Raising and editing a draft is open to the system-admin, project-manager and store-keeper roles, because taking the count is the store's own work. Approving, rejecting and deleting stay with system-admin and project-manager: an approval posts the balance and is the second pair of eyes on somebody else's count, which is also why it has to come from someone other than whoever raised the document.",
       "name": "Stock Adjustments (Web)"
     },
     {
@@ -109222,7 +109226,7 @@
       "name": "Storage Locations"
     },
     {
-      "description": "Web-console counterpart of the storage location API, gated by organization role instead of a flat authority. Covers the same create, read and lookup operations as the mobile API plus partial update and delete, which the mobile API does not expose. Reads are open to the system-admin and project-manager roles in the caller's current tenant, because a project manager raises and approves stock adjustments and cannot pick a location to count without them. Creating, editing and deleting a location stays with system-admin.",
+      "description": "Web-console counterpart of the storage location API, gated by organization role instead of a flat authority. Covers the same create, read and lookup operations as the mobile API plus partial update and delete, which the mobile API does not expose. Reads are open to the system-admin, project-manager and store-keeper roles in the caller's current tenant, because a project manager raises and approves stock adjustments and cannot pick a location to count without them, and every stores document names the location the material came from or went to. Creating, editing and deleting a location stays with system-admin.",
       "name": "Storage Locations (Web)"
     },
     {
@@ -109250,7 +109254,7 @@
       "name": "Vendors"
     },
     {
-      "description": "Web-console counterpart of the vendors API, restricted to the system-admin role for the current tenant instead of the flat vendor authorities used by the mobile variant. Covers the same create, browse, search, update, delete and summary operations for vendors and their contacts, tax identifiers, bank accounts and payment terms, for use from the admin web console.",
+      "description": "Web-console counterpart of the vendors API, gated by organization role for the current tenant instead of by the flat vendor authorities used by the mobile variant. Naming a vendor and reaching its contacts are open to the system-admin and store-keeper roles, because a delivery has to say who brought it; the vendor summary, tax identifiers, bank accounts and payment terms are commercial rather than stores information and stay with system-admin, as do all vendor writes. Covers create, browse, search, update, delete and summary operations for vendors and their contacts, tax identifiers, bank accounts and payment terms, for use from the admin web console.",
       "name": "Vendors (Web)"
     },
     {

--- a/docs/org-scoped-roles.md
+++ b/docs/org-scoped-roles.md
@@ -24,7 +24,8 @@ org-5/                      ← This is a folder (Keycloak group) for the organi
     ├── project-manager
     ├── qa-engineer
     ├── safety-officer
-    └── site-engineer
+    ├── site-engineer
+    └── store-keeper
 ```
 
 - When a user **joins an organization**, they are placed inside the `org-5` folder.
@@ -57,7 +58,8 @@ org-5/
     ├── project-manager
     ├── qa-engineer
     ├── safety-officer
-    └── site-engineer
+    ├── site-engineer
+    └── store-keeper
 ```
 
 **File:** `KeycloakGroupService.java` → `createOrganizationGroup()` and `createDefaultRoleSubgroups()`
@@ -178,6 +180,7 @@ PROJECT_MANAGER("project-manager") // Can manage projects within the org
 QA_ENGINEER("qa-engineer")         // Quality inspections, checklists, quality NCRs
 SAFETY_OFFICER("safety-officer")   // Safety inspections and safety NCRs
 SITE_ENGINEER("site-engineer")     // Reads inspections, reports corrective action
+STORE_KEEPER("store-keeper")       // Runs the store: receipts, issues, transfers, counts
 ```
 
 The three inspection roles sit here rather than among the realm occupation roles because this is the
@@ -188,11 +191,57 @@ for assignment, not an authority.
 The enum also carries a second, smaller idea. `getManagerRoles()` names the four that count as
 manager standing (`SYSTEM_ADMIN`, `ORG_MANAGER`, `HR_ADMIN`, `PROJECT_MANAGER`), and that set decides
 who may be named the manager on a project invite code and who appears in the manager listings. The
-inspection roles are deliberately outside it: a QA engineer signs off quality, not headcount.
+inspection roles and `STORE_KEEPER` are deliberately outside it: a QA engineer signs off quality,
+not headcount, and running a store is not managing people either.
 
 That set is also the whole of what `ORG_MANAGER` does. No `@PreAuthorize` anywhere names
 `'org-manager'`, and the web role picker does not offer it, so it can only be granted through the
 API. It is not inert, though, and removing it would silently narrow `MANAGER_ROLES`.
+
+#### What `store-keeper` grants
+
+The Resources domain used to have nothing between plain organization membership and `system-admin`,
+so letting somebody book a delivery meant making them an administrator of the whole organization.
+`store-keeper` is the tier in between, and it is scoped to the work rather than to the domain: it
+grants the storekeeper's own documents and the reads those forms need, and nothing else.
+
+Writes it grants, nine endpoints in all:
+
+| Document | Endpoints |
+| --- | --- |
+| Goods received note | `POST /grns/web`, `PATCH /grns/web` |
+| Material issue | `POST /material-consumptions/web` |
+| Site transfer | `POST /site-transfers/web`, `POST /site-transfers/web/{id}/receive`, `POST /site-transfers/web/{id}/cancel`, `PATCH /site-transfers/web/{id}/status` |
+| Stock adjustment | `POST /stock-adjustments/web`, `PUT /stock-adjustments/web/{id}` |
+
+The site-transfer status route is on that list as a signpost rather than as an authority: it refuses
+every payload it is handed and answers by naming the receive and cancel routes, which is a more
+useful reply than a 403 to somebody who holds both of those.
+
+Reads it grants: the material catalogue and its stock figures, storage locations, the inventory
+ledger, goods received notes, site transfers, material issues, indents and indent items, purchase
+orders and their lines, and vendor identity and contacts. The reads are there because the forms
+cannot be filled in without them, which is the failure mode this role exists to close: an endpoint
+opened for a write while the lookup behind its form stays shut is the same 403 one screen earlier.
+
+What it does not grant, and why:
+
+- **No approval or rejection of a stock adjustment.** Approving is what posts the balance, and it is
+  meant to be the second pair of eyes on a count somebody else took. `SelfApprovalPolicy` already
+  refuses a caller approving the document they raised, but a role holding both halves would let two
+  storekeepers wave each other's counts through, which is the same control gone. Approval stays with
+  `system-admin` and `project-manager`.
+- **No deletions anywhere**, including of a stock adjustment or a goods received note.
+- **No catalogue, storage-location, vendor, purchase-order or indent writes.** Deciding what
+  materials exist, who supplies them and what has been ordered is not the same job as recording what
+  arrived.
+- **No vendor financial reads.** The vendor summary, bank accounts, tax identifiers and payment terms
+  are outside it; the storekeeper gets the vendor's name and contacts, which is what a delivery
+  needs.
+
+Two of these endpoints resolve the caller to an employee record: confirming and cancelling a site
+transfer both read who did it from the session rather than the payload. A `store-keeper` account with
+no employee row in the organization is refused there, with the role held.
 
 **When would you change this file?**
 - When you want to add a new role (e.g., `FINANCE_ADMIN("finance-admin")`)

--- a/src/main/java/org/tornotron/echno_backend/common/enums/OrgRole.java
+++ b/src/main/java/org/tornotron/echno_backend/common/enums/OrgRole.java
@@ -35,7 +35,24 @@ public enum OrgRole {
     // manager on a project invite code.
     QA_ENGINEER("qa-engineer"),
     SAFETY_OFFICER("safety-officer"),
-    SITE_ENGINEER("site-engineer");
+    SITE_ENGINEER("site-engineer"),
+    // The stores function. Before this role the Resources domain had nothing between plain
+    // organization membership and system-admin, so booking a delivery meant handing the person
+    // on the store counter the authority to delete projects and edit anybody's employee record.
+    // What it grants is the storekeeper's own work and the reads those forms need: goods
+    // receipts, material issues, site transfers out and in, and the count corrections that
+    // reconcile a shelf to the ledger, plus read access to the catalogue, storage locations,
+    // stock ledger, indents, purchase orders and vendor identity that filling those forms
+    // requires. What it does not grant is the second pair of eyes on any of it: no approval or
+    // rejection of a stock adjustment, no deletions, and no catalogue, vendor or purchase-order
+    // writes. A storekeeper who both counts and approves their own correction is the shape
+    // SelfApprovalPolicy exists to refuse, and a role that could do both halves would defeat it
+    // one request earlier than the policy is consulted.
+    //
+    // Deliberately not a manager role, for the same reason the three inspection roles are not:
+    // getManagerRoles decides who may be named the manager on a project invite code and who
+    // appears in the manager listings, and running a store is not managing headcount.
+    STORE_KEEPER("store-keeper");
 
     private final String groupName;
 

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
@@ -27,9 +27,12 @@ import java.util.List;
 @Tag(
         name = "Goods Received Notes (Web)",
         description = "Goods received notes (GRNs) record materials received against a vendor, capturing "
-                + "the delivery and its line items. This is the web-console API, restricted to the "
-                + "system-admin role for the current tenant rather than flat authorities. Endpoints "
-                + "cover creating, browsing, filtering by vendor or date range, and updating GRNs."
+                + "the delivery and its line items. This is the web-console API, gated by organization "
+                + "role for the current tenant rather than by flat authorities. Recording a receipt and "
+                + "reading one are open to the system-admin and store-keeper roles, because booking a "
+                + "delivery in is the store\'s own work and used to require administering the whole "
+                + "organization. Endpoints cover creating, browsing, filtering by vendor or date range, "
+                + "and updating GRNs."
 )
 public class GoodsReceivedNoteControllerWeb {
 
@@ -40,7 +43,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @PostMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Create a goods received note",
             description = "Creates a GRN recording materials received against a vendor with its line items. "
@@ -60,7 +63,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Get a goods received note by id",
             description = "Returns a single GRN."
@@ -76,7 +79,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List goods received notes",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -90,7 +93,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List goods received notes (paged)",
             description = "Returns a single page of GRNs controlled by the pageNo and pageSize parameters."
@@ -107,7 +110,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping("/vendor/{vendorId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List goods received notes for a vendor",
             description = "Returns the GRNs recorded against the given vendor."
@@ -122,7 +125,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @PatchMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Update a goods received note",
             description = "Applies an update to the GRN identified in the request body."
@@ -139,7 +142,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping("/date-range")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List goods received notes by date range",
             description = "Returns the GRNs recorded between the given start and end date-times."

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
@@ -57,7 +57,7 @@ public class IndentControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List indents, paginated",
             description = "Returns a single page of indents. The pageNo and pageSize parameters control paging."
@@ -88,7 +88,7 @@ public class IndentControllerWeb {
      * @return A {@link ResponseEntity} containing the page of indent summaries.
      */
     @GetMapping("/summary")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List indents as summaries, paginated",
             description = "Returns a single page of indents without their item lines, each "
@@ -108,7 +108,7 @@ public class IndentControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List all indents",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -122,7 +122,7 @@ public class IndentControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Get an indent by id",
             description = "Returns a single indent, including its creator, project and requested items."
@@ -176,7 +176,7 @@ public class IndentControllerWeb {
     // ==================== IndentItem Endpoints ====================
 
     @GetMapping("/{indentId}/items")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List items on an indent",
             description = "Returns every requested item on the given indent."

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
@@ -51,7 +51,7 @@ public class IndentItemControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Get an indent item by id",
             description = "Returns a single indent item, including its material and conversion status."
@@ -67,7 +67,7 @@ public class IndentItemControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List all indent items",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -93,7 +93,7 @@ public class IndentItemControllerWeb {
      * @return A {@link ResponseEntity} containing the page of indent items.
      */
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List indent items, paginated",
             description = "Returns a single page of indent items with the paging metadata included. "
@@ -109,7 +109,7 @@ public class IndentItemControllerWeb {
     }
 
     @GetMapping("/indent/{indentId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List items for an indent",
             description = "Returns every item belonging to the given indent."
@@ -124,7 +124,7 @@ public class IndentItemControllerWeb {
     }
 
     @GetMapping("/material/{materialId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List items for a material",
             description = "Returns every indent item that requests the given material, across all indents."
@@ -139,7 +139,7 @@ public class IndentItemControllerWeb {
     }
 
     @GetMapping("/conversion-status")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List items by conversion status",
             description = "Returns every indent item whose converted-to-purchase-order flag matches the "

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
@@ -36,10 +36,12 @@ import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
                 + "ADJUST rows carrying the reason the stock moved; all four of those objects are already "
                 + "readable by a project manager, so a ledger read anchored to one of them shows the movements "
                 + "behind something the caller can already open. The four listings that name nothing and range "
-                + "over the whole organization stay with system-admin: the unpaginated and paginated listings "
-                + "of every transaction, the listing by transaction type and the listing by date range. Those "
-                + "are the movement report rather than the history behind a document, and no part of the "
-                + "stock-adjustment workflow reaches them."
+                + "over the whole organization stay closed to a project manager: the unpaginated and paginated "
+                + "listings of every transaction, the listing by transaction type and the listing by date range. "
+                + "Those are the movement report rather than the history behind a document, and no part of the "
+                + "stock-adjustment workflow reaches them. The store-keeper role reads all of it, anchored or "
+                + "not, because this ledger is the record of the receipts, issues and transfers a storekeeper "
+                + "posts and answering for it means being able to read it back."
 )
 public class InventoryTransactionControllerWeb {
     private final InventoryTransactionService inventoryTransactionService;
@@ -52,7 +54,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Get an inventory transaction by id",
             description = "Returns a single inventory transaction."
@@ -68,7 +70,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List inventory transactions",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -83,7 +85,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List inventory transactions (paged)",
             description = "Returns a single page of inventory transactions controlled by the pageNo and pageSize parameters."
@@ -100,7 +102,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/material/{materialId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List inventory transactions for a material",
             description = "Returns the inventory transactions recorded for the given material."
@@ -115,7 +117,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/material/{materialId}/history")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Get a material's movement history (timeline, paged)",
             description = "Returns the material's stock movements as a timeline, oldest movement first, "
@@ -137,7 +139,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/project/{projectId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List inventory transactions for a project",
             description = "Returns the inventory transactions recorded for the given project."
@@ -152,7 +154,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/type/{transactionType}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List inventory transactions by type",
             description = "Returns the inventory transactions of the given transaction type."
@@ -168,7 +170,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/date-range")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List inventory transactions by date range",
             description = "Returns the inventory transactions recorded between the given start and end date-times."
@@ -187,7 +189,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/storage-location/{storageLocationId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List inventory transactions for a storage location",
             description = "Returns the inventory transactions recorded at the given storage location."
@@ -203,7 +205,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/storage-location/{storageLocationId}/material/{materialId}/project/{projectId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List inventory transactions for a location, material and project",
             description = "Returns the inventory transactions matching the given storage location, material and project."
@@ -222,7 +224,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/storage-location/{storageLocationId}/stock")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Get stock at a storage location",
             description = "Returns the current material stock levels at the given storage location."
@@ -238,7 +240,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/material/{materialId}/stock")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Get stock for a material",
             description = "Returns the current stock levels of the given material across storage locations."
@@ -254,7 +256,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/task/{taskId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List inventory transactions for a task",
             description = "Returns the inventory transactions recorded for the given task."
@@ -269,7 +271,7 @@ public class InventoryTransactionControllerWeb {
     }
 
     @GetMapping("/project/{projectId}/task-summary")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Get task material usage summary for a project",
             description = "Returns a per-task summary of material usage for the given project."

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
@@ -37,9 +37,11 @@ import java.util.List;
                 + "current tenant. Covers the same create, browse, search, update, stock lookup and "
                 + "delete operations as the standard materials endpoints, for use from the admin web "
                 + "console rather than the mobile app. Reads, including the stock lookup, are open to "
-                + "the system-admin and project-manager roles, because a project manager raises and "
-                + "approves stock adjustments and those are documents about a material's balance. "
-                + "Changing the catalogue, its thresholds included, stays with system-admin."
+                + "the system-admin, project-manager and store-keeper roles, because a project manager "
+                + "raises and approves stock adjustments and those are documents about a material's "
+                + "balance, and a storekeeper cannot name a material on a receipt, an issue or a count "
+                + "without reading the catalogue first. Changing the catalogue, its thresholds included, "
+                + "stays with system-admin."
 )
 public class MaterialControllerWeb {
 
@@ -78,7 +80,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Get a material by id",
             description = "Returns a single material with its creator and current aggregate stock value."
@@ -94,7 +96,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List all materials",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -108,7 +110,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List materials, paginated",
             description = "Returns a single page of materials. The pageNo and pageSize parameters "
@@ -126,7 +128,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/low-stock")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List materials at or below their reorder level",
             description = "Returns a page of the materials whose stock has reached the reorder level "
@@ -156,7 +158,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/summary")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Total the catalogue and the value of the stock on hand",
             description = "Returns the figures a materials dashboard strip is built from, totalled "
@@ -183,7 +185,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/search")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Search materials by name",
             description = "Returns materials whose name matches the given search term, such as \"Cement\" "
@@ -199,7 +201,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/{id}/stock")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Get a material with its current stock",
             description = "Returns a material along with its current stock. When projectId and "
@@ -266,7 +268,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/{materialId}/location-thresholds")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List a material's per-location threshold overrides",
             description = "Returns every storage-location override of the material's planning thresholds. "

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
@@ -27,10 +27,12 @@ import java.util.List;
 @Validated
 @Tag(
         name = "Material Consumptions (Web)",
-        description = "Web-console counterpart of the material consumptions API, restricted to the "
-                + "system-admin role for the current tenant. Covers the same recording and lookup "
-                + "operations as the standard material consumption endpoints, for use from the admin "
-                + "web console rather than the mobile app."
+        description = "Web-console counterpart of the material consumptions API, gated by organization "
+                + "role for the current tenant. Recording an issue and looking issues up are open to the "
+                + "system-admin and store-keeper roles: handing material out over the counter is the "
+                + "store\'s own work. Covers the same recording and lookup operations as the standard "
+                + "material consumption endpoints, for use from the admin web console rather than the "
+                + "mobile app."
 )
 public class MaterialConsumptionControllerWeb {
 
@@ -41,7 +43,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @PostMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Record a material consumption",
             description = "Records material consumed against a project, and optionally a storage "
@@ -62,7 +64,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Get a material consumption by id",
             description = "Returns a single material consumption record with its material, project, "
@@ -79,7 +81,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List all material consumptions",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -94,7 +96,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List material consumptions, paginated",
             description = "Returns a single page of material consumption records. The pageNo and "
@@ -112,7 +114,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/material/{materialId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List consumptions for a material",
             description = "Returns every consumption record for the given material, such as all draws "
@@ -129,7 +131,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/type/{consumptionType}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List consumptions by type",
             description = "Returns every consumption record of the given consumption type, such as "
@@ -145,7 +147,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/date-range")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List consumptions in a date range",
             description = "Returns every consumption record whose consumption date falls between "
@@ -165,7 +167,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/task/{taskId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List consumptions for a task",
             description = "Returns every consumption record linked to the given task."

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
@@ -28,8 +28,10 @@ import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
         name = "Purchase Orders",
         description = "Purchase orders raised against a vendor, optionally converted from an indent. A "
                 + "purchase order carries line items, a status lifecycle from draft through fully "
-                + "received or cancelled, and the totals used for payables. Access is restricted to the "
-                + "system-admin role for the current tenant."
+                + "received or cancelled, and the totals used for payables. Raising and changing an order "
+                + "is restricted to the system-admin role for the current tenant. Reading one is also open "
+                + "to store-keeper, which is what a goods receipt is booked against: the receiving end has "
+                + "to see what was ordered without being able to alter the order."
 )
 public class PurchaseOrderController {
 
@@ -56,7 +58,7 @@ public class PurchaseOrderController {
         return new ResponseEntity<>(created, HttpStatus.CREATED);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping("/{id}")
     @Operation(
             summary = "Get a purchase order by id",
@@ -72,7 +74,7 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrder);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping
     @Operation(
             summary = "List all purchase orders",
@@ -87,7 +89,7 @@ public class PurchaseOrderController {
                 purchaseOrderService.getAllPurchaseOrders(0, UnpagedResultCap.MAX_ROWS));
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping("/all")
     @Operation(
             summary = "List purchase orders, paginated",
@@ -105,7 +107,7 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrders);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping("/vendor/{vendorId}")
     @Operation(
             summary = "List purchase orders for a vendor",
@@ -121,7 +123,7 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrders);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping("/indent/{indentId}")
     @Operation(
             summary = "List purchase orders for an indent",
@@ -136,7 +138,7 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrders);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping("/status/{status}")
     @Operation(
             summary = "List purchase orders by status",

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
@@ -58,7 +58,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Get a purchase order by id",
             description = "Returns a single purchase order including its vendor, indent link, items and totals."
@@ -81,7 +81,7 @@ public class PurchaseOrderControllerWeb {
      * @return A {@link ResponseEntity} containing a page of trail entries and HTTP status 200 (OK).
      */
     @GetMapping("/{id}/status-history")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Read a purchase order's status trail",
             description = "Returns a page of the order's status entries, newest first: what it moved "
@@ -107,7 +107,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List all purchase orders",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -122,7 +122,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List purchase orders, paginated",
             description = "Returns a single page of purchase orders. The pageNo and pageSize parameters "
@@ -140,7 +140,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/vendor/{vendorId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List purchase orders for a vendor",
             description = "Returns every purchase order raised against the given vendor, for example every "
@@ -156,7 +156,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/indent/{indentId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List purchase orders for an indent",
             description = "Returns every purchase order that was raised from the given material indent."
@@ -171,7 +171,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/status/{status}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List purchase orders by status",
             description = "Returns every purchase order currently in the given lifecycle status, such as "

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
@@ -28,8 +28,9 @@ import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
         name = "Purchase Order Items",
         description = "Line items belonging to a purchase order: the material, ordered and received "
                 + "quantities, unit price and totals. Items can be created independently of the parent "
-                + "order create call and looked up by purchase order or by material. Access is restricted "
-                + "to the system-admin role for the current tenant."
+                + "order create call and looked up by purchase order or by material. Writing an item is "
+                + "restricted to the system-admin role for the current tenant. Reading one is also open to "
+                + "store-keeper, who needs the ordered quantities to check a delivery against them."
 )
 public class PurchaseOrderItemController {
 
@@ -57,7 +58,7 @@ public class PurchaseOrderItemController {
         return new ResponseEntity<>(created, HttpStatus.CREATED);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping("/{id}")
     @Operation(
             summary = "Get a purchase order item by id",
@@ -73,7 +74,7 @@ public class PurchaseOrderItemController {
         return ResponseEntity.ok(item);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping
     @Operation(
             summary = "List all purchase order items",
@@ -100,7 +101,7 @@ public class PurchaseOrderItemController {
      * @return A {@link ResponseEntity} containing the page of purchase order items.
      */
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List purchase order items, paginated",
             description = "Returns a single page of purchase order items with the paging metadata included. "
@@ -115,7 +116,7 @@ public class PurchaseOrderItemController {
         return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageQuery.getPageNo(), pageQuery.getPageSize()));
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping("/purchase-order/{purchaseOrderId}")
     @Operation(
             summary = "List items for a purchase order",
@@ -132,7 +133,7 @@ public class PurchaseOrderItemController {
         return ResponseEntity.ok(items);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @GetMapping("/material/{materialId}")
     @Operation(
             summary = "List items for a material",

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
@@ -54,7 +54,7 @@ public class PurchaseOrderItemControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Get a purchase order item by id",
             description = "Returns a single purchase order line item, including ordered and received quantities."
@@ -70,7 +70,7 @@ public class PurchaseOrderItemControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List all purchase order items",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -96,7 +96,7 @@ public class PurchaseOrderItemControllerWeb {
      * @return A {@link ResponseEntity} containing the page of purchase order items.
      */
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List purchase order items, paginated",
             description = "Returns a single page of purchase order items with the paging metadata included. "
@@ -112,7 +112,7 @@ public class PurchaseOrderItemControllerWeb {
     }
 
     @GetMapping("/purchase-order/{purchaseOrderId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List items for a purchase order",
             description = "Returns every line item belonging to the given purchase order, for example all "
@@ -129,7 +129,7 @@ public class PurchaseOrderItemControllerWeb {
     }
 
     @GetMapping("/material/{materialId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List items for a material",
             description = "Returns every purchase order line item that orders the given material, across "

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
@@ -30,9 +30,12 @@ import java.util.List;
 @Tag(
         name = "Site Transfers (Web)",
         description = "Web-app view of site transfers: the same movement of materials between two projects "
-                + "and their storage locations as the mobile-facing site-transfer endpoints, restricted to "
-                + "the system-admin role for the caller's current tenant. Creating a transfer checks that "
-                + "the sending location holds enough stock before the items are recorded."
+                + "and their storage locations as the mobile-facing site-transfer endpoints, gated by "
+                + "organization role for the caller's current tenant. Raising a transfer, confirming what "
+                + "the receiving site took delivery of, and cancelling one that never arrived are open to "
+                + "the system-admin and store-keeper roles, since both ends of a transfer are worked by a "
+                + "store. Creating a transfer checks that the sending location holds enough stock before "
+                + "the items are recorded."
 )
 public class SiteTransferControllerWeb {
 
@@ -43,7 +46,7 @@ public class SiteTransferControllerWeb {
     }
 
     @PostMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Create a site transfer",
             description = "Creates a site transfer moving materials from a sending project, and optionally a "
@@ -64,7 +67,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Get a site transfer by id",
             description = "Returns a single site transfer including its sending and receiving projects, "
@@ -81,7 +84,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List all site transfers",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -96,7 +99,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List site transfers, paginated",
             description = "Returns a single page of site transfers ordered by issue date, most recent first. "
@@ -114,7 +117,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/status/{status}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List site transfers by status",
             description = "Returns every site transfer currently in the given status, for example PENDING, "
@@ -130,7 +133,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/sending-project/{projectId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List site transfers sent from a project",
             description = "Returns every site transfer whose sending project is the given project id."
@@ -145,7 +148,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/receiving-project/{projectId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List site transfers received by a project",
             description = "Returns every site transfer whose receiving project is the given project id."
@@ -160,7 +163,7 @@ public class SiteTransferControllerWeb {
     }
 
     @PatchMapping("/{id}/status")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Deprecated
     @Operation(
             deprecated = true,
@@ -187,7 +190,7 @@ public class SiteTransferControllerWeb {
     }
 
     @PostMapping("/{id}/receive")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Record what the receiving site took delivery of",
             description = "Posts the stock that actually arrived at the receiving project and "
@@ -219,7 +222,7 @@ public class SiteTransferControllerWeb {
     }
 
     @PostMapping("/{id}/cancel")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Cancel a transfer that never arrived",
             description = "Abandons a PENDING transfer and returns the whole sent quantity to the "
@@ -244,7 +247,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/{id}/status-history")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Read a site transfer's status trail",
             description = "Returns a page of the transfer's status entries, newest first: what it "

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -35,9 +35,12 @@ import java.util.List;
                 + "current tenant. A draft is either approved, which posts it, or rejected with a "
                 + "stated reason, which posts nothing and keeps the refused correction on the "
                 + "record; both decisions freeze the document. "
-                + "Read endpoints require tenant membership; write and decision endpoints require the "
-                + "system-admin or project-manager role, and approval additionally has to come from "
-                + "someone other than whoever raised the document."
+                + "Read endpoints require tenant membership. Raising and editing a draft is open to the "
+                + "system-admin, project-manager and store-keeper roles, because taking the count is the "
+                + "store's own work. Approving, rejecting and deleting stay with system-admin and "
+                + "project-manager: an approval posts the balance and is the second pair of eyes on "
+                + "somebody else's count, which is also why it has to come from someone other than "
+                + "whoever raised the document."
 )
 public class StockAdjustmentControllerWeb {
 
@@ -119,7 +122,7 @@ public class StockAdjustmentControllerWeb {
     }
 
     @PostMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Create a stock adjustment",
             description = "Records a stock adjustment document capturing the counted and system quantities, "
@@ -139,7 +142,7 @@ public class StockAdjustmentControllerWeb {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Update a stock adjustment",
             description = "Replaces the header fields and line items of an existing stock adjustment with "

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
@@ -29,10 +29,11 @@ import java.util.List;
         description = "Web-console counterpart of the storage location API, gated by organization role "
                 + "instead of a flat authority. Covers the same create, read and lookup operations as the "
                 + "mobile API plus partial update and delete, which the mobile API does not expose. Reads "
-                + "are open to the system-admin and project-manager roles in the caller's current tenant, "
-                + "because a project manager raises and approves stock adjustments and cannot pick a "
-                + "location to count without them. Creating, editing and deleting a location stays with "
-                + "system-admin."
+                + "are open to the system-admin, project-manager and store-keeper roles in the caller's "
+                + "current tenant, because a project manager raises and approves stock adjustments and "
+                + "cannot pick a location to count without them, and every stores document names the "
+                + "location the material came from or went to. Creating, editing and deleting a location "
+                + "stays with system-admin."
 )
 public class StorageLocationControllerWeb {
 
@@ -63,7 +64,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "Get a storage location by id",
             description = "Returns a single storage location, including its resolved project name and "
@@ -80,7 +81,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List all storage locations",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -95,7 +96,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List storage locations, paginated",
             description = "Returns a single page of storage locations. The pageNo and pageSize "
@@ -112,7 +113,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping("/project/{projectId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List storage locations for a project",
             description = "Returns the storage locations linked to the given project id, for example the "
@@ -128,7 +129,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping("/type/{locationType}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager','store-keeper')")
     @Operation(
             summary = "List storage locations by type",
             description = "Returns the storage locations of the given type, for example all WAREHOUSE "

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
@@ -23,11 +23,14 @@ import java.util.List;
 @Validated
 @Tag(
         name = "Vendors (Web)",
-        description = "Web-console counterpart of the vendors API, restricted to the system-admin role "
-                + "for the current tenant instead of the flat vendor authorities used by the mobile "
-                + "variant. Covers the same create, browse, search, update, delete and summary "
-                + "operations for vendors and their contacts, tax identifiers, bank accounts and "
-                + "payment terms, for use from the admin web console."
+        description = "Web-console counterpart of the vendors API, gated by organization role for the "
+                + "current tenant instead of by the flat vendor authorities used by the mobile variant. "
+                + "Naming a vendor and reaching its contacts are open to the system-admin and store-keeper "
+                + "roles, because a delivery has to say who brought it; the vendor summary, tax "
+                + "identifiers, bank accounts and payment terms are commercial rather than stores "
+                + "information and stay with system-admin, as do all vendor writes. Covers create, "
+                + "browse, search, update, delete and summary operations for vendors and their contacts, "
+                + "tax identifiers, bank accounts and payment terms, for use from the admin web console."
 )
 public class VendorControllerWeb {
 
@@ -58,7 +61,7 @@ public class VendorControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Get a vendor by id",
             description = "Returns a single vendor."
@@ -74,7 +77,7 @@ public class VendorControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List vendors",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -88,7 +91,7 @@ public class VendorControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List vendors (paged)",
             description = "Returns a single page of vendors controlled by the pageNo and pageSize parameters."
@@ -105,7 +108,7 @@ public class VendorControllerWeb {
     }
 
     @GetMapping("/search")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "Search vendors by name",
             description = "Returns vendors whose name matches the given search term."
@@ -175,7 +178,7 @@ public class VendorControllerWeb {
     // ==================== Contact Endpoints ====================
 
     @GetMapping("/{vendorId}/contacts")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
     @Operation(
             summary = "List vendor contacts",
             description = "Returns the contacts recorded for the given vendor."

--- a/src/test/java/org/tornotron/echno_backend/architecture/StoreKeeperRoleScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/StoreKeeperRoleScopeTest.java
@@ -42,7 +42,7 @@ class StoreKeeperRoleScopeTest {
     private static final String ROLE = "store-keeper";
 
     /**
-     * Every endpoint the role may reach, as {@code CONTROLLER.method}.
+     * Every endpoint the role may reach, as {@code CONTROLLER.method VERB path}.
      *
      * <p>The reads are here because a form that cannot be filled in is the same refusal one screen
      * earlier: a receipt names a purchase order, a vendor, a project, a storage location and a
@@ -52,137 +52,150 @@ class StoreKeeperRoleScopeTest {
      */
     private static final Set<String> EXPECTED = new TreeSet<>(Set.of(
             // Recording a delivery, which is the case the role was introduced for.
-            "GoodsReceivedNoteControllerWeb.createGrn",
-            "GoodsReceivedNoteControllerWeb.updateGrn",
-            "GoodsReceivedNoteControllerWeb.getGrnById",
-            "GoodsReceivedNoteControllerWeb.getAllGrns",
-            "GoodsReceivedNoteControllerWeb.getAllGrnsPaginated",
-            "GoodsReceivedNoteControllerWeb.getGrnsByVendor",
-            "GoodsReceivedNoteControllerWeb.getGrnsByDateRange",
+            "GoodsReceivedNoteControllerWeb.createGrn POST",
+            "GoodsReceivedNoteControllerWeb.getGrnById GET /{id}",
+            "GoodsReceivedNoteControllerWeb.getAllGrns GET",
+            "GoodsReceivedNoteControllerWeb.getAllGrnsPaginated GET /all",
+            "GoodsReceivedNoteControllerWeb.getGrnsByVendor GET /vendor/{vendorId}",
+            "GoodsReceivedNoteControllerWeb.updateGrn PATCH",
+            "GoodsReceivedNoteControllerWeb.getGrnsByDateRange GET /date-range",
 
             // Handing material out over the counter.
-            "MaterialConsumptionControllerWeb.createMaterialConsumption",
-            "MaterialConsumptionControllerWeb.getMaterialConsumptionById",
-            "MaterialConsumptionControllerWeb.getAllMaterialConsumptions",
-            "MaterialConsumptionControllerWeb.getAllMaterialConsumptionsPaginated",
-            "MaterialConsumptionControllerWeb.getConsumptionsByMaterial",
-            "MaterialConsumptionControllerWeb.getConsumptionsByType",
-            "MaterialConsumptionControllerWeb.getConsumptionsByDateRange",
-            "MaterialConsumptionControllerWeb.getConsumptionsByTask",
+            "MaterialConsumptionControllerWeb.createMaterialConsumption POST",
+            "MaterialConsumptionControllerWeb.getMaterialConsumptionById GET /{id}",
+            "MaterialConsumptionControllerWeb.getAllMaterialConsumptions GET",
+            "MaterialConsumptionControllerWeb.getAllMaterialConsumptionsPaginated GET /all",
+            "MaterialConsumptionControllerWeb.getConsumptionsByMaterial GET /material/{materialId}",
+            "MaterialConsumptionControllerWeb.getConsumptionsByType GET /type/{consumptionType}",
+            "MaterialConsumptionControllerWeb.getConsumptionsByDateRange GET /date-range",
+            "MaterialConsumptionControllerWeb.getConsumptionsByTask GET /task/{taskId}",
 
             // Both ends of a site transfer are worked by a store: one despatches, one confirms.
             // The status route is a signpost rather than an authority. It refuses every payload and
             // answers by naming the receive and cancel routes, which is a better reply than a 403
             // to a caller who holds both of those.
-            "SiteTransferControllerWeb.createSiteTransfer",
-            "SiteTransferControllerWeb.receiveSiteTransfer",
-            "SiteTransferControllerWeb.cancelSiteTransfer",
-            "SiteTransferControllerWeb.updateSiteTransferStatus",
-            "SiteTransferControllerWeb.getSiteTransferById",
-            "SiteTransferControllerWeb.getAllSiteTransfers",
-            "SiteTransferControllerWeb.getAllSiteTransfersPaginated",
-            "SiteTransferControllerWeb.getSiteTransfersByStatus",
-            "SiteTransferControllerWeb.getSiteTransfersBySendingProject",
-            "SiteTransferControllerWeb.getSiteTransfersByReceivingProject",
-            "SiteTransferControllerWeb.readStatusHistory",
+            "SiteTransferControllerWeb.createSiteTransfer POST",
+            "SiteTransferControllerWeb.getSiteTransferById GET /{id}",
+            "SiteTransferControllerWeb.getAllSiteTransfers GET",
+            "SiteTransferControllerWeb.getAllSiteTransfersPaginated GET /all",
+            "SiteTransferControllerWeb.getSiteTransfersByStatus GET /status/{status}",
+            "SiteTransferControllerWeb.getSiteTransfersBySendingProject GET /sending-project/{projectId}",
+            "SiteTransferControllerWeb.getSiteTransfersByReceivingProject GET /receiving-project/{projectId}",
+            "SiteTransferControllerWeb.updateSiteTransferStatus PATCH /{id}/status",
+            "SiteTransferControllerWeb.receiveSiteTransfer POST /{id}/receive",
+            "SiteTransferControllerWeb.cancelSiteTransfer POST /{id}/cancel",
+            "SiteTransferControllerWeb.readStatusHistory GET /{id}/status-history",
 
             // Taking the count and writing down what it found. Approving it is somebody else's.
-            "StockAdjustmentControllerWeb.createStockAdjustment",
-            "StockAdjustmentControllerWeb.updateStockAdjustment",
+            "StockAdjustmentControllerWeb.createStockAdjustment POST",
+            "StockAdjustmentControllerWeb.updateStockAdjustment PUT /{id}",
 
             // The catalogue and the balances held against it, which every stores form names.
-            "MaterialControllerWeb.getMaterialById",
-            "MaterialControllerWeb.getAllMaterials",
-            "MaterialControllerWeb.getAllMaterialsPaginated",
-            "MaterialControllerWeb.getLowStockMaterials",
-            "MaterialControllerWeb.getStockSummary",
-            "MaterialControllerWeb.searchMaterials",
-            "MaterialControllerWeb.getMaterialWithStock",
-            "MaterialControllerWeb.getLocationThresholds",
+            "MaterialControllerWeb.getMaterialById GET /{id}",
+            "MaterialControllerWeb.getAllMaterials GET",
+            "MaterialControllerWeb.getAllMaterialsPaginated GET /all",
+            "MaterialControllerWeb.getLowStockMaterials GET /low-stock",
+            "MaterialControllerWeb.getStockSummary GET /summary",
+            "MaterialControllerWeb.searchMaterials GET /search",
+            "MaterialControllerWeb.getMaterialWithStock GET /{id}/stock",
+            "MaterialControllerWeb.getLocationThresholds GET /{materialId}/location-thresholds",
 
             // Where the material came from and where it is going.
-            "StorageLocationControllerWeb.getStorageLocationById",
-            "StorageLocationControllerWeb.getAllStorageLocations",
-            "StorageLocationControllerWeb.getAllStorageLocationsPaginated",
-            "StorageLocationControllerWeb.getStorageLocationsByProject",
-            "StorageLocationControllerWeb.getStorageLocationsByType",
+            "StorageLocationControllerWeb.getStorageLocationById GET /{id}",
+            "StorageLocationControllerWeb.getAllStorageLocations GET",
+            "StorageLocationControllerWeb.getAllStorageLocationsPaginated GET /all",
+            "StorageLocationControllerWeb.getStorageLocationsByProject GET /project/{projectId}",
+            "StorageLocationControllerWeb.getStorageLocationsByType GET /type/{locationType}",
 
             // The ledger the storekeeper's own documents post into.
-            "InventoryTransactionControllerWeb.getTransactionById",
-            "InventoryTransactionControllerWeb.getAllTransactions",
-            "InventoryTransactionControllerWeb.getAllTransactionsPaginated",
-            "InventoryTransactionControllerWeb.getTransactionsByMaterial",
-            "InventoryTransactionControllerWeb.getMaterialMovementHistory",
-            "InventoryTransactionControllerWeb.getTransactionsByProject",
-            "InventoryTransactionControllerWeb.getTransactionsByType",
-            "InventoryTransactionControllerWeb.getTransactionsByDateRange",
-            "InventoryTransactionControllerWeb.getTransactionsByStorageLocation",
-            "InventoryTransactionControllerWeb.getTransactionsByStorageLocationMaterialAndProject",
-            "InventoryTransactionControllerWeb.getStockByStorageLocation",
-            "InventoryTransactionControllerWeb.getStockByMaterial",
-            "InventoryTransactionControllerWeb.getTransactionsByTask",
-            "InventoryTransactionControllerWeb.getTaskMaterialUsageSummary",
+            "InventoryTransactionControllerWeb.getTransactionById GET /{id}",
+            "InventoryTransactionControllerWeb.getAllTransactions GET",
+            "InventoryTransactionControllerWeb.getAllTransactionsPaginated GET /all",
+            "InventoryTransactionControllerWeb.getTransactionsByMaterial GET /material/{materialId}",
+            "InventoryTransactionControllerWeb.getMaterialMovementHistory GET /material/{materialId}/history",
+            "InventoryTransactionControllerWeb.getTransactionsByProject GET /project/{projectId}",
+            "InventoryTransactionControllerWeb.getTransactionsByType GET /type/{transactionType}",
+            "InventoryTransactionControllerWeb.getTransactionsByDateRange GET /date-range",
+            "InventoryTransactionControllerWeb.getTransactionsByStorageLocation GET /storage-location/{storageLocationId}",
+            "InventoryTransactionControllerWeb.getTransactionsByStorageLocationMaterialAndProject GET /storage-location/{storageLocationId}/material/{materialId}/project/{projectId}",
+            "InventoryTransactionControllerWeb.getStockByStorageLocation GET /storage-location/{storageLocationId}/stock",
+            "InventoryTransactionControllerWeb.getStockByMaterial GET /material/{materialId}/stock",
+            "InventoryTransactionControllerWeb.getTransactionsByTask GET /task/{taskId}",
+            "InventoryTransactionControllerWeb.getTaskMaterialUsageSummary GET /project/{projectId}/task-summary",
 
             // What was ordered, so a delivery can be checked against it. Read only: placing and
-            // changing the order is procurement's, and the receiving end must not be able to edit
+            // changing the order is procurement's, and the receiving end must not be able to alter
             // the figures it is being measured against. Both twins carry the org-role guard, so
             // both get the read.
-            "PurchaseOrderControllerWeb.getPurchaseOrderById",
-            "PurchaseOrderControllerWeb.getAllPurchaseOrders",
-            "PurchaseOrderControllerWeb.getAllPurchaseOrdersPaginated",
-            "PurchaseOrderControllerWeb.getPurchaseOrdersByVendor",
-            "PurchaseOrderControllerWeb.getPurchaseOrdersByIndent",
-            "PurchaseOrderControllerWeb.getPurchaseOrdersByStatus",
-            "PurchaseOrderControllerWeb.readStatusHistory",
-            "PurchaseOrderController.getPurchaseOrderById",
-            "PurchaseOrderController.getAllPurchaseOrders",
-            "PurchaseOrderController.getAllPurchaseOrdersPaginated",
-            "PurchaseOrderController.getPurchaseOrdersByVendor",
-            "PurchaseOrderController.getPurchaseOrdersByIndent",
-            "PurchaseOrderController.getPurchaseOrdersByStatus",
-            "PurchaseOrderItemControllerWeb.getPurchaseOrderItemById",
-            "PurchaseOrderItemControllerWeb.getAllPurchaseOrderItems",
-            "PurchaseOrderItemControllerWeb.getPurchaseOrderItemsPaginated",
-            "PurchaseOrderItemControllerWeb.getItemsByPurchaseOrderId",
-            "PurchaseOrderItemControllerWeb.getItemsByMaterialId",
-            "PurchaseOrderItemController.getPurchaseOrderItemById",
-            "PurchaseOrderItemController.getAllPurchaseOrderItems",
-            "PurchaseOrderItemController.getPurchaseOrderItemsPaginated",
-            "PurchaseOrderItemController.getItemsByPurchaseOrderId",
-            "PurchaseOrderItemController.getItemsByMaterialId",
+            "PurchaseOrderControllerWeb.getPurchaseOrderById GET /{id}",
+            "PurchaseOrderControllerWeb.readStatusHistory GET /{id}/status-history",
+            "PurchaseOrderControllerWeb.getAllPurchaseOrders GET",
+            "PurchaseOrderControllerWeb.getAllPurchaseOrdersPaginated GET /all",
+            "PurchaseOrderControllerWeb.getPurchaseOrdersByVendor GET /vendor/{vendorId}",
+            "PurchaseOrderControllerWeb.getPurchaseOrdersByIndent GET /indent/{indentId}",
+            "PurchaseOrderControllerWeb.getPurchaseOrdersByStatus GET /status/{status}",
+            "PurchaseOrderController.getPurchaseOrderById GET /{id}",
+            "PurchaseOrderController.getAllPurchaseOrders GET",
+            "PurchaseOrderController.getAllPurchaseOrdersPaginated GET /all",
+            "PurchaseOrderController.getPurchaseOrdersByVendor GET /vendor/{vendorId}",
+            "PurchaseOrderController.getPurchaseOrdersByIndent GET /indent/{indentId}",
+            "PurchaseOrderController.getPurchaseOrdersByStatus GET /status/{status}",
+            "PurchaseOrderItemControllerWeb.getPurchaseOrderItemById GET /{id}",
+            "PurchaseOrderItemControllerWeb.getAllPurchaseOrderItems GET",
+            "PurchaseOrderItemControllerWeb.getPurchaseOrderItemsPaginated GET /paginated",
+            "PurchaseOrderItemControllerWeb.getItemsByPurchaseOrderId GET /purchase-order/{purchaseOrderId}",
+            "PurchaseOrderItemControllerWeb.getItemsByMaterialId GET /material/{materialId}",
+            "PurchaseOrderItemController.getPurchaseOrderItemById GET /{id}",
+            "PurchaseOrderItemController.getAllPurchaseOrderItems GET",
+            "PurchaseOrderItemController.getPurchaseOrderItemsPaginated GET /paginated",
+            "PurchaseOrderItemController.getItemsByPurchaseOrderId GET /purchase-order/{purchaseOrderId}",
+            "PurchaseOrderItemController.getItemsByMaterialId GET /material/{materialId}",
 
             // What has been requisitioned, so the store knows what a delivery answers and what is
-            // still outstanding. Raising a requisition is not on this list.
-            "IndentControllerWeb.getAllIndents",
-            "IndentControllerWeb.getAllIndentSummaries",
-            "IndentControllerWeb.getAnIndent",
-            "IndentControllerWeb.getItems",
-            "IndentItemControllerWeb.getIndentItemById",
-            "IndentItemControllerWeb.getAllIndentItems",
-            "IndentItemControllerWeb.getIndentItemsPaginated",
-            "IndentItemControllerWeb.getIndentItemsByIndentId",
-            "IndentItemControllerWeb.getIndentItemsByMaterialId",
-            "IndentItemControllerWeb.getIndentItemsByConversionStatus",
+            // still outstanding. Raising a requisition is not on this list. Both getAllIndents
+            // overloads are here by name and by mapping: they are two endpoints, not one.
+            "IndentControllerWeb.getAllIndents GET /all",
+            "IndentControllerWeb.getAllIndentSummaries GET /summary",
+            "IndentControllerWeb.getAllIndents GET",
+            "IndentControllerWeb.getAnIndent GET /{id}",
+            "IndentControllerWeb.getItems GET /{indentId}/items",
+            "IndentItemControllerWeb.getIndentItemById GET /{id}",
+            "IndentItemControllerWeb.getAllIndentItems GET",
+            "IndentItemControllerWeb.getIndentItemsPaginated GET /paginated",
+            "IndentItemControllerWeb.getIndentItemsByIndentId GET /indent/{indentId}",
+            "IndentItemControllerWeb.getIndentItemsByMaterialId GET /material/{materialId}",
+            "IndentItemControllerWeb.getIndentItemsByConversionStatus GET /conversion-status",
 
             // Who brought the delivery, and how to reach them about it. The vendor summary, bank
             // accounts, tax identifiers and payment terms are commercial rather than stores
             // information and are deliberately absent.
-            "VendorControllerWeb.getVendorById",
-            "VendorControllerWeb.getAllVendors",
-            "VendorControllerWeb.getAllVendorsPaginated",
-            "VendorControllerWeb.searchVendors",
-            "VendorControllerWeb.getContacts"
+            "VendorControllerWeb.getVendorById GET /{id}",
+            "VendorControllerWeb.getAllVendors GET",
+            "VendorControllerWeb.getAllVendorsPaginated GET /all",
+            "VendorControllerWeb.searchVendors GET /search",
+            "VendorControllerWeb.getContacts GET /{vendorId}/contacts"
     ));
 
-    /** One granted endpoint: the controller it sits on, the method, and the mapping above it. */
-    private record Granted(String controller, String method, String mapping) {
+    /**
+     * One granted endpoint: the controller it sits on, the method, and the mapping above it.
+     *
+     * <p>The signature names the mapping as well as the method, because a method name alone is not
+     * unique. {@code IndentControllerWeb} declares {@code getAllIndents} twice, once on
+     * {@code @GetMapping("/all")} and once on the bare {@code @GetMapping}, and keying by name
+     * collapsed the two into one entry: the set comparison then held with one of the pair
+     * ungranted, which is the failure this test exists to catch. Ninety-four guarded mappings must
+     * produce ninety-four signatures.
+     */
+    private record Granted(String controller, String method, String verb, String path) {
         String signature() {
-            return controller + "." + method;
+            String endpoint = path.isEmpty() ? verb : verb + " " + path;
+            return controller + "." + method + " " + endpoint;
         }
     }
 
     private static final Pattern PRE_AUTHORIZE = Pattern.compile("^\\s*@PreAuthorize\\((.*)\\)\\s*$");
-    private static final Pattern MAPPING = Pattern.compile("^\\s*@(Get|Post|Put|Patch|Delete)Mapping\\b.*");
+    private static final Pattern MAPPING = Pattern.compile(
+            "^\\s*@(Get|Post|Put|Patch|Delete)Mapping\\b\\s*(?:\\(\\s*(?:value\\s*=\\s*)?\"([^\"]*)\")?");
     private static final Pattern METHOD = Pattern.compile("^\\s*(?:public|protected)\\s+.*?\\b(\\w+)\\s*\\(.*");
 
     private List<Granted> grantedEndpoints() throws IOException {
@@ -201,7 +214,8 @@ class StoreKeeperRoleScopeTest {
         List<Granted> granted = new ArrayList<>();
 
         boolean carriesRole = false;
-        String mapping = null;
+        String verb = null;
+        String path = null;
         for (String line : lines) {
             Matcher pre = PRE_AUTHORIZE.matcher(line);
             if (pre.matches()) {
@@ -209,17 +223,20 @@ class StoreKeeperRoleScopeTest {
                 continue;
             }
             Matcher map = MAPPING.matcher(line);
-            if (map.matches()) {
-                mapping = map.group(1).toUpperCase();
+            if (map.find()) {
+                verb = map.group(1).toUpperCase();
+                path = map.group(2) == null ? "" : map.group(2);
                 continue;
             }
             Matcher method = METHOD.matcher(line);
             if (method.matches()) {
                 if (carriesRole) {
-                    granted.add(new Granted(controller, method.group(1), mapping == null ? "?" : mapping));
+                    granted.add(new Granted(controller, method.group(1),
+                            verb == null ? "?" : verb, path == null ? "" : path));
                 }
                 carriesRole = false;
-                mapping = null;
+                verb = null;
+                path = null;
             }
         }
         return granted;
@@ -227,10 +244,20 @@ class StoreKeeperRoleScopeTest {
 
     @Test
     void theRoleReachesExactlyTheEndpointsTheStoresWorkflowNeeds() throws IOException {
+        List<Granted> granted = grantedEndpoints();
         Set<String> actual = new TreeSet<>();
-        for (Granted g : grantedEndpoints()) {
+        for (Granted g : granted) {
             actual.add(g.signature());
         }
+
+        // The comparison below is a set comparison, so it is only as good as the key. Two guarded
+        // mappings sharing a signature would collapse into one entry and the set could then hold
+        // with one of the pair ungranted. Keying by mapping as well as method name is what keeps
+        // them apart, and this is the assertion that says so rather than assuming it.
+        assertThat(actual)
+                .as("one signature per guarded mapping. A collapse here means the key is not "
+                        + "unique and the comparison below can no longer see a removal")
+                .hasSize(granted.size());
 
         assertThat(actual)
                 .as("endpoints guarded on the '%s' role. Adding one is a widening of the role and "
@@ -250,8 +277,8 @@ class StoreKeeperRoleScopeTest {
         for (Granted g : grantedEndpoints()) {
             String method = g.method().toLowerCase();
             if (method.startsWith("approve") || method.startsWith("reject")
-                    || method.startsWith("delete") || "DELETE".equals(g.mapping())) {
-                forbidden.add(g.signature() + " (" + g.mapping() + ")");
+                    || method.startsWith("delete") || "DELETE".equals(g.verb())) {
+                forbidden.add(g.signature());
             }
         }
 

--- a/src/test/java/org/tornotron/echno_backend/architecture/StoreKeeperRoleScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/StoreKeeperRoleScopeTest.java
@@ -1,0 +1,262 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the whole of what the {@code store-keeper} role can reach, in one list.
+ *
+ * <p>The role exists because the Resources domain had nothing between plain organization membership
+ * and {@code system-admin}, so the only way to let somebody book a delivery was to make them an
+ * administrator of the organization. A role that narrow is only worth having while it stays narrow,
+ * and the way it stops being narrow is one guard at a time, each addition reasonable on its own.
+ *
+ * <p>So this test compares the two directions at once. The expected table below is the whole grant,
+ * and it is asserted to equal what the source actually carries, which means an endpoint added to the
+ * role and an endpoint removed from it both fail here. A widening is then a deliberate edit to this
+ * table with a reason attached, rather than a line in a diff nobody counts.
+ *
+ * <p>It reads the source rather than the loaded classes on purpose. Every entry is one
+ * {@code @PreAuthorize} string sitting above one mapping, which is exactly what is being pinned, and
+ * a text scan covers controllers this test does not have to know the names of: a guard added
+ * anywhere under {@code src/main} shows up whether or not somebody remembered this file.
+ */
+class StoreKeeperRoleScopeTest {
+
+    private static final Path SOURCE_ROOT = Path.of(
+            System.getProperty("main.source.root", "src/main/java"));
+
+    private static final String ROLE = "store-keeper";
+
+    /**
+     * Every endpoint the role may reach, as {@code CONTROLLER.method}.
+     *
+     * <p>The reads are here because a form that cannot be filled in is the same refusal one screen
+     * earlier: a receipt names a purchase order, a vendor, a project, a storage location and a
+     * material, and every one of those is a lookup the browser makes before the storekeeper can type
+     * anything. Opening the write and leaving the lookups shut moves the 403 rather than removing
+     * it, which is the failure this codebase has already made once.
+     */
+    private static final Set<String> EXPECTED = new TreeSet<>(Set.of(
+            // Recording a delivery, which is the case the role was introduced for.
+            "GoodsReceivedNoteControllerWeb.createGrn",
+            "GoodsReceivedNoteControllerWeb.updateGrn",
+            "GoodsReceivedNoteControllerWeb.getGrnById",
+            "GoodsReceivedNoteControllerWeb.getAllGrns",
+            "GoodsReceivedNoteControllerWeb.getAllGrnsPaginated",
+            "GoodsReceivedNoteControllerWeb.getGrnsByVendor",
+            "GoodsReceivedNoteControllerWeb.getGrnsByDateRange",
+
+            // Handing material out over the counter.
+            "MaterialConsumptionControllerWeb.createMaterialConsumption",
+            "MaterialConsumptionControllerWeb.getMaterialConsumptionById",
+            "MaterialConsumptionControllerWeb.getAllMaterialConsumptions",
+            "MaterialConsumptionControllerWeb.getAllMaterialConsumptionsPaginated",
+            "MaterialConsumptionControllerWeb.getConsumptionsByMaterial",
+            "MaterialConsumptionControllerWeb.getConsumptionsByType",
+            "MaterialConsumptionControllerWeb.getConsumptionsByDateRange",
+            "MaterialConsumptionControllerWeb.getConsumptionsByTask",
+
+            // Both ends of a site transfer are worked by a store: one despatches, one confirms.
+            // The status route is a signpost rather than an authority. It refuses every payload and
+            // answers by naming the receive and cancel routes, which is a better reply than a 403
+            // to a caller who holds both of those.
+            "SiteTransferControllerWeb.createSiteTransfer",
+            "SiteTransferControllerWeb.receiveSiteTransfer",
+            "SiteTransferControllerWeb.cancelSiteTransfer",
+            "SiteTransferControllerWeb.updateSiteTransferStatus",
+            "SiteTransferControllerWeb.getSiteTransferById",
+            "SiteTransferControllerWeb.getAllSiteTransfers",
+            "SiteTransferControllerWeb.getAllSiteTransfersPaginated",
+            "SiteTransferControllerWeb.getSiteTransfersByStatus",
+            "SiteTransferControllerWeb.getSiteTransfersBySendingProject",
+            "SiteTransferControllerWeb.getSiteTransfersByReceivingProject",
+            "SiteTransferControllerWeb.readStatusHistory",
+
+            // Taking the count and writing down what it found. Approving it is somebody else's.
+            "StockAdjustmentControllerWeb.createStockAdjustment",
+            "StockAdjustmentControllerWeb.updateStockAdjustment",
+
+            // The catalogue and the balances held against it, which every stores form names.
+            "MaterialControllerWeb.getMaterialById",
+            "MaterialControllerWeb.getAllMaterials",
+            "MaterialControllerWeb.getAllMaterialsPaginated",
+            "MaterialControllerWeb.getLowStockMaterials",
+            "MaterialControllerWeb.getStockSummary",
+            "MaterialControllerWeb.searchMaterials",
+            "MaterialControllerWeb.getMaterialWithStock",
+            "MaterialControllerWeb.getLocationThresholds",
+
+            // Where the material came from and where it is going.
+            "StorageLocationControllerWeb.getStorageLocationById",
+            "StorageLocationControllerWeb.getAllStorageLocations",
+            "StorageLocationControllerWeb.getAllStorageLocationsPaginated",
+            "StorageLocationControllerWeb.getStorageLocationsByProject",
+            "StorageLocationControllerWeb.getStorageLocationsByType",
+
+            // The ledger the storekeeper's own documents post into.
+            "InventoryTransactionControllerWeb.getTransactionById",
+            "InventoryTransactionControllerWeb.getAllTransactions",
+            "InventoryTransactionControllerWeb.getAllTransactionsPaginated",
+            "InventoryTransactionControllerWeb.getTransactionsByMaterial",
+            "InventoryTransactionControllerWeb.getMaterialMovementHistory",
+            "InventoryTransactionControllerWeb.getTransactionsByProject",
+            "InventoryTransactionControllerWeb.getTransactionsByType",
+            "InventoryTransactionControllerWeb.getTransactionsByDateRange",
+            "InventoryTransactionControllerWeb.getTransactionsByStorageLocation",
+            "InventoryTransactionControllerWeb.getTransactionsByStorageLocationMaterialAndProject",
+            "InventoryTransactionControllerWeb.getStockByStorageLocation",
+            "InventoryTransactionControllerWeb.getStockByMaterial",
+            "InventoryTransactionControllerWeb.getTransactionsByTask",
+            "InventoryTransactionControllerWeb.getTaskMaterialUsageSummary",
+
+            // What was ordered, so a delivery can be checked against it. Read only: placing and
+            // changing the order is procurement's, and the receiving end must not be able to edit
+            // the figures it is being measured against. Both twins carry the org-role guard, so
+            // both get the read.
+            "PurchaseOrderControllerWeb.getPurchaseOrderById",
+            "PurchaseOrderControllerWeb.getAllPurchaseOrders",
+            "PurchaseOrderControllerWeb.getAllPurchaseOrdersPaginated",
+            "PurchaseOrderControllerWeb.getPurchaseOrdersByVendor",
+            "PurchaseOrderControllerWeb.getPurchaseOrdersByIndent",
+            "PurchaseOrderControllerWeb.getPurchaseOrdersByStatus",
+            "PurchaseOrderControllerWeb.readStatusHistory",
+            "PurchaseOrderController.getPurchaseOrderById",
+            "PurchaseOrderController.getAllPurchaseOrders",
+            "PurchaseOrderController.getAllPurchaseOrdersPaginated",
+            "PurchaseOrderController.getPurchaseOrdersByVendor",
+            "PurchaseOrderController.getPurchaseOrdersByIndent",
+            "PurchaseOrderController.getPurchaseOrdersByStatus",
+            "PurchaseOrderItemControllerWeb.getPurchaseOrderItemById",
+            "PurchaseOrderItemControllerWeb.getAllPurchaseOrderItems",
+            "PurchaseOrderItemControllerWeb.getPurchaseOrderItemsPaginated",
+            "PurchaseOrderItemControllerWeb.getItemsByPurchaseOrderId",
+            "PurchaseOrderItemControllerWeb.getItemsByMaterialId",
+            "PurchaseOrderItemController.getPurchaseOrderItemById",
+            "PurchaseOrderItemController.getAllPurchaseOrderItems",
+            "PurchaseOrderItemController.getPurchaseOrderItemsPaginated",
+            "PurchaseOrderItemController.getItemsByPurchaseOrderId",
+            "PurchaseOrderItemController.getItemsByMaterialId",
+
+            // What has been requisitioned, so the store knows what a delivery answers and what is
+            // still outstanding. Raising a requisition is not on this list.
+            "IndentControllerWeb.getAllIndents",
+            "IndentControllerWeb.getAllIndentSummaries",
+            "IndentControllerWeb.getAnIndent",
+            "IndentControllerWeb.getItems",
+            "IndentItemControllerWeb.getIndentItemById",
+            "IndentItemControllerWeb.getAllIndentItems",
+            "IndentItemControllerWeb.getIndentItemsPaginated",
+            "IndentItemControllerWeb.getIndentItemsByIndentId",
+            "IndentItemControllerWeb.getIndentItemsByMaterialId",
+            "IndentItemControllerWeb.getIndentItemsByConversionStatus",
+
+            // Who brought the delivery, and how to reach them about it. The vendor summary, bank
+            // accounts, tax identifiers and payment terms are commercial rather than stores
+            // information and are deliberately absent.
+            "VendorControllerWeb.getVendorById",
+            "VendorControllerWeb.getAllVendors",
+            "VendorControllerWeb.getAllVendorsPaginated",
+            "VendorControllerWeb.searchVendors",
+            "VendorControllerWeb.getContacts"
+    ));
+
+    /** One granted endpoint: the controller it sits on, the method, and the mapping above it. */
+    private record Granted(String controller, String method, String mapping) {
+        String signature() {
+            return controller + "." + method;
+        }
+    }
+
+    private static final Pattern PRE_AUTHORIZE = Pattern.compile("^\\s*@PreAuthorize\\((.*)\\)\\s*$");
+    private static final Pattern MAPPING = Pattern.compile("^\\s*@(Get|Post|Put|Patch|Delete)Mapping\\b.*");
+    private static final Pattern METHOD = Pattern.compile("^\\s*(?:public|protected)\\s+.*?\\b(\\w+)\\s*\\(.*");
+
+    private List<Granted> grantedEndpoints() throws IOException {
+        List<Granted> granted = new ArrayList<>();
+        try (Stream<Path> files = Files.walk(SOURCE_ROOT)) {
+            for (Path file : files.filter(p -> p.toString().endsWith(".java")).toList()) {
+                granted.addAll(grantedIn(file));
+            }
+        }
+        return granted;
+    }
+
+    private List<Granted> grantedIn(Path file) throws IOException {
+        String controller = file.getFileName().toString().replace(".java", "");
+        List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+        List<Granted> granted = new ArrayList<>();
+
+        boolean carriesRole = false;
+        String mapping = null;
+        for (String line : lines) {
+            Matcher pre = PRE_AUTHORIZE.matcher(line);
+            if (pre.matches()) {
+                carriesRole = pre.group(1).contains("'" + ROLE + "'");
+                continue;
+            }
+            Matcher map = MAPPING.matcher(line);
+            if (map.matches()) {
+                mapping = map.group(1).toUpperCase();
+                continue;
+            }
+            Matcher method = METHOD.matcher(line);
+            if (method.matches()) {
+                if (carriesRole) {
+                    granted.add(new Granted(controller, method.group(1), mapping == null ? "?" : mapping));
+                }
+                carriesRole = false;
+                mapping = null;
+            }
+        }
+        return granted;
+    }
+
+    @Test
+    void theRoleReachesExactlyTheEndpointsTheStoresWorkflowNeeds() throws IOException {
+        Set<String> actual = new TreeSet<>();
+        for (Granted g : grantedEndpoints()) {
+            actual.add(g.signature());
+        }
+
+        assertThat(actual)
+                .as("endpoints guarded on the '%s' role. Adding one is a widening of the role and "
+                        + "belongs in the table in this test with a reason; removing one is a "
+                        + "capability the storekeeper workflow silently lost", ROLE)
+                .isEqualTo(EXPECTED);
+    }
+
+    @Test
+    void theRoleNeverApprovesRejectsOrDeletesAnything() throws IOException {
+        // The storekeeper counts the shelf and writes down what they found. Approving the count is
+        // what posts the balance, and it is meant to be somebody else reading the document. The
+        // SelfApprovalPolicy already refuses a caller approving their own, but it is consulted one
+        // request too late to help if the role holds both halves: two storekeepers would simply
+        // approve each other's, and the control would be gone with the policy still passing.
+        List<String> forbidden = new ArrayList<>();
+        for (Granted g : grantedEndpoints()) {
+            String method = g.method().toLowerCase();
+            if (method.startsWith("approve") || method.startsWith("reject")
+                    || method.startsWith("delete") || "DELETE".equals(g.mapping())) {
+                forbidden.add(g.signature() + " (" + g.mapping() + ")");
+            }
+        }
+
+        assertThat(forbidden)
+                .as("endpoints on the '%s' role that approve, reject or delete", ROLE)
+                .isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWebAuthzTest.java
@@ -1,0 +1,176 @@
+package org.tornotron.echno_backend.goodsReceivedNote;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization test for the goods receipt, which is the case the {@code store-keeper}
+ * role was introduced for.
+ *
+ * <p>Before the role there was nothing between plain organization membership and {@code
+ * system-admin} anywhere in Resources, so the only way to let the person on the store counter book a
+ * delivery was to make them an administrator of the organization, able to delete projects and edit
+ * anybody's employee record. Every method here answered 403 to a storekeeper.
+ *
+ * <p>The reads are tested alongside the write on purpose. Opening {@code POST /grns/web} on its own
+ * would move the refusal rather than remove it: the browser lists the notes already recorded before
+ * it offers to record another, and a storekeeper who may create one and may not see it has been
+ * given a form and no register.
+ *
+ * <p>{@code @orgSecurity} is mocked so the branch under test is the only one answering true: the
+ * storekeeper stubs deliberately answer false to every expression that does not name the role, which
+ * is exactly a caller holding {@code store-keeper} and nothing else.
+ */
+@WebMvcTest(GoodsReceivedNoteControllerWeb.class)
+@Import(GoodsReceivedNoteControllerWebAuthzTest.TestSecurityConfig.class)
+class GoodsReceivedNoteControllerWebAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GoodsReceivedNoteService goodsReceivedNoteService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    // RPTExchangeFilter also depends on this cache; mocked for the same reason.
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** A caller holding store-keeper and no other org role. */
+    private void asStoreKeeper() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(true);
+    }
+
+    /** A caller who is a member of the tenant and holds no org role at all. */
+    private void asPlainMember() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(false);
+    }
+
+    private void stubReads() {
+        when(goodsReceivedNoteService.getGrnById(anyLong())).thenReturn(new GoodsReceivedNoteDto());
+        when(goodsReceivedNoteService.getAllGrns(anyInt(), anyInt())).thenReturn(Page.empty());
+        when(goodsReceivedNoteService.getGrnsByVendor(anyLong())).thenReturn(List.of());
+        when(goodsReceivedNoteService.getGrnsByDateRange(any(), any())).thenReturn(List.of());
+    }
+
+    /** The register the browser reads before it offers to record another delivery. */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/grns/web",
+            "/api/v1/grns/web/1",
+            "/api/v1/grns/web/all?pageNo=0&pageSize=20",
+            "/api/v1/grns/web/vendor/1",
+            "/api/v1/grns/web/date-range?startDate=2026-01-01T00:00:00&endDate=2026-12-31T00:00:00"
+    })
+    void aStoreKeeperMayReadGoodsReceivedNotes(String path) throws Exception {
+        asStoreKeeper();
+        stubReads();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * The endpoint the issue was filed about. A 400 here would be the payload failing validation
+     * after the guard let the request through, so the assertion is only that it is not a refusal.
+     */
+    @Test
+    void aStoreKeeperMayRecordADelivery() throws Exception {
+        asStoreKeeper();
+        when(goodsReceivedNoteService.createGoodsReceivedNote(any()))
+                .thenReturn(new GoodsReceivedNoteDto());
+
+        mockMvc.perform(post("/api/v1/grns/web")
+                        .with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "receivedOn": "2026-09-07T10:00:00",
+                                  "receivedByEmployeeId": 1,
+                                  "vendorId": 1,
+                                  "purchaseOrderId": 1,
+                                  "projectId": 1,
+                                  "items": [
+                                    {"materialId": 1, "orderedQuantity": 10, "receivedQuantity": 10, "unitCost": 100}
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isCreated());
+    }
+
+    /** Correcting the header of a note already booked, for example a challan number typed wrong. */
+    @Test
+    void aStoreKeeperMayCorrectANoteTheyBooked() throws Exception {
+        asStoreKeeper();
+        when(goodsReceivedNoteService.updateGoodsReceivedNote(any()))
+                .thenReturn(new GoodsReceivedNoteDto());
+
+        mockMvc.perform(patch("/api/v1/grns/web")
+                        .with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"id\": 1, \"invoiceNumber\": \"INV-1\"}"))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * The other half of the tier. Goods receipts were never open to every member of the
+     * organization and this change does not open them: the role is what grants them, so a member
+     * without it is still refused.
+     */
+    @Test
+    void aPlainMemberIsStillRefused() throws Exception {
+        asPlainMember();
+
+        mockMvc.perform(get("/api/v1/grns/web").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWebAuthzTest.java
@@ -47,9 +47,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * <p>The four listings that name nothing and range over the whole organization stay with
  * system-admin. That line is about which screen the ledger belongs to rather than about
  * confidentiality: a caller who may list every material may walk the anchored reads and
- * reassemble the same rows. It is drawn so that the movement report stays an admin surface
- * until somebody decides it should not, which is the question #650 asks of the whole Resources
- * domain.
+ * reassemble the same rows. It is drawn so that the movement report is not a project manager's
+ * screen. The store-keeper role added for #650 reads all of it, anchored or not, because this
+ * ledger is the record of the receipts, issues and transfers a storekeeper posts, and answering
+ * for it means being able to read it back.
  */
 @WebMvcTest(InventoryTransactionControllerWeb.class)
 @Import(InventoryTransactionControllerWebAuthzTest.TestSecurityConfig.class)
@@ -101,14 +102,14 @@ class InventoryTransactionControllerWebAuthzTest {
 
     /** A caller holding project-manager and not system-admin. */
     private void asProjectManager() {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager", "store-keeper")).thenReturn(true);
     }
 
-    /** A caller holding system-admin, which satisfies both spellings of the guard. */
+    /** A caller holding system-admin, which satisfies every spelling of the guard. */
     private void asSystemAdmin() {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(true);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager", "store-keeper")).thenReturn(true);
     }
 
     private void stubReads() {
@@ -206,8 +207,8 @@ class InventoryTransactionControllerWebAuthzTest {
     @Test
     void aMemberHoldingNeitherRoleIsStillRefusedTheAnchoredRead() throws Exception {
         when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager", "store-keeper")).thenReturn(false);
 
         mockMvc.perform(get("/api/v1/inventory-transactions/web/material/7/history").with(jwt()))
                 .andExpect(status().isForbidden());

--- a/src/test/java/org/tornotron/echno_backend/material/MaterialControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/MaterialControllerWebAuthzTest.java
@@ -52,10 +52,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * list and search are on the same footing, because the form has to name the material before it can
  * ask for its balance.
  *
+ * <p>The reads are also what the storekeeper role introduced for #650 reads: a receipt, an issue
+ * and a count each name a material before anything else can be typed, so the store cannot be given
+ * the write while the catalogue lookup behind the form stays shut.
+ *
  * <p>The write half is the ratchet. Creating a material, editing it, deleting it, or moving its
- * reorder thresholds are catalogue decisions rather than count decisions, and they stay with
- * system-admin until the role question in #650 is settled. If a later change widened them along
- * with the reads, {@code aProjectManagerMayNot*} fails.
+ * reorder thresholds are catalogue decisions rather than count decisions, and #650 left them with
+ * system-admin: deciding what materials exist is a different job from recording what arrived. If a
+ * later change widened them along with the reads, {@code aProjectManagerMayNot*} fails.
  *
  * <p>{@code @orgSecurity} is mocked so each branch is exercised on its own: the project-manager
  * tests deliberately answer false to the system-admin-only expression and true to the pair, which
@@ -95,7 +99,7 @@ class MaterialControllerWebAuthzTest {
     /** A caller holding project-manager and not system-admin. */
     private void asProjectManager() {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager", "store-keeper")).thenReturn(true);
     }
 
     private void stubReads() {
@@ -145,11 +149,11 @@ class MaterialControllerWebAuthzTest {
             "/api/v1/materials/web/1/stock?projectId=4&storageLocationId=7"
     })
     void aMemberHoldingNeitherRoleIsStillRefusedTheRead(String path) throws Exception {
-        // Widening the read to project-manager is not widening it to everybody. The Resources
-        // domain has no role between member and system-admin (#650) and this does not invent one.
+        // Widening the read to project-manager and store-keeper is not widening it to everybody.
+        // The tier below both of those is still plain membership, and it reads nothing here.
         when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager", "store-keeper")).thenReturn(false);
 
         mockMvc.perform(get(path).with(jwt()))
                 .andExpect(status().isForbidden());
@@ -195,7 +199,7 @@ class MaterialControllerWebAuthzTest {
     @Test
     void aSystemAdminStillReadsTheBalance() throws Exception {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(true);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager", "store-keeper")).thenReturn(true);
         stubReads();
 
         mockMvc.perform(get("/api/v1/materials/web/1/stock?projectId=4&storageLocationId=7").with(jwt()))

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
@@ -58,7 +58,7 @@ class SiteTransferControllerWebAuthzTest {
 
     @Test
     void readAll_isOk_forASystemAdmin() throws Exception {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(true);
         when(siteTransferService.getAllSiteTransfers(anyInt(), anyInt())).thenReturn(Page.empty());
 
         mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
@@ -67,8 +67,10 @@ class SiteTransferControllerWebAuthzTest {
 
     @Test
     void readAll_isForbidden_forAProjectManagerWhoIsNotASystemAdmin() throws Exception {
-        // Only 'project-manager' holds here; the guard demands 'system-admin', so the
-        // controller's exact-role check must reject this caller.
+        // Only 'project-manager' holds here. The guard asks for 'system-admin' or 'store-keeper',
+        // so the controller's exact-role check must reject this caller. Site transfers move stock
+        // between two sites and are worked by the stores at each end; a project manager reads the
+        // balances they land on and does not post the movement.
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("project-manager")).thenReturn(true);
 
         mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
@@ -77,7 +79,7 @@ class SiteTransferControllerWebAuthzTest {
 
     @Test
     void readAll_isForbidden_forACallerWithNoElevatedRole() throws Exception {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(false);
 
         mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
                 .andExpect(status().isForbidden());
@@ -90,7 +92,7 @@ class SiteTransferControllerWebAuthzTest {
      */
     @Test
     void receive_isForbidden_forACallerWithNoElevatedRole() throws Exception {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(false);
 
         mockMvc.perform(post("/api/v1/site-transfers/web/51/receive").with(jwt()).with(csrf())
                         .contentType(APPLICATION_JSON)
@@ -101,7 +103,7 @@ class SiteTransferControllerWebAuthzTest {
     /** Cancelling returns stock to the sending project, so it is gated the same way. */
     @Test
     void cancel_isForbidden_forACallerWithNoElevatedRole() throws Exception {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(false);
 
         mockMvc.perform(post("/api/v1/site-transfers/web/51/cancel").with(jwt()).with(csrf())
                         .contentType(APPLICATION_JSON)

--- a/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWebAuthzTest.java
@@ -41,8 +41,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * manager may raise and approve those documents. A location list they cannot read leaves the
  * balance lookup they can now reach with nothing to be scoped by.
  *
- * <p>Whether a storekeeper should be able to create a location without also being able to delete
- * a project is the role question in #650, and this does not answer it: the writes are untouched.
+ * <p>#650 answered the other half of that question. A storekeeper reads the location list, because
+ * every stores document names the shelf the material came from or went to, and does not create,
+ * edit or delete one: defining the store is a different decision from working in it. The writes
+ * here are untouched.
  */
 @WebMvcTest(StorageLocationControllerWeb.class)
 @Import(StorageLocationControllerWebAuthzTest.TestSecurityConfig.class)
@@ -69,7 +71,7 @@ class StorageLocationControllerWebAuthzTest {
     /** A caller holding project-manager and not system-admin. */
     private void asProjectManager() {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager", "store-keeper")).thenReturn(true);
     }
 
     private void stubReads() {
@@ -100,7 +102,7 @@ class StorageLocationControllerWebAuthzTest {
     void aMemberHoldingNeitherRoleIsStillRefusedTheRead() throws Exception {
         when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager", "store-keeper")).thenReturn(false);
 
         mockMvc.perform(get("/api/v1/storage-locations/web/project/4").with(jwt()))
                 .andExpect(status().isForbidden());


### PR DESCRIPTION
Closes part of #650: the Resources half of it.

## The gap

There is nothing between plain organization membership and `system-admin` anywhere in Resources. To let a storekeeper book a goods receipt you make them a system administrator of the organization, which also lets them delete projects, edit anybody's employee record and change organization settings. Abhijith's decision on the issue was to build a role scoped to the job rather than repurpose the unused `org-manager` or widen `project-manager`.

## The role

`STORE_KEEPER("store-keeper")`, a new `OrgRole` value, so it is a Keycloak subgroup under each organization's own group and per-tenant by construction. It is deliberately **not** in `getManagerRoles()`, for the same reason the three inspection roles are not: that set decides who may be named the manager on a project invite code and who appears in the manager listings, and running a store is not managing people.

What it can do, traced from the workflow rather than from the issue title:

| Step | Endpoints granted |
| --- | --- |
| Book a delivery in | `POST /grns/web`, `PATCH /grns/web` + the five GRN reads |
| Hand material out | `POST /material-consumptions/web` + the seven consumption reads |
| Despatch and confirm a site transfer | `POST /site-transfers/web`, `.../{id}/receive`, `.../{id}/cancel`, `PATCH .../{id}/status` + the seven transfer reads |
| Count the shelf and write down what it found | `POST /stock-adjustments/web`, `PUT /stock-adjustments/web/{id}` |
| Fill those forms in | reads on materials and their balances, storage locations, the inventory ledger, purchase orders and their lines (both twins), indents and indent items, and vendor identity and contacts |

94 endpoint grants in all, every one additive. No existing role's reach changes anywhere in this diff.

The reads are the point as much as the writes. Opening a create endpoint while the lookup behind its form stays shut moves the 403 one screen earlier rather than removing it, which is the shape #666 left behind. The GRN form alone reads vendors, purchase orders, the cited order's lines, materials, projects and storage locations before the storekeeper can type anything.

## What it deliberately cannot do

- **No approval or rejection of a stock adjustment.** Approving posts the balance and is meant to be a second pair of eyes on somebody else's count. `SelfApprovalPolicy` refuses a caller approving the document they raised, but it is consulted one request too late to help if the role holds both halves: two storekeepers would approve each other's and the control would be gone with the policy still passing. Approval stays with `system-admin` and `project-manager`.
- **No deletions anywhere.**
- **No catalogue, storage-location, vendor, purchase-order or indent writes.** Deciding what materials exist, who supplies them and what has been ordered is a different job from recording what arrived.
- **No vendor financial reads.** The summary, bank accounts, tax identifiers and payment terms stay with `system-admin`; the storekeeper gets the name and the contacts a delivery needs.

## The guard/service key hazard

Checked, and not created here. Every service on this path loads its records by `TenantContext.getCurrentOrgId()`, which is the same key `hasAnyOrgRoleForCurrentTenant` reads. No endpoint on the grant takes an organization id from the caller.

## Tests

Pushed as their own commit ahead of the change so the red is measured rather than asserted.

- `StoreKeeperRoleScopeTest` carries the whole grant as one list and compares it against what the source actually guards, in both directions, so a later widening is an edit to that list with a reason attached. A second test refuses any approve, reject or delete on the role.
- `GoodsReceivedNoteControllerWebAuthzTest` covers the driving case through the web slice, reads and writes, and pins that a plain member is still refused.

## Not in this PR

- The Keycloak seed in `echno-deployment` has no `store-keeper` subgroup and no seeded user holding one, so staging has nobody to test as. Written up on the issue; it needs a realm change I have not made.
- `echno-core` needs a `STORE_KEEPER` member on its `OrgRole` enum before `echno-web` can offer the role in the assign-role dialog.
- The Resources sidebar still shows every entry to everybody, which is the other half of #650.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `store-keeper` organization role for store-related operations.
  * Store keepers can now access inventory records, materials, storage locations, vendors, purchase orders, site transfers, goods receipts, material consumption, indents, and related reads.
  * Store keepers can create or update selected operational records, including goods receipts, material consumption, site transfers, and stock-adjustment drafts.
  * Approval, deletion, and purchasing or catalogue-management actions remain restricted.

* **Documentation**
  * Updated API specifications and role documentation to describe store-keeper permissions.

* **Tests**
  * Added and updated authorization coverage for the new role and its access boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->