### PR TITLE
Vary the employee record by what the caller may see of pay

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5223,7 +5223,7 @@
             "type": "string"
           },
           "salary": {
-            "description": "Salary of the employee.",
+            "description": "Salary of the employee. Written only for a caller who administers personnel in this tenant (system-admin or hr-admin) and on the caller's own record; absent from the response otherwise.",
             "example": 65000.0,
             "format": "double",
             "type": "number"

--- a/src/main/java/org/tornotron/echno_backend/common/service/OrgRoleAuthority.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/OrgRoleAuthority.java
@@ -1,0 +1,62 @@
+package org.tornotron.echno_backend.common.service;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * The org-scoped role authority, written down once.
+ *
+ * <p>{@code JwtAuthConverter} mints {@code ORG_{orgId}_ROLE_{role}} from the Keycloak group path
+ * {@code /org-{orgId}/{role}}, and everything that asks whether a caller holds a role in an
+ * organization is comparing against that string. {@link OrganizationSecurityService} answers that
+ * question for {@code @PreAuthorize} and remains the only way to ask it there. This class exists
+ * because the same question is now also asked outside a guard, while a response body is being
+ * written, where there is no bean to inject. Both paths go through the format below rather than
+ * through two copies of it.
+ *
+ * <p>Everything read here is a thread local: the {@link SecurityContextHolder} authentication and
+ * the {@link TenantContext} organization id. Both are set for the whole of a request, the response
+ * body included, because {@code TenantFilter} is a servlet filter and clears the scope only after
+ * the dispatcher has written the body. On a thread with neither, the answer is false.
+ */
+public final class OrgRoleAuthority {
+
+    private OrgRoleAuthority() {
+    }
+
+    /** The authority a caller carries when they hold {@code role} in {@code organizationId}. */
+    public static String of(Long organizationId, String role) {
+        return "ORG_" + organizationId + "_ROLE_" + role;
+    }
+
+    /**
+     * Whether the caller on this thread holds any of {@code roles} in the organization the thread
+     * is scoped to.
+     *
+     * <p>False when there is no authentication, and false when no organization id is in scope. The
+     * second case includes the global-admin bypass, which sets no organization id: a bypass session
+     * reads across tenants but holds no role in any one of them, and this answers accordingly. That
+     * matches {@code hasAnyOrgRoleForCurrentTenant}, which refuses the same caller for the same
+     * reason, so a bypass does not quietly become a wider grant here than it is at a guard.
+     */
+    public static boolean heldForCurrentTenant(String... roles) {
+        Long organizationId = TenantContext.getCurrentOrgId();
+        if (organizationId == null) {
+            return false;
+        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            return false;
+        }
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        return Arrays.stream(roles)
+                .map(role -> of(organizationId, role))
+                .anyMatch(required -> authorities.stream()
+                        .anyMatch(authority -> authority.getAuthority().equals(required)));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
@@ -103,7 +103,7 @@ public class OrganizationSecurityService {
             return false;
         }
         // This authority format matches what JwtAuthConverter produces from "/org-{id}/{role}"
-        String requiredAuthority = "ORG_" + organizationId + "_ROLE_" + role;
+        String requiredAuthority = OrgRoleAuthority.of(organizationId, role);
         boolean result = auth.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().equals(requiredAuthority));
         log.debug("Org role check for org {} role '{}': {}", organizationId, role, result);
@@ -128,7 +128,7 @@ public class OrganizationSecurityService {
 
         Collection<? extends GrantedAuthority> authorities = auth.getAuthorities();
         boolean result = Arrays.stream(roles)
-                .map(role -> "ORG_" + organizationId + "_ROLE_" + role)
+                .map(role -> OrgRoleAuthority.of(organizationId, role))
                 .anyMatch(required -> authorities.stream()
                         .anyMatch(a -> a.getAuthority().equals(required)));
 

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.employee.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.attendance.dto.ShiftTimingDto;
@@ -112,4 +113,14 @@ public class EmployeeDto {
 
     @Schema(description = "Files attached to the employee record.")
     private List<AttachmentDto> attachments;
+
+    /**
+     * The Keycloak subject of the user this employee record belongs to. Never published: it is
+     * an internal identifier, and it is here so the record can say whose it is without a second
+     * query. Kept out of the document by {@code @JsonIgnore} and out of the schema by
+     * {@code @Schema(hidden = true)}.
+     */
+    @JsonIgnore
+    @Schema(hidden = true)
+    private String userKeycloakId;
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
@@ -1,8 +1,11 @@
 package org.tornotron.echno_backend.employee.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.tornotron.echno_backend.attendance.dto.ShiftTimingDto;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.enums.OrgRole;
@@ -16,6 +19,11 @@ import java.util.Set;
 @Schema(description = "Full view of an employee, covering personal details, employment, reporting line, "
         + "roles and status.")
 @Data
+// Both read the fields rather than the accessors, because getSalary() below answers for the
+// caller on the current thread. Left on the getters, a test comparing two records would call it,
+// and two records with different pay would be equal to a caller who may see neither.
+@ToString(doNotUseGetters = true)
+@EqualsAndHashCode(doNotUseGetters = true)
 public class EmployeeDto {
     @Schema(description = "Unique employee id.", example = "7")
     private Long id;
@@ -59,7 +67,9 @@ public class EmployeeDto {
     @Schema(description = "Blood group of the employee.", example = "O+")
     private String bloodGroup;
 
-    @Schema(description = "Salary of the employee.", example = "65000.0")
+    @Schema(description = "Salary of the employee. Written only for a caller who administers "
+            + "personnel in this tenant (system-admin or hr-admin) and on the caller's own record; "
+            + "absent from the response otherwise.", example = "65000.0")
     private Double salary;
 
     @Schema(description = "Id of this employee's reporting manager.", example = "5")
@@ -123,4 +133,26 @@ public class EmployeeDto {
     @JsonIgnore
     @Schema(hidden = true)
     private String userKeycloakId;
+
+    /**
+     * The salary, for a caller entitled to it, and nothing at all for a caller who is not. See
+     * {@link EmployeeSalaryVisibility} for who is entitled and why.
+     *
+     * <p>The decision sits on the accessor rather than on an endpoint deliberately. This record is
+     * returned from both employee controllers and is nested inside eleven other response types
+     * (project, task, material, purchase order, goods received note, indent, site transfer,
+     * material consumption, inventory transaction, payable, WBS element), each guarded for its own
+     * resource and none of them for personnel data. A guard, a view or a second DTO would have to
+     * be remembered at every one of those call sites and at the next one somebody adds. An
+     * accessor cannot be forgotten: a new endpoint returning this type inherits the decision by
+     * returning the type.
+     *
+     * <p>Withheld means absent rather than null, so the field reads the same as any other optional
+     * one. {@code echno-core} parses it as a nullish number, so an absent salary needs no client
+     * change.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Double getSalary() {
+        return EmployeeSalaryVisibility.visibleTo(userKeycloakId) ? salary : null;
+    }
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeSalaryVisibility.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeSalaryVisibility.java
@@ -1,0 +1,80 @@
+package org.tornotron.echno_backend.employee.dto;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.tornotron.echno_backend.common.service.OrgRoleAuthority;
+
+/**
+ * Who may read an employee's pay.
+ *
+ * <p>{@link EmployeeDto} is the record of a colleague, and four of its fields are personal: salary,
+ * date of birth, address and phone number. Three of them have an ordinary use on a site. Somebody
+ * has to reach a person, somebody has to arrange transport, and some work has an age floor. Pay has
+ * no such use, and it is the one field on this record whose readership is a management question
+ * rather than an operational one.
+ *
+ * <p>The line is drawn where the module already draws it. {@code PATCH /employee/web/{id}} is
+ * gated on {@code system-admin} and {@code hr-admin}; those two roles set the salary, so those two
+ * roles read it. {@code project-manager} is admitted to the directory reads and not to the PATCH,
+ * and it is not admitted here either. Nothing else moves: date of birth, address and phone number
+ * stay visible to every caller the read itself admits, which is what keeps the directory worth
+ * having.
+ *
+ * <p>Date of birth was the field that could have gone either way. It stays because it is used
+ * (age-restricted work, birthdays) and because this record already carries a blood group and an
+ * emergency contact, which are more sensitive on any honest ranking. Cutting the birth date while
+ * leaving those two would be a line drawn nowhere.
+ *
+ * <p>A person always reads their own pay, whatever role they hold. Both single-record reads carry
+ * a self branch and {@code GET /user/web/employees} returns nothing but the caller's own records,
+ * so without that clause a person would be handed their own record with their own pay cut out of
+ * it.
+ *
+ * <p>The decision is taken from thread-local state only: the authentication and the tenant scope.
+ * No query, because this runs while the response is being written, and with
+ * {@code spring.jpa.open-in-view} false there is no session there to run one in. Where either is
+ * missing, the answer is no.
+ */
+final class EmployeeSalaryVisibility {
+
+    /**
+     * The roles that may set a salary through the employee PATCH, and therefore may read one back.
+     */
+    private static final String[] PAYROLL_ROLES = {"system-admin", "hr-admin"};
+
+    private EmployeeSalaryVisibility() {
+    }
+
+    /**
+     * @param subjectKeycloakId the Keycloak subject of the user whose record is being written
+     * @return whether the caller may see that person's pay
+     */
+    static boolean visibleTo(String subjectKeycloakId) {
+        return isTheCaller(subjectKeycloakId)
+                || OrgRoleAuthority.heldForCurrentTenant(PAYROLL_ROLES);
+    }
+
+    /**
+     * Whether the record belongs to whoever is asking. Compared on the Keycloak subject, which is
+     * on the token and on the record, so the self branch costs nothing and holds across
+     * organizations: {@code GET /user/web/employees} answers with records from every organization
+     * the caller belongs to, and only one of them can be the tenant in scope.
+     *
+     * <p>Mirrors how {@code UserContextService.getCurrentKeycloakId} reads the subject.
+     */
+    private static boolean isTheCaller(String subjectKeycloakId) {
+        if (subjectKeycloakId == null) {
+            return false;
+        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+        Object principal = authentication.getPrincipal();
+        String callerSubject = principal instanceof Jwt jwt
+                ? jwt.getSubject()
+                : authentication.getName();
+        return subjectKeycloakId.equals(callerSubject);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/employee/mapper/EmployeeMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/mapper/EmployeeMapper.java
@@ -36,5 +36,6 @@ public interface EmployeeMapper {
     @Mapping(source = "user.createdAt", target = "createdAt")
     @Mapping(source = "user.updatedAt", target = "updatedAt")
     @Mapping(source = "user.attachments", target = "attachments")
+    @Mapping(source = "user.keycloakId", target = "userKeycloakId")
     EmployeeDto toDto(Employee employee);
 }

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeSalaryVisibilityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeSalaryVisibilityTest.java
@@ -1,0 +1,241 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * What a colleague's employee record says about their pay, and to whom.
+ *
+ * <p>{@code EmployeeDto} carries salary, date of birth, address and phone number, and the
+ * directory reads are open to {@code project-manager}, so every project manager read all four of
+ * a colleague. Three of the four earn their place on a construction site: somebody has to reach a
+ * person, arrange transport, or know that a job has an age floor. Pay does not, and the roles that
+ * may set it here are {@code system-admin} and {@code hr-admin} - the PATCH beside these reads has
+ * always been gated on those two. So pay is now shown to exactly the roles that may change it,
+ * plus the person whose pay it is.
+ *
+ * <p>The decision is enforced on the type rather than on the endpoint, so these tests are about a
+ * response body and not about a 403. Every read below is admitted; what varies is whether the
+ * body carries {@code salary}.
+ *
+ * <p>The mocked {@code @orgSecurity} bean only opens the door. The visibility decision reads the
+ * caller's real authorities and the real {@code TenantContext} that {@code TenantFilter} sets from
+ * the JWT, so what is asserted here is the mechanism and not the stub.
+ */
+@WebMvcTest(EmployeeControllerWeb.class)
+@Import(EmployeeSalaryVisibilityTest.TestSecurityConfig.class)
+class EmployeeSalaryVisibilityTest {
+
+    private static final long ORG = 100L;
+    private static final long COLLEAGUE = 42L;
+    private static final double PAY = 65000.0;
+
+    /** The Keycloak subject on the JWT every request below is made with. */
+    private static final String CALLER = "kc-caller";
+
+    /** The Keycloak subject on the record being read, so the record is somebody else's. */
+    private static final String SOMEONE_ELSE = "kc-colleague";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EmployeeService employeeService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @BeforeEach
+    void admitEveryRead() {
+        // TenantFilter infers this from the membership authority on the JWT when the slice loads
+        // it. Set here as well so the visibility decision has a tenant to read either way; the
+        // filter's own finally clears it after every request that reaches the filter.
+        TenantContext.setCurrentOrgId(ORG);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(anyString(), anyString(), anyString()))
+                .thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), any(String[].class))).thenReturn(true);
+        when(employeeService.displayAnEmployee(COLLEAGUE)).thenReturn(recordOf(SOMEONE_ELSE));
+        when(employeeService.displayAllEmployees(anyInt(), anyInt(), any(), any(), any()))
+                .thenReturn(page(recordOf(SOMEONE_ELSE)));
+    }
+
+    /**
+     * TenantContext is a ThreadLocal and MockMvc runs on the test thread. TenantFilter clears it
+     * in a finally, but a test that never reaches the filter would otherwise leave a scope behind
+     * for the next one.
+     */
+    @AfterEach
+    void clearTenantScope() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void salaryIsWithheldFromAProjectManagerReadingTheDirectory() throws Exception {
+        mockMvc.perform(get("/api/v1/employee/web").with(projectManager()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].salary").doesNotHaveJsonPath());
+    }
+
+    @Test
+    void salaryIsWithheldFromAProjectManagerReadingOneColleague() throws Exception {
+        mockMvc.perform(get("/api/v1/employee/web/" + COLLEAGUE).with(projectManager()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.salary").doesNotHaveJsonPath());
+    }
+
+    @Test
+    void salaryIsShownToASystemAdmin() throws Exception {
+        mockMvc.perform(get("/api/v1/employee/web/" + COLLEAGUE).with(systemAdmin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.salary").value(PAY));
+    }
+
+    /** hr-admin may set the salary through the PATCH beside this read, so it may read it back. */
+    @Test
+    void salaryIsShownToAnHrAdmin() throws Exception {
+        mockMvc.perform(get("/api/v1/employee/web/" + COLLEAGUE).with(hrAdmin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.salary").value(PAY));
+    }
+
+    /**
+     * A person reads their own pay whatever role they hold. Without this the self branch on this
+     * read, added in #710 so somebody could read back the record they may edit, would hand them a
+     * record with their own pay cut out of it.
+     */
+    @Test
+    void salaryIsShownOnTheCallersOwnRecord() throws Exception {
+        when(employeeService.displayAnEmployee(COLLEAGUE)).thenReturn(recordOf(CALLER));
+
+        mockMvc.perform(get("/api/v1/employee/web/" + COLLEAGUE).with(plainMember()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.salary").value(PAY));
+    }
+
+    // The three fields that stay. Asserted one per test: chaining them would report a failure by
+    // describing the whole response, and what is being pinned is a separate decision per field.
+
+    @Test
+    void aProjectManagerStillReadsAColleaguesPhoneNumber() throws Exception {
+        mockMvc.perform(get("/api/v1/employee/web/" + COLLEAGUE).with(projectManager()))
+                .andExpect(jsonPath("$.phoneNumber").value("9847012345"));
+    }
+
+    @Test
+    void aProjectManagerStillReadsAColleaguesAddress() throws Exception {
+        mockMvc.perform(get("/api/v1/employee/web/" + COLLEAGUE).with(projectManager()))
+                .andExpect(jsonPath("$.address").value("45 Anna Nagar, Chennai"));
+    }
+
+    @Test
+    void aProjectManagerStillReadsAColleaguesDateOfBirth() throws Exception {
+        mockMvc.perform(get("/api/v1/employee/web/" + COLLEAGUE).with(projectManager()))
+                .andExpect(jsonPath("$.dateOfBirth").exists());
+    }
+
+    /** The internal identifier the visibility decision reads must not reach a client. */
+    @Test
+    void theSubjectTheDecisionReadsIsNotPublished() throws Exception {
+        mockMvc.perform(get("/api/v1/employee/web/" + COLLEAGUE).with(systemAdmin()))
+                .andExpect(jsonPath("$.userKeycloakId").doesNotHaveJsonPath());
+    }
+
+    private static EmployeeDto recordOf(String subject) {
+        EmployeeDto dto = new EmployeeDto();
+        dto.setId(COLLEAGUE);
+        dto.setEmployeeName("Ravi Kumar");
+        dto.setSalary(PAY);
+        dto.setPhoneNumber("9847012345");
+        dto.setAddress("45 Anna Nagar, Chennai");
+        dto.setDateOfBirth(LocalDateTime.of(1994, 3, 22, 0, 0));
+        dto.setUserKeycloakId(subject);
+        return dto;
+    }
+
+    private static Page<EmployeeDto> page(EmployeeDto dto) {
+        return new PageImpl<>(List.of(dto));
+    }
+
+    private static RequestPostProcessor projectManager() {
+        return caller("ORG_MEMBER_" + ORG, "ORG_" + ORG + "_ROLE_project-manager");
+    }
+
+    private static RequestPostProcessor systemAdmin() {
+        return caller("ORG_MEMBER_" + ORG, "ORG_" + ORG + "_ROLE_system-admin");
+    }
+
+    private static RequestPostProcessor hrAdmin() {
+        return caller("ORG_MEMBER_" + ORG, "ORG_" + ORG + "_ROLE_hr-admin");
+    }
+
+    private static RequestPostProcessor plainMember() {
+        return caller("ORG_MEMBER_" + ORG);
+    }
+
+    /**
+     * A caller carrying the membership authority TenantFilter infers the tenant from, so the
+     * request runs with a real organization scope rather than none.
+     */
+    private static RequestPostProcessor caller(String... authorities) {
+        return jwt()
+                .jwt(builder -> builder.subject(CALLER))
+                .authorities(Arrays.stream(authorities)
+                        .map(SimpleGrantedAuthority::new)
+                        .toArray(GrantedAuthority[]::new));
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
`EmployeeDto` carries salary, date of birth, address and phone number. The directory reads admit `project-manager`, so every project manager reads all four of every colleague.

Three of the four earn their place on a construction site: somebody has to reach a person, arrange transport, or know that a job has an age floor. Pay does not, and in this codebase the roles that may set it are `system-admin` and `hr-admin`, which is exactly what the PATCH beside these reads has always been gated on. So pay is now shown to the roles that may change it, plus the person whose pay it is.

Nothing is narrowed at the endpoint. Narrowing the directory would take the phone number away with the salary, and the whole point of the directory is that a manager can reach their team.

First commit is the tests, so the red is measured rather than assumed.

Refs #711

https://claude.ai/code/session_018LUw1wk1SqVZN55TQDKRHn