### PR TITLE
Open the procurement document reads to the role that already reads the ledger

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -108962,7 +108962,7 @@
       "name": "Goods Received Notes"
     },
     {
-      "description": "Goods received notes (GRNs) record materials received against a vendor, capturing the delivery and its line items. This is the web-console API, gated by organization role for the current tenant rather than by flat authorities. Recording a receipt and reading one are open to the system-admin and store-keeper roles, because booking a delivery in is the store's own work and used to require administering the whole organization. Endpoints cover creating, browsing, filtering by vendor or date range, and updating GRNs.",
+      "description": "Goods received notes (GRNs) record materials received against a vendor, capturing the delivery and its line items. This is the web-console API, gated by organization role for the current tenant rather than by flat authorities. Recording a receipt and reading one are open to the system-admin and store-keeper roles, because booking a delivery in is the store's own work and used to require administering the whole organization. Reading is open to the project-manager role as well, which already sees the same receipt in the stock ledger. Endpoints cover creating, browsing, filtering by vendor or date range, and updating GRNs.",
       "name": "Goods Received Notes (Web)"
     },
     {
@@ -109078,7 +109078,7 @@
       "name": "Material Consumptions"
     },
     {
-      "description": "Web-console counterpart of the material consumptions API, gated by organization role for the current tenant. Recording an issue and looking issues up are open to the system-admin and store-keeper roles: handing material out over the counter is the store's own work. Covers the same recording and lookup operations as the standard material consumption endpoints, for use from the admin web console rather than the mobile app.",
+      "description": "Web-console counterpart of the material consumptions API, gated by organization role for the current tenant. Recording an issue is open to the system-admin and store-keeper roles: handing material out over the counter is the store's own work. Looking issues up is open to those two and to the project-manager role, which already sees the same consumption in the stock ledger. Covers the same recording and lookup operations as the standard material consumption endpoints, for use from the admin web console rather than the mobile app.",
       "name": "Material Consumptions (Web)"
     },
     {
@@ -109162,7 +109162,7 @@
       "name": "Purchase Order Items (Web)"
     },
     {
-      "description": "Purchase orders raised against a vendor, optionally converted from an indent. A purchase order carries line items, a status lifecycle from draft through fully received or cancelled, and the totals used for payables. Raising and changing an order is restricted to the system-admin role for the current tenant. Reading one is also open to store-keeper, which is what a goods receipt is booked against: the receiving end has to see what was ordered without being able to alter the order.",
+      "description": "Purchase orders raised against a vendor, optionally converted from an indent. A purchase order carries line items, a status lifecycle from draft through fully received or cancelled, and the totals used for payables. Raising and changing an order is restricted to the system-admin role for the current tenant. Reading one is also open to store-keeper, which is what a goods receipt is booked against, and to project-manager, which already sees what that receipt booked in the stock ledger. Neither can alter the order.",
       "name": "Purchase Orders"
     },
     {
@@ -109190,7 +109190,7 @@
       "name": "Site Transfers"
     },
     {
-      "description": "Web-app view of site transfers: the same movement of materials between two projects and their storage locations as the mobile-facing site-transfer endpoints, gated by organization role for the caller's current tenant. Raising a transfer, confirming what the receiving site took delivery of, and cancelling one that never arrived are open to the system-admin and store-keeper roles, since both ends of a transfer are worked by a store. Creating a transfer checks that the sending location holds enough stock before the items are recorded.",
+      "description": "Web-app view of site transfers: the same movement of materials between two projects and their storage locations as the mobile-facing site-transfer endpoints, gated by organization role for the caller's current tenant. Raising a transfer, confirming what the receiving site took delivery of, and cancelling one that never arrived are open to the system-admin and store-keeper roles, since both ends of a transfer are worked by a store. Reading a transfer is open to the project-manager role as well, which already sees the movement in the stock ledger and raises the adjustment that settles a receipt variance. Creating a transfer checks that the sending location holds enough stock before the items are recorded.",
       "name": "Site Transfers (Web)"
     },
     {

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
@@ -27,12 +27,13 @@ import java.util.List;
 @Tag(
         name = "Goods Received Notes (Web)",
         description = "Goods received notes (GRNs) record materials received against a vendor, capturing "
-                + "the delivery and its line items. This is the web-console API, gated by organization "
-                + "role for the current tenant rather than by flat authorities. Recording a receipt and "
-                + "reading one are open to the system-admin and store-keeper roles, because booking a "
-                + "delivery in is the store\'s own work and used to require administering the whole "
-                + "organization. Endpoints cover creating, browsing, filtering by vendor or date range, "
-                + "and updating GRNs."
+                + "the delivery and its line items. This is the web-console API, gated by organization role "
+                + "for the current tenant rather than by flat authorities. Recording a receipt and reading "
+                + "one are open to the system-admin and store-keeper roles, because booking a delivery in "
+                + "is the store's own work and used to require administering the whole organization. "
+                + "Reading is open to the project-manager role as well, which already sees the same receipt "
+                + "in the stock ledger. Endpoints cover creating, browsing, filtering by vendor or date "
+                + "range, and updating GRNs."
 )
 public class GoodsReceivedNoteControllerWeb {
 
@@ -63,7 +64,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "Get a goods received note by id",
             description = "Returns a single GRN."
@@ -79,7 +80,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List goods received notes",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -93,7 +94,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List goods received notes (paged)",
             description = "Returns a single page of GRNs controlled by the pageNo and pageSize parameters."
@@ -110,7 +111,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping("/vendor/{vendorId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List goods received notes for a vendor",
             description = "Returns the GRNs recorded against the given vendor."
@@ -142,7 +143,7 @@ public class GoodsReceivedNoteControllerWeb {
     }
 
     @GetMapping("/date-range")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List goods received notes by date range",
             description = "Returns the GRNs recorded between the given start and end date-times."

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
@@ -57,7 +57,7 @@ public class IndentControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List indents, paginated",
             description = "Returns a single page of indents. The pageNo and pageSize parameters control paging."
@@ -88,7 +88,7 @@ public class IndentControllerWeb {
      * @return A {@link ResponseEntity} containing the page of indent summaries.
      */
     @GetMapping("/summary")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List indents as summaries, paginated",
             description = "Returns a single page of indents without their item lines, each "
@@ -108,7 +108,7 @@ public class IndentControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List all indents",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -122,7 +122,7 @@ public class IndentControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "Get an indent by id",
             description = "Returns a single indent, including its creator, project and requested items."
@@ -176,7 +176,7 @@ public class IndentControllerWeb {
     // ==================== IndentItem Endpoints ====================
 
     @GetMapping("/{indentId}/items")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List items on an indent",
             description = "Returns every requested item on the given indent."

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
@@ -27,12 +27,13 @@ import java.util.List;
 @Validated
 @Tag(
         name = "Material Consumptions (Web)",
-        description = "Web-console counterpart of the material consumptions API, gated by organization "
-                + "role for the current tenant. Recording an issue and looking issues up are open to the "
-                + "system-admin and store-keeper roles: handing material out over the counter is the "
-                + "store\'s own work. Covers the same recording and lookup operations as the standard "
-                + "material consumption endpoints, for use from the admin web console rather than the "
-                + "mobile app."
+        description = "Web-console counterpart of the material consumptions API, gated by organization role for "
+                + "the current tenant. Recording an issue is open to the system-admin and store-keeper "
+                + "roles: handing material out over the counter is the store's own work. Looking issues up "
+                + "is open to those two and to the project-manager role, which already sees the same "
+                + "consumption in the stock ledger. Covers the same recording and lookup operations as the "
+                + "standard material consumption endpoints, for use from the admin web console rather than "
+                + "the mobile app."
 )
 public class MaterialConsumptionControllerWeb {
 
@@ -64,7 +65,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "Get a material consumption by id",
             description = "Returns a single material consumption record with its material, project, "
@@ -81,7 +82,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List all material consumptions",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -96,7 +97,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List material consumptions, paginated",
             description = "Returns a single page of material consumption records. The pageNo and "
@@ -114,7 +115,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/material/{materialId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List consumptions for a material",
             description = "Returns every consumption record for the given material, such as all draws "
@@ -131,7 +132,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/type/{consumptionType}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List consumptions by type",
             description = "Returns every consumption record of the given consumption type, such as "
@@ -147,7 +148,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/date-range")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List consumptions in a date range",
             description = "Returns every consumption record whose consumption date falls between "
@@ -167,7 +168,7 @@ public class MaterialConsumptionControllerWeb {
     }
 
     @GetMapping("/task/{taskId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List consumptions for a task",
             description = "Returns every consumption record linked to the given task."

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
@@ -30,8 +30,9 @@ import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
                 + "purchase order carries line items, a status lifecycle from draft through fully "
                 + "received or cancelled, and the totals used for payables. Raising and changing an order "
                 + "is restricted to the system-admin role for the current tenant. Reading one is also open "
-                + "to store-keeper, which is what a goods receipt is booked against: the receiving end has "
-                + "to see what was ordered without being able to alter the order."
+                + "to store-keeper, which is what a goods receipt is booked against, and to "
+                + "project-manager, which already sees what that receipt booked in the stock ledger. "
+                + "Neither can alter the order."
 )
 public class PurchaseOrderController {
 
@@ -58,7 +59,7 @@ public class PurchaseOrderController {
         return new ResponseEntity<>(created, HttpStatus.CREATED);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @GetMapping("/{id}")
     @Operation(
             summary = "Get a purchase order by id",
@@ -74,7 +75,7 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrder);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @GetMapping
     @Operation(
             summary = "List all purchase orders",
@@ -89,7 +90,7 @@ public class PurchaseOrderController {
                 purchaseOrderService.getAllPurchaseOrders(0, UnpagedResultCap.MAX_ROWS));
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @GetMapping("/all")
     @Operation(
             summary = "List purchase orders, paginated",
@@ -107,7 +108,7 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrders);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @GetMapping("/vendor/{vendorId}")
     @Operation(
             summary = "List purchase orders for a vendor",
@@ -123,7 +124,7 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrders);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @GetMapping("/indent/{indentId}")
     @Operation(
             summary = "List purchase orders for an indent",
@@ -138,7 +139,7 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrders);
     }
 
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @GetMapping("/status/{status}")
     @Operation(
             summary = "List purchase orders by status",

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
@@ -58,7 +58,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "Get a purchase order by id",
             description = "Returns a single purchase order including its vendor, indent link, items and totals."
@@ -81,7 +81,7 @@ public class PurchaseOrderControllerWeb {
      * @return A {@link ResponseEntity} containing a page of trail entries and HTTP status 200 (OK).
      */
     @GetMapping("/{id}/status-history")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "Read a purchase order's status trail",
             description = "Returns a page of the order's status entries, newest first: what it moved "
@@ -107,7 +107,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List all purchase orders",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -122,7 +122,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List purchase orders, paginated",
             description = "Returns a single page of purchase orders. The pageNo and pageSize parameters "
@@ -140,7 +140,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/vendor/{vendorId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List purchase orders for a vendor",
             description = "Returns every purchase order raised against the given vendor, for example every "
@@ -156,7 +156,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/indent/{indentId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List purchase orders for an indent",
             description = "Returns every purchase order that was raised from the given material indent."
@@ -171,7 +171,7 @@ public class PurchaseOrderControllerWeb {
     }
 
     @GetMapping("/status/{status}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List purchase orders by status",
             description = "Returns every purchase order currently in the given lifecycle status, such as "

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
@@ -34,7 +34,9 @@ import java.util.List;
                 + "organization role for the caller's current tenant. Raising a transfer, confirming what "
                 + "the receiving site took delivery of, and cancelling one that never arrived are open to "
                 + "the system-admin and store-keeper roles, since both ends of a transfer are worked by a "
-                + "store. Creating a transfer checks that the sending location holds enough stock before "
+                + "store. Reading a transfer is open to the project-manager role as well, which already "
+                + "sees the movement in the stock ledger and raises the adjustment that settles a receipt "
+                + "variance. Creating a transfer checks that the sending location holds enough stock before "
                 + "the items are recorded."
 )
 public class SiteTransferControllerWeb {
@@ -67,7 +69,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "Get a site transfer by id",
             description = "Returns a single site transfer including its sending and receiving projects, "
@@ -84,7 +86,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List all site transfers",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -99,7 +101,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List site transfers, paginated",
             description = "Returns a single page of site transfers ordered by issue date, most recent first. "
@@ -117,7 +119,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/status/{status}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List site transfers by status",
             description = "Returns every site transfer currently in the given status, for example PENDING, "
@@ -133,7 +135,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/sending-project/{projectId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List site transfers sent from a project",
             description = "Returns every site transfer whose sending project is the given project id."
@@ -148,7 +150,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/receiving-project/{projectId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "List site transfers received by a project",
             description = "Returns every site transfer whose receiving project is the given project id."
@@ -247,7 +249,7 @@ public class SiteTransferControllerWeb {
     }
 
     @GetMapping("/{id}/status-history")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','store-keeper','project-manager')")
     @Operation(
             summary = "Read a site transfer's status trail",
             description = "Returns a page of the transfer's status entries, newest first: what it "

--- a/src/test/java/org/tornotron/echno_backend/common/security/ProcurementDocumentGuardSplitTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/security/ProcurementDocumentGuardSplitTest.java
@@ -1,0 +1,175 @@
+package org.tornotron.echno_backend.common.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNoteController;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNoteControllerWeb;
+import org.tornotron.echno_backend.indent.IndentController;
+import org.tornotron.echno_backend.indent.IndentControllerWeb;
+import org.tornotron.echno_backend.materialConsumption.MaterialConsumptionController;
+import org.tornotron.echno_backend.materialConsumption.MaterialConsumptionControllerWeb;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderController;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderControllerWeb;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferController;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferControllerWeb;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The read side of the five procurement documents moved and the write side did not, on every
+ * endpoint rather than on the handful a slice can exercise.
+ *
+ * <p>A web-slice test proves a status code for one request. It cannot easily prove the negative
+ * this change rests on, that no write was widened along with the reads, because a write is guarded
+ * behind argument binding: {@code @PreAuthorize} is evaluated when the handler is invoked, so an
+ * endpoint that validates its body answers 400 to a deliberately empty one and says nothing about
+ * its guard. Reading the annotation is the direct way to ask, and it covers the endpoints a slice
+ * would have skipped as well as the next one somebody adds.
+ *
+ * <p>The rule: on these controllers a GET admits {@code project-manager} beside
+ * {@code system-admin}, and everything else admits {@code system-admin} alone. Reading a purchase
+ * order is not raising one.
+ */
+class ProcurementDocumentGuardSplitTest {
+
+    private static final String PROJECT_MANAGER = "project-manager";
+
+    /** The five document controllers that carry the org-role guard, web twins and the one mobile. */
+    private static final List<Class<?>> ROLE_GUARDED = List.of(
+            GoodsReceivedNoteControllerWeb.class,
+            PurchaseOrderControllerWeb.class,
+            PurchaseOrderController.class,
+            IndentControllerWeb.class,
+            SiteTransferControllerWeb.class,
+            MaterialConsumptionControllerWeb.class);
+
+    /**
+     * The mobile twins that are guarded on flat {@code resource:scope} authorities instead. Nothing
+     * in the realm mints those, so they refuse every caller including a system admin. That is the
+     * phantom-guard defect of #684 rather than this decision, and repairing it is a separate change
+     * with its own blast radius. Pinned here so the omission reads as deliberate.
+     */
+    private static final List<Class<?>> AUTHORITY_GUARDED = List.of(
+            GoodsReceivedNoteController.class,
+            IndentController.class,
+            SiteTransferController.class,
+            MaterialConsumptionController.class);
+
+    @Test
+    void everyDocumentReadAdmitsTheProjectManager() {
+        List<String> readsThatDoNot = new ArrayList<>();
+        for (Class<?> controller : ROLE_GUARDED) {
+            for (Method method : requestMappedMethods(controller)) {
+                if (isRead(method) && !guardOf(method).contains(PROJECT_MANAGER)) {
+                    readsThatDoNot.add(describe(controller, method));
+                }
+            }
+        }
+        assertThat(readsThatDoNot).isEmpty();
+    }
+
+    @Test
+    void noDocumentWriteAdmitsTheProjectManager() {
+        List<String> writesThatDo = new ArrayList<>();
+        for (Class<?> controller : ROLE_GUARDED) {
+            for (Method method : requestMappedMethods(controller)) {
+                if (!isRead(method) && guardOf(method).contains(PROJECT_MANAGER)) {
+                    writesThatDo.add(describe(controller, method));
+                }
+            }
+        }
+        assertThat(writesThatDo).isEmpty();
+    }
+
+    /** A guard that stopped mentioning system-admin would be a narrowing, not a widening. */
+    @Test
+    void everyDocumentEndpointStillAdmitsTheSystemAdmin() {
+        List<String> withoutSystemAdmin = new ArrayList<>();
+        for (Class<?> controller : ROLE_GUARDED) {
+            for (Method method : requestMappedMethods(controller)) {
+                if (!guardOf(method).contains("system-admin")) {
+                    withoutSystemAdmin.add(describe(controller, method));
+                }
+            }
+        }
+        assertThat(withoutSystemAdmin).isEmpty();
+    }
+
+    @Test
+    void theAuthorityGuardedMobileTwinsWereLeftAlone() {
+        List<String> touched = new ArrayList<>();
+        for (Class<?> controller : AUTHORITY_GUARDED) {
+            for (Method method : requestMappedMethods(controller)) {
+                if (guardOf(method).contains("orgSecurity")) {
+                    touched.add(describe(controller, method));
+                }
+            }
+        }
+        assertThat(touched).isEmpty();
+    }
+
+    /** Guards against the whole thing passing because reflection found nothing to look at. */
+    @Test
+    void theEndpointsUnderTestWereActuallyFound() {
+        int total = 0;
+        for (Class<?> controller : ROLE_GUARDED) {
+            total += requestMappedMethods(controller).size();
+        }
+        assertThat(total).isEqualTo(56);
+    }
+
+    private static List<Method> requestMappedMethods(Class<?> controller) {
+        List<Method> methods = new ArrayList<>();
+        for (Method method : controller.getDeclaredMethods()) {
+            if (method.isSynthetic() || method.isBridge()) {
+                continue;
+            }
+            if (mappingAnnotationPresent(method)) {
+                methods.add(method);
+            }
+        }
+        methods.sort(Comparator.comparing(Method::getName));
+        return methods;
+    }
+
+    private static boolean mappingAnnotationPresent(Method method) {
+        for (var annotation : method.getAnnotations()) {
+            if (annotation.annotationType().isAnnotationPresent(RequestMapping.class)
+                    || annotation.annotationType() == RequestMapping.class) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isRead(Method method) {
+        return method.isAnnotationPresent(GetMapping.class);
+    }
+
+    private static String guardOf(Method method) {
+        PreAuthorize guard = method.getAnnotation(PreAuthorize.class);
+        return guard == null ? "" : guard.value();
+    }
+
+    private static String describe(Class<?> controller, Method method) {
+        String verb = method.isAnnotationPresent(GetMapping.class) ? "GET"
+                : method.isAnnotationPresent(PostMapping.class) ? "POST"
+                : method.isAnnotationPresent(PatchMapping.class) ? "PATCH"
+                : method.isAnnotationPresent(PutMapping.class) ? "PUT"
+                : method.isAnnotationPresent(DeleteMapping.class) ? "DELETE"
+                : "MAPPED";
+        return verb + " " + controller.getSimpleName() + "." + method.getName()
+                + " guarded by " + guardOf(method);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/security/ProcurementDocumentReadAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/security/ProcurementDocumentReadAuthzTest.java
@@ -111,9 +111,15 @@ class ProcurementDocumentReadAuthzTest {
     @MockitoBean
     private RPTCache rptCache;
 
-    /** The caller holds project-manager and nothing else, which is the role under test. */
+    /**
+     * The caller holds project-manager and nothing else, which is the role under test. The stub
+     * names all three roles the read guards now carry, store-keeper included, because the guard
+     * asks in a single call and an argument list that does not match it leaves the mock answering
+     * false. The write guards are deliberately left unstubbed, so the refusals below are the
+     * mock's default rather than an assertion the stub arranged.
+     */
     private void aProjectManager() {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager"))
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper", "project-manager"))
                 .thenReturn(true);
     }
 

--- a/src/test/java/org/tornotron/echno_backend/common/security/ProcurementDocumentReadAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/security/ProcurementDocumentReadAuthzTest.java
@@ -1,0 +1,313 @@
+package org.tornotron.echno_backend.common.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNoteControllerWeb;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNoteService;
+import org.tornotron.echno_backend.indent.IndentControllerWeb;
+import org.tornotron.echno_backend.indent.IndentService;
+import org.tornotron.echno_backend.materialConsumption.MaterialConsumptionControllerWeb;
+import org.tornotron.echno_backend.materialConsumption.MaterialConsumptionService;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderController;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderControllerWeb;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderService;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferControllerWeb;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferService;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferDto;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * A project manager may read the procurement documents behind the movements they already see, and
+ * may still not raise one.
+ *
+ * <p>#672 moved ten reads on {@code InventoryTransactionControllerWeb} to
+ * {@code system-admin, project-manager}, so the role that approves a stock adjustment can read the
+ * {@code ADJUST} rows the approval wrote. The ledger does not separate movement types, so the same
+ * reads return the {@code GRN}, {@code TRANSFER_IN}, {@code TRANSFER_OUT}, {@code USE} and
+ * {@code PRODUCTION_CONSUME} rows too, with {@code referenceNumber}, {@code quantityChanged},
+ * {@code remarks} and {@code unitCost} on each. Meanwhile every controller for the documents that
+ * wrote those rows was {@code system-admin} on all of its methods, reads included. The derived view
+ * was open and the document was shut, which is #680.
+ *
+ * <p>It is settled by opening the documents. A project manager already reads every project, task,
+ * employee, material, storage location and stock adjustment, and the whole general ledger. On that
+ * evidence these five were the outlier. That also closes #695, where a project manager could raise
+ * and approve the stock adjustment that settles a transfer receipt variance while being refused the
+ * transfer the adjustment names.
+ *
+ * <p>Writes do not move, and half of this class is about that. Reading a purchase order is not
+ * raising one, receiving a transfer posts stock into a project, and cancelling one takes it back
+ * out. Those stay where they were.
+ *
+ * <p>One slice over six controllers rather than six slices, following
+ * {@link ReadWriteGuardSymmetryTest}: Spring caches a context per distinct slice and the test JVM
+ * is capped. {@code @orgSecurity} is mocked, and the stubs use exact role arguments, so what is
+ * pinned is the role list each guard actually asks for.
+ */
+@WebMvcTest({
+        GoodsReceivedNoteControllerWeb.class,
+        PurchaseOrderControllerWeb.class,
+        PurchaseOrderController.class,
+        IndentControllerWeb.class,
+        SiteTransferControllerWeb.class,
+        MaterialConsumptionControllerWeb.class
+})
+@Import(ProcurementDocumentReadAuthzTest.TestSecurityConfig.class)
+class ProcurementDocumentReadAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GoodsReceivedNoteService goodsReceivedNoteService;
+
+    @MockitoBean
+    private PurchaseOrderService purchaseOrderService;
+
+    @MockitoBean
+    private IndentService indentService;
+
+    @MockitoBean
+    private SiteTransferService siteTransferService;
+
+    @MockitoBean
+    private MaterialConsumptionService materialConsumptionService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** The caller holds project-manager and nothing else, which is the role under test. */
+    private void aProjectManager() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager"))
+                .thenReturn(true);
+    }
+
+    // ---- the reads a project manager gains ----
+
+    @Test
+    void aProjectManagerReadsGoodsReceivedNotes() throws Exception {
+        aProjectManager();
+        when(goodsReceivedNoteService.getAllGrns(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/grns/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aProjectManagerReadsPurchaseOrders() throws Exception {
+        aProjectManager();
+        when(purchaseOrderService.getAllPurchaseOrders(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/purchase-orders/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * The mobile twin of the purchase order reads is on the same org-role guard as the web one, so
+     * it moves with it. The other four mobile controllers are on flat {@code resource:scope}
+     * authorities that nothing mints, refuse every caller, and are a separate repair.
+     */
+    @Test
+    void aProjectManagerReadsPurchaseOrdersOnTheMobileTwin() throws Exception {
+        aProjectManager();
+        when(purchaseOrderService.getAllPurchaseOrders(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/purchase-orders").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aProjectManagerReadsIndents() throws Exception {
+        aProjectManager();
+        when(indentService.getAllIndents(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/indents/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    /** The summary listing is the same rows without their lines, so it moves with the listing. */
+    @Test
+    void aProjectManagerReadsTheIndentSummaryListing() throws Exception {
+        aProjectManager();
+        when(indentService.getAllIndentsSummary(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/indents/web/summary").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aProjectManagerReadsSiteTransfers() throws Exception {
+        aProjectManager();
+        when(siteTransferService.getAllSiteTransfers(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    /** #695: the transfer a stock adjustment names, which the same role may raise and approve. */
+    @Test
+    void aProjectManagerOpensTheTransferAStockAdjustmentNames() throws Exception {
+        aProjectManager();
+        when(siteTransferService.getSiteTransferById(anyLong())).thenReturn(new SiteTransferDto());
+
+        mockMvc.perform(get("/api/v1/site-transfers/web/31").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aProjectManagerReadsMaterialConsumptions() throws Exception {
+        aProjectManager();
+        when(materialConsumptionService.getAllMaterialConsumptions(anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/material-consumptions/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * The status trail names who moved a document and when. It goes with the document rather than
+     * being held back: the ledger rows a project manager already reads carry {@code createdBy}, so
+     * withholding the trail would hide the same fact from the surface where it reads as an answer.
+     */
+    @Test
+    void aProjectManagerReadsASiteTransferStatusTrail() throws Exception {
+        aProjectManager();
+        when(siteTransferService.getStatusHistory(anyLong(), anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/site-transfers/web/31/status-history").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aProjectManagerReadsAPurchaseOrderStatusTrail() throws Exception {
+        aProjectManager();
+        when(purchaseOrderService.getStatusHistory(anyLong(), anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/purchase-orders/web/31/status-history").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * The by-project listings take the project from the caller and no guard reads it, so they are
+     * as wide as the unfiltered listing rather than narrower. That is why they move together with
+     * it: opening only these would read as project-scoped while not being it. {@code project-manager}
+     * is an organization role here and not a per-project one, so this grants nothing the listing
+     * above does not already grant.
+     */
+    @Test
+    void aProjectManagerReadsTransfersSentFromAProject() throws Exception {
+        aProjectManager();
+        when(siteTransferService.getSiteTransfersBySendingProject(anyLong())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/site-transfers/web/sending-project/9").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    // ---- the writes a project manager does not gain ----
+
+    /**
+     * The write refusals below use the endpoints whose guard is reached without a request body.
+     * {@code @PreAuthorize} is evaluated when the handler is invoked, which is after argument
+     * binding, so a deliberately empty body on a validated endpoint answers 400 and proves nothing
+     * about the guard. {@link ProcurementDocumentGuardSplitTest} covers every write, body or not,
+     * by reading the annotation itself.
+     */
+    @Test
+    void aProjectManagerCannotMoveAPurchaseOrdersStatus() throws Exception {
+        aProjectManager();
+
+        mockMvc.perform(patch("/api/v1/purchase-orders/web/31/status").with(jwt()).with(csrf())
+                        .param("status", "APPROVED"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aProjectManagerCannotDeleteAnIndent() throws Exception {
+        aProjectManager();
+
+        mockMvc.perform(delete("/api/v1/indents/web/31").with(jwt()).with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aProjectManagerCannotReceiveASiteTransfer() throws Exception {
+        aProjectManager();
+
+        mockMvc.perform(post("/api/v1/site-transfers/web/31/receive").with(jwt()).with(csrf())
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"items\":[{\"itemId\":84,\"receivedQuantity\":8}]}"))
+                .andExpect(status().isForbidden());
+    }
+
+    /** Cancelling returns stock to the sending project, so it is gated the same way. */
+    @Test
+    void aProjectManagerCannotCancelASiteTransfer() throws Exception {
+        aProjectManager();
+
+        mockMvc.perform(post("/api/v1/site-transfers/web/31/cancel").with(jwt()).with(csrf())
+                        .contentType(APPLICATION_JSON).content("{\"reason\":\"Lorry turned back\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ---- and a caller holding neither role still reads nothing ----
+
+    @Test
+    void aCallerWithNoElevatedRoleStillReadsNoPurchaseOrders() throws Exception {
+        mockMvc.perform(get("/api/v1/purchase-orders/web").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aCallerWithNoElevatedRoleStillReadsNoSiteTransfers() throws Exception {
+        mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWebAuthzTest.java
@@ -73,15 +73,23 @@ class GoodsReceivedNoteControllerWebAuthzTest {
     @MockitoBean
     private RPTCache rptCache;
 
-    /** A caller holding store-keeper and no other org role. */
+    /**
+     * A caller holding store-keeper and no other org role. The reads on this controller now admit
+     * project-manager as well, so the guard behind them asks for three roles in one call and needs
+     * its own stub; the writes still ask for two.
+     */
     private void asStoreKeeper() {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper", "project-manager"))
+                .thenReturn(true);
     }
 
     /** A caller who is a member of the tenant and holds no org role at all. */
     private void asPlainMember() {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper", "project-manager"))
+                .thenReturn(false);
     }
 
     private void stubReads() {

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
@@ -27,12 +27,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Web-slice authorization test for SiteTransferControllerWeb. Every endpoint on this
- * controller gates on the single system-admin role, so the reads are more tightly
- * restricted than on the inventory-document controllers (which let any member read).
- * The stubs use exact role arguments: the system-admin test proves admittance, and the
- * project-manager test proves that role alone is refused, which locks in the exact role
- * name the guard requires. @orgSecurity is mocked.
+ * Web-slice authorization test for SiteTransferControllerWeb. Reads admit the system-admin
+ * and project-manager roles; everything that moves stock admits system-admin alone.
+ *
+ * <p>The project-manager case used to assert a refusal on the listing, and it is now an
+ * admittance: #680 opened the five procurement document reads so the role that already
+ * reads every movement through the inventory ledger can open the documents those movements
+ * came from, and #695 is the case that made it concrete, a project manager raising the stock
+ * adjustment that settles a transfer receipt variance while being refused the transfer it
+ * names. The refusal that remains is the one that always mattered here: receiving posts stock
+ * into a project and cancelling takes it back out.
+ *
+ * <p>The stubs use exact role arguments, so what is pinned is the role list each guard asks
+ * for rather than any role at all. @orgSecurity is mocked. The wider read/write split across
+ * all five documents is in ProcurementDocumentGuardSplitTest.
  */
 @WebMvcTest(SiteTransferControllerWeb.class)
 @Import(SiteTransferControllerWebAuthzTest.TestSecurityConfig.class)
@@ -56,30 +64,36 @@ class SiteTransferControllerWebAuthzTest {
     @MockitoBean
     private RPTCache rptCache;
 
+    /**
+     * The exact-argument stub is what carries this test. The guard asks for all three roles in a
+     * single call, so this matches only a guard that names exactly {@code system-admin},
+     * {@code store-keeper} and {@code project-manager}: a stub of a narrower call would not match,
+     * and the read would answer 403. The mock cannot say which of the three the caller holds, which
+     * is why the refusal below is stubbed on the same call returning false. That the read admits
+     * {@code project-manager} in particular is asserted by
+     * {@code ProcurementDocumentGuardSplitTest#everyDocumentReadAdmitsTheProjectManager}, which
+     * reads the annotation rather than the mock.
+     */
     @Test
-    void readAll_isOk_forASystemAdmin() throws Exception {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(true);
+    void readAll_isOk_forAnAdmittedRole() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper", "project-manager"))
+                .thenReturn(true);
         when(siteTransferService.getAllSiteTransfers(anyInt(), anyInt())).thenReturn(Page.empty());
 
         mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
                 .andExpect(status().isOk());
     }
 
-    @Test
-    void readAll_isForbidden_forAProjectManagerWhoIsNotASystemAdmin() throws Exception {
-        // Only 'project-manager' holds here. The guard asks for 'system-admin' or 'store-keeper',
-        // so the controller's exact-role check must reject this caller. Site transfers move stock
-        // between two sites and are worked by the stores at each end; a project manager reads the
-        // balances they land on and does not post the movement.
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("project-manager")).thenReturn(true);
-
-        mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
-                .andExpect(status().isForbidden());
-    }
-
+    /**
+     * The refusal a project manager used to get from this read was removed with #695: a project
+     * manager raises the stock adjustment that settles a receipt variance and now reads the
+     * transfer that adjustment names. What stays asserted here is that a caller holding none of
+     * the three admitted roles is refused.
+     */
     @Test
     void readAll_isForbidden_forACallerWithNoElevatedRole() throws Exception {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "store-keeper", "project-manager"))
+                .thenReturn(false);
 
         mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
                 .andExpect(status().isForbidden());


### PR DESCRIPTION
#672 moved ten reads on `InventoryTransactionControllerWeb` to `system-admin, project-manager`, so the role that approves a stock adjustment can read the `ADJUST` rows the approval wrote. The ledger does not separate movement types, so the same reads return the `GRN`, `TRANSFER_IN`, `TRANSFER_OUT`, `USE` and `PRODUCTION_CONSUME` rows too, each carrying `referenceNumber`, `quantityChanged`, `remarks` and `unitCost`. Meanwhile every controller for the documents that wrote those rows was `system-admin` on all of its methods, reads included. The derived view was open and the document was shut. That is #680.

It is settled by opening the documents, which is #680's first resolution. A project manager already reads every project, task, employee, material, storage location and stock adjustment, and the whole general ledger. On that evidence these five were the outlier.

**Closes #695** with the same change: a project manager could raise and approve the stock adjustment that settles a transfer receipt variance while being refused the site transfer the adjustment names.

**No write moves.** Reading a purchase order is not raising one, receiving a transfer posts stock into a project, and cancelling one takes it back out. `ProcurementDocumentGuardSplitTest` asserts that across all 56 endpoints by reading the annotation, which is the only way to cover the writes a slice cannot reach.

First commit is the tests, so the red is measured rather than assumed.

Refs #680
Closes #695

https://claude.ai/code/session_018LUw1wk1SqVZN55TQDKRHn