### PR TITLE
Repair the five mobile employee guards that refuse everybody, and settle the sixth

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -33829,7 +33829,7 @@
     },
     "/api/v1/employee": {
       "get": {
-        "description": "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result.",
+        "description": "Returns at most 500 rows of the caller's own organization. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result.",
         "operationId": "readAllEmployees",
         "responses": {
           "200": {
@@ -33873,7 +33873,7 @@
                 }
               }
             },
-            "description": "Caller lacks the employee read or admin authority"
+            "description": "Caller is not a system admin, HR admin or project manager in the current organization"
           },
           "404": {
             "content": {
@@ -34044,7 +34044,7 @@
     },
     "/api/v1/employee/batch": {
       "patch": {
-        "description": "Applies partial updates to several employees in one call. Each entry names an employee id and the map of fields to change on that employee.",
+        "description": "Applies partial updates to several employees of the caller's organization in one call. Each entry names an employee id and the map of fields to change on that employee.",
         "operationId": "batchUpdateEmployees",
         "requestBody": {
           "content": {
@@ -34098,7 +34098,7 @@
                 }
               }
             },
-            "description": "Caller lacks the employee update or admin authority"
+            "description": "Caller is not a system admin or HR admin in the current organization"
           },
           "404": {
             "content": {
@@ -34291,7 +34291,7 @@
     },
     "/api/v1/employee/organization/{id}": {
       "get": {
-        "description": "Returns the employees belonging to the given organization. A non-admin caller must be a member of that organization.",
+        "description": "Returns the employees belonging to the given organization, which must be the organization the caller's session is scoped to.",
         "operationId": "readEmployeesByOrganizationId",
         "parameters": [
           {
@@ -34346,7 +34346,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the organization and lacks the employee admin authority"
+            "description": "Caller named an organization that is not the current tenant, or is not a system admin, HR admin or project manager in it"
           },
           "404": {
             "content": {
@@ -36218,7 +36218,7 @@
     },
     "/api/v1/employee/{id}": {
       "delete": {
-        "description": "Deletes the employee with the given id.",
+        "description": "Deletes the employee with the given id from the caller's organization, and removes their membership of it in Keycloak.",
         "operationId": "deleteEmployee",
         "parameters": [
           {
@@ -36270,7 +36270,7 @@
                 }
               }
             },
-            "description": "Caller lacks the employee delete or admin authority"
+            "description": "Caller is not a system admin or HR admin in the current organization"
           },
           "404": {
             "content": {
@@ -36440,7 +36440,7 @@
         ]
       },
       "patch": {
-        "description": "Applies the supplied map of fields to the employee with the given id, changing only the fields present in the request.",
+        "description": "Applies the supplied map of fields to the employee with the given id, changing only the fields present in the request. Callable by the employee themselves or by a system admin or HR admin.",
         "operationId": "partialUpdateAnEmployee",
         "parameters": [
           {
@@ -36502,7 +36502,7 @@
                 }
               }
             },
-            "description": "Caller lacks the employee update or admin authority"
+            "description": "Caller is neither the employee nor a system admin or HR admin"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
@@ -97,6 +97,35 @@ public class EmployeeController {
     /**
      * Creates a new employee.
      *
+     * <p><b>Proposed for removal under #675 and #716; deliberately left refusing until that is
+     * decided, and not to be repaired by analogy with the guards around it.</b> The other guards
+     * on this controller named an authority the realm cannot issue and were repaired, because each
+     * had work behind it that somebody needs. This one has neither a caller nor a working body:
+     *
+     * <ul>
+     *   <li>Nothing calls it. echno-core publishes no direct employee create and pins that with a
+     *       regression test; echno-web has no create call site and no create form, only the
+     *       invitation flow; the Flutter client's one employee call is
+     *       {@code GET /employee/organization/{id}}. The route is reachable through the web BFF's
+     *       catch-all proxy, so this is an absence of callers rather than an absence of reach.
+     *   <li>It cannot succeed. {@code addEmployee} never sets {@code user}, and
+     *       {@code Employee.user} is a {@code nullable = false} join column, so the save ends in a
+     *       constraint violation whatever the caller sends.
+     *   <li>It discards what it demands. {@code EmployeeObjectMapper} writes neither
+     *       {@code designation} nor {@code department}, both {@code @NotBlank} on
+     *       {@link EmployeeCreationDto}, along with {@code joiningDate}, {@code employeeId} and
+     *       {@code salary}. That is the defect {@code status} was removed from the payload for.
+     *   <li>It picks the tenant out of the body. {@code addEmployee} resolves the organization by
+     *       {@code organizationName}, and {@code Organization} is the tenant root, so no ambient
+     *       defence narrows that lookup to the caller's own. Repairing the guard alone would turn
+     *       a route nobody can reach into a cross-tenant write.
+     * </ul>
+     *
+     * <p>An administrator adding somebody who has never signed in is a real gap, and the answer to
+     * it is a designed route that says what it does about the Keycloak user, not this one. The
+     * route that works today is {@link #joinOrganization}, reached by an invite code redeemed at
+     * {@code POST /api/v1/invitation/web/validate/userId/{userId}}.
+     *
      * @param employeeCreationDto DTO containing the details for the new employee.
      * @return A {@link ResponseEntity} with the created employee's DTO and HTTP status 201 (Created).
      */
@@ -119,17 +148,28 @@ public class EmployeeController {
     /**
      * Retrieves a list of all employees.
      *
+     * <p>The employee directory. {@code EmployeeDto} carries salary, date of birth, address and
+     * phone number, so this is the personnel record rather than a picker feed, and the roles that
+     * read it are the ones the web twin's listings already name: {@code system-admin},
+     * {@code hr-admin} and {@code project-manager}. A member who only needs to pick a colleague
+     * out of a list has {@code GET /api/v1/employee/web/lookup}, which any member may read
+     * because it exposes none of that.
+     *
+     * <p>{@code employee:read} and {@code employee:admin}, which this asked for until now, cannot
+     * be issued: see {@link #readAnEmployee} for the mechanism. Repaired to what the web twin
+     * says rather than deleted, per #716.
+     *
      * @return A {@link ResponseEntity} containing the list of employee DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-    @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     @Operation(
             summary = "List all employees",
-            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
+            description = "Returns at most 500 rows of the caller's own organization. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee read or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a system admin, HR admin or project manager in the current organization")
     })
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
         return UnpagedResultCap.respond(employeeService.displayAllEmployees(
@@ -175,19 +215,31 @@ public class EmployeeController {
     /**
      * Retrieves all employees belonging to a specific organization.
      *
-     * @param id The ID of the organization.
+     * <p>The same directory as {@link #readAllEmployees}, reached by naming the organization
+     * rather than leaving it to the session, so it takes the same three roles. The organization
+     * clause changes though, and not as a substitution. The old guard paired the phantom
+     * authority with {@code isMember(#id)}, which establishes that the caller belongs to the
+     * organization they named and leaves the organization the request is scoped to unexamined; a
+     * caller who belongs to two organizations could therefore read the other one's directory
+     * while their session was scoped here. {@code isCurrentTenant} is the check for that, and it
+     * has to be made here because {@code Organization} is the tenant root: it implements no
+     * {@code TenantScopedEntity}, so {@code TenantIsolationLoadListener} returns on its first
+     * line for it and a caller-supplied organization id carries no ambient protection.
+     *
+     * @param id The ID of the organization, which must be the one the caller's session is scoped to.
      * @return A {@link ResponseEntity} containing a list of employee DTOs for the specified organization and HTTP status 200 (OK).
      */
     @GetMapping("/organization/{id}")
-    @PreAuthorize("(hasAuthority('employee:read') and @orgSecurity.isMember(#id)) or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.isCurrentTenant(#id)"
+            + " and @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     @Operation(
             summary = "List employees in an organization",
-            description = "Returns the employees belonging to the given organization. A non-admin caller "
-                    + "must be a member of that organization."
+            description = "Returns the employees belonging to the given organization, which must be the "
+                    + "organization the caller's session is scoped to."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the organization and lacks the employee admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller named an organization that is not the current tenant, or is not a system admin, HR admin or project manager in it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
     })
     public ResponseEntity<List<EmployeeDto>> readEmployeesByOrganizationId(@PathVariable Long id) {
@@ -197,21 +249,33 @@ public class EmployeeController {
     /**
      * Partially updates an existing employee.
      *
+     * <p>Gated exactly as the web twin's PATCH is, so a person may maintain their own record from
+     * the phone and {@code system-admin} or {@code hr-admin} may maintain anyone's. Keeping the
+     * two twins identical also keeps this endpoint level with the {@link #readAnEmployee} beside
+     * it, which #710 set to the same expression: a guard that let someone edit a record they
+     * could not then read back is the asymmetry that issue was about.
+     *
+     * <p>The service loads the employee with
+     * {@code findByIdAndOrganizationId(id, TenantContext.getCurrentOrgId())}, the same id the
+     * guard resolves and the same organization, so the guard and the write cannot land on
+     * different rows.
+     *
      * @param updates A map of fields to update.
      * @param id      The ID of the employee to update.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @PatchMapping("{id}")
-    @PreAuthorize("hasAuthority('employee:update') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Partially update an employee",
             description = "Applies the supplied map of fields to the employee with the given id, "
-                    + "changing only the fields present in the request."
+                    + "changing only the fields present in the request. Callable by the employee "
+                    + "themselves or by a system admin or HR admin."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the supplied fields is not valid"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system admin or HR admin"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<ApiResponse> partialUpdateAnEmployee(
@@ -226,20 +290,38 @@ public class EmployeeController {
     /**
      * Updates multiple employees in a batch.
      *
+     * <p>Personnel maintenance across a set of people at once: moving a crew to a new department
+     * at handover, closing out a set of records at the end of a contract. That is the work
+     * {@code system-admin} and {@code hr-admin} do, and it is the pair the single-record PATCH
+     * already admits.
+     *
+     * <p>The self clause the single-record PATCH carries has no counterpart here and is not
+     * simply omitted for convenience. The ids arrive inside the request body rather than on the
+     * path, so there is nothing for {@code #id} to bind to, and a person maintaining their own
+     * record has the single-record route to do it on. A guard that cannot name what it is
+     * guarding is the shape to avoid, so the roles decide and nothing pretends to check the ids.
+     *
+     * <p>What does check them is underneath: {@code batchUpdateEmployees} reads the employees
+     * inside a {@code @Transactional} method, so the {@code orgFilter} is on and
+     * {@code TenantIsolationLoadListener} runs on every row it materialises. An id belonging to
+     * another organization is either filtered out of the read or refused at load, so a
+     * {@code hr-admin} of one tenant cannot reach into another by listing its ids.
+     *
      * @param updates A list of DTOs containing the updates for each employee.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @PatchMapping("/batch")
-    @PreAuthorize("hasAuthority('employee:update') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Batch update employees",
-            description = "Applies partial updates to several employees in one call. Each entry names an "
-                    + "employee id and the map of fields to change on that employee."
+            description = "Applies partial updates to several employees of the caller's organization in "
+                    + "one call. Each entry names an employee id and the map of fields to change on that "
+                    + "employee."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch update applied"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update entries failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee update or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a system admin or HR admin in the current organization")
     })
     public ResponseEntity<ApiResponse> batchUpdateEmployees(@Valid @RequestBody List<EmployeePatchDto> updates) {
         employeeService.batchUpdateEmployees(updates);
@@ -249,18 +331,30 @@ public class EmployeeController {
     /**
      * Deletes an employee by their ID.
      *
+     * <p>Removing a person from the organization, which also takes their Keycloak group
+     * membership away and so ends their access. That is administration rather than anything a
+     * manager does day to day, and the web twin already reserves it to {@code system-admin} and
+     * {@code hr-admin}. There is deliberately no self clause: nobody deletes their own
+     * membership from the phone.
+     *
+     * <p>The guard names no id, so there is no id for it to disagree with the service about.
+     * {@code deleteAnEmployee} finds the row with
+     * {@code findByIdAndOrganizationId(id, TenantContext.getCurrentOrgId())} and a foreign id
+     * simply does not resolve.
+     *
      * @param id The ID of the employee to delete.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @DeleteMapping("{id}")
-    @PreAuthorize("hasAuthority('employee:delete') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Delete an employee",
-            description = "Deletes the employee with the given id."
+            description = "Deletes the employee with the given id from the caller's organization, and "
+                    + "removes their membership of it in Keycloak."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee deleted"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a system admin or HR admin in the current organization"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<ApiResponse> deleteEmployee(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -16,11 +16,9 @@ import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
-import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeLookupDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
-import org.tornotron.echno_backend.employee.dto.EmployeePatchDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeUpdateFieldsDto;
 import org.tornotron.echno_backend.employee.dto.OrgRoleAssignmentDto;
 
@@ -37,6 +35,23 @@ import java.util.Set;
                 + "assignment, subordinate and manager lookups, and org-role assignment, alongside the "
                 + "same read, update and delete operations as the base employee API."
 )
+/**
+ * Web-client twin of {@link EmployeeController}.
+ *
+ * <p>There is deliberately no direct create here. An employee is a person's membership of an
+ * organization, so the record needs a user to hang off, and the route that supplies one is
+ * {@code joinOrganization} below. A person with no membership yet reaches it by redeeming an
+ * invite code at {@code POST /api/v1/invitation/web/validate/userId/{userId}}, guarded by
+ * {@code isSelfUser} because the redeemer has no tenant to check them against; an administrator
+ * adding somebody who already has an account uses {@code joinOrganization} directly.
+ *
+ * <p>A commented-out {@code @PostMapping createEmployee} sat here until #675 and is gone. It was
+ * never routed, so {@code POST /api/v1/employee/web} answered 401 to an anonymous caller exactly
+ * as a real path would, and echno-core published a client method against it on that evidence. A
+ * block of commented-out mappings is a suggestion the compiler cannot check and a client reader
+ * cannot distinguish from a plan, which is how it misled. If a direct create is wanted, it needs a
+ * design that says what it does about the Keycloak user rather than an uncommenting.
+ */
 public class EmployeeControllerWeb {
 
     private final EmployeeService employeeService;
@@ -77,23 +92,6 @@ public class EmployeeControllerWeb {
         return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.joinOrganization(userId, orgId, employeeJoinOrgDto));
     }
 
-//    /**
-//     * Creates a new employee.
-//     *
-//     * @param employeeCreationDto DTO containing the details for the new employee.
-//     * @return A {@link ResponseEntity} with the created employee's DTO and HTTP status 201 (Created).
-//     */
-//    @PostMapping
-//    @PreAuthorize("hasAuthority('employee:create') or hasAuthority('employee:admin')")
-//    public ResponseEntity<EmployeeDto> createEmployee(@Valid @RequestBody EmployeeCreationDto employeeCreationDto) {
-//        return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.addEmployee(employeeCreationDto));
-//    }
-
-    /**
-     * Retrieves a list of all employees.
-     *
-     * @return A {@link ResponseEntity} containing the list of employee DTOs and HTTP status 200 (OK).
-     */
     /**
      * Minimal, non-sensitive employee list for populating pickers. Readable by any
      * tenant member; the full employee reads below are restricted to management roles.
@@ -183,19 +181,6 @@ public class EmployeeControllerWeb {
         return ResponseEntity.status(HttpStatus.OK).body(employee);
     }
 
-
-//    /**
-//     * Retrieves all employees belonging to a specific organization.
-//     *
-//     * @param id The ID of the organization.
-//     * @return A {@link ResponseEntity} containing a list of employee DTOs for the specified organization and HTTP status 200 (OK).
-//     */
-//    @GetMapping("/organization/{id}")
-//    @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
-//    public ResponseEntity<List<EmployeeDto>> readEmployeesByOrganizationId(@PathVariable Long id) {
-//        return ResponseEntity.status(HttpStatus.OK).body(employeeService.displayEmployeesByOrganization(id));
-//    }
-
     /**
      * Partially updates an existing employee.
      *
@@ -224,18 +209,6 @@ public class EmployeeControllerWeb {
         employeeService.partialUpdateAnEmployee(updates,id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" updated"));
     }
-
-//    /**
-//     * Updates multiple employees in a batch.
-//     *
-//     * @param updates A list of DTOs containing the updates for each employee.
-//     * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
-//     */
-//    @PatchMapping("/batch")
-//    public ResponseEntity<ApiResponse> batchUpdateEmployees(@Valid @RequestBody List<EmployeePatchDto> updates) {
-//        employeeService.batchUpdateEmployees(updates);
-//        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
-//    }
 
     /**
      * Deletes an employee by their ID.

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeMobileGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeMobileGuardTest.java
@@ -1,0 +1,277 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The five guards on the mobile {@code EmployeeController} that named an authority no realm can
+ * issue, and what each answers now.
+ *
+ * <p>{@code employee:read}, {@code employee:update} and {@code employee:delete} are bare
+ * {@code resource:scope} authorities. {@code JwtAuthConverter} mints those in one place,
+ * {@code extractPermissions}, which reads the {@code authorization} claim of an RPT, so each needs
+ * a Keycloak Authorization Services resource named {@code employee} carrying the matching scope.
+ * The only automated provisioner registers a scopeless Default Resource and a scopeless Default
+ * Permission, and a permission with no scopes yields no {@code resource:scope} authority at all.
+ * Every one of these endpoints therefore refused every caller from the day the annotation was
+ * written. Same mechanism as #641 and #684, repaired the same way as #710 rather than deleted.
+ * See #716.
+ *
+ * <p>Each endpoint is tested twice over, and the pair is the point. A caller holding the old
+ * authority and nothing else must now be refused, or the repair has widened the surface instead of
+ * moving it; a caller holding the org role and none of the old authorities must now be admitted,
+ * or the endpoint is still dead. The first half of each pair is what a realm cannot actually
+ * produce, granted here directly on the token so the assertion means something.
+ *
+ * <p>What this proves and what it does not: {@code @orgSecurity} is a mock, so these tests fix the
+ * expression each endpoint evaluates and the roles it names. They say nothing about how
+ * {@code OrganizationSecurityService} resolves a role, which
+ * {@code KeycloakOrgMembershipInvariantIT} and {@code TenantIsolationIT} cover against a real
+ * context.
+ */
+@WebMvcTest(EmployeeController.class)
+@Import(EmployeeMobileGuardTest.TestSecurityConfig.class)
+class EmployeeMobileGuardTest {
+
+    private static final long OWN_ORG = 100L;
+    private static final long FOREIGN_ORG = 200L;
+    private static final long EMPLOYEE = 7L;
+
+    private static final String PATCH_BODY = """
+            {"department":"Civil"}
+            """;
+
+    private static final String BATCH_BODY = """
+            [{"id":7,"updates":{"department":"Civil"}}]
+            """;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EmployeeService employeeService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** Nobody: no org role anywhere, not the employee in question, no organization entitlement. */
+    private void callerHoldsNoRole() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), any(String[].class))).thenReturn(false);
+        when(orgSecurity.isCurrentTenant(anyLong())).thenReturn(false);
+    }
+
+    /** An HR admin of the organization the session is scoped to, holding no Keycloak authority. */
+    private void callerIsAnHrAdminOf(long orgId) {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), any(String[].class))).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(anyLong())).thenReturn(false);
+        when(orgSecurity.isCurrentTenant(eq(orgId))).thenReturn(true);
+    }
+
+    private void listingsAnswer() {
+        Page<EmployeeDto> page = new PageImpl<>(List.of(new EmployeeDto()));
+        // any() rather than anyString(): the controller passes null for all three filters, and
+        // anyString() does not match a null argument.
+        when(employeeService.displayAllEmployees(anyInt(), anyInt(), any(), any(), any()))
+                .thenReturn(page);
+        when(employeeService.displayEmployeesByOrganization(anyLong()))
+                .thenReturn(List.of(new EmployeeDto()));
+    }
+
+    // ---- GET / : the directory listing -------------------------------------------------
+
+    @Test
+    void theListing_isRefusedToAHolderOfTheOldReadAuthority() throws Exception {
+        callerHoldsNoRole();
+
+        mockMvc.perform(get("/api/v1/employee")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:read"),
+                                new SimpleGrantedAuthority("employee:admin"))))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    @Test
+    void theListing_answersARoleHolderWhoHoldsNoAuthorityAtAll() throws Exception {
+        callerIsAnHrAdminOf(OWN_ORG);
+        listingsAnswer();
+
+        mockMvc.perform(get("/api/v1/employee").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    // ---- GET /organization/{id} : the same directory, organization named ----------------
+
+    @Test
+    void theOrganizationListing_isRefusedToAHolderOfTheOldReadAuthority() throws Exception {
+        callerHoldsNoRole();
+
+        mockMvc.perform(get("/api/v1/employee/organization/" + OWN_ORG)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:read"),
+                                new SimpleGrantedAuthority("employee:admin"))))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    /**
+     * The organization clause is the part that changed shape rather than merely being substituted.
+     * The old guard asked {@code isMember(#id)}, which a caller who belongs to two organizations
+     * satisfies for either of them, so the directory of the organization their session was not
+     * scoped to came back. {@code isCurrentTenant} refuses it, and it has to, because
+     * {@code Organization} is the tenant root and no ambient defence covers an id the caller
+     * supplies for it.
+     */
+    @Test
+    void theOrganizationListing_isRefusedForAnOrganizationThatIsNotTheCurrentTenant() throws Exception {
+        callerIsAnHrAdminOf(OWN_ORG);
+
+        mockMvc.perform(get("/api/v1/employee/organization/" + FOREIGN_ORG).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    @Test
+    void theOrganizationListing_answersForTheCallersOwnOrganization() throws Exception {
+        callerIsAnHrAdminOf(OWN_ORG);
+        listingsAnswer();
+
+        mockMvc.perform(get("/api/v1/employee/organization/" + OWN_ORG).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    // ---- PATCH /{id} : maintaining one record ------------------------------------------
+
+    @Test
+    void theUpdate_isRefusedToAHolderOfTheOldUpdateAuthority() throws Exception {
+        callerHoldsNoRole();
+
+        mockMvc.perform(patch("/api/v1/employee/" + EMPLOYEE)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:update"),
+                                new SimpleGrantedAuthority("employee:admin")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PATCH_BODY))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    @Test
+    void theUpdate_answersTheEmployeeThemselvesOrAnAdmin() throws Exception {
+        callerIsAnHrAdminOf(OWN_ORG);
+
+        mockMvc.perform(patch("/api/v1/employee/" + EMPLOYEE)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PATCH_BODY))
+                .andExpect(status().isOk());
+    }
+
+    // ---- PATCH /batch : maintaining a set ----------------------------------------------
+
+    @Test
+    void theBatchUpdate_isRefusedToAHolderOfTheOldUpdateAuthority() throws Exception {
+        callerHoldsNoRole();
+
+        mockMvc.perform(patch("/api/v1/employee/batch")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:update"),
+                                new SimpleGrantedAuthority("employee:admin")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BATCH_BODY))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    /**
+     * The ids a batch acts on arrive in the body, so no guard can bind to them and the roles are
+     * what decide. Recording that deliberately: a later reader should not add a {@code #id} clause
+     * here expecting it to bind to anything.
+     */
+    @Test
+    void theBatchUpdate_answersAnAdminOfTheCurrentOrganization() throws Exception {
+        callerIsAnHrAdminOf(OWN_ORG);
+
+        mockMvc.perform(patch("/api/v1/employee/batch")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BATCH_BODY))
+                .andExpect(status().isOk());
+    }
+
+    // ---- DELETE /{id} : ending a membership ---------------------------------------------
+
+    @Test
+    void theDelete_isRefusedToAHolderOfTheOldDeleteAuthority() throws Exception {
+        callerHoldsNoRole();
+
+        mockMvc.perform(delete("/api/v1/employee/" + EMPLOYEE)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:delete"),
+                                new SimpleGrantedAuthority("employee:admin"))))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
+    @Test
+    void theDelete_answersAnAdminOfTheCurrentOrganization() throws Exception {
+        callerIsAnHrAdminOf(OWN_ORG);
+
+        mockMvc.perform(delete("/api/v1/employee/" + EMPLOYEE).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeMobileGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeMobileGuardTest.java
@@ -94,6 +94,21 @@ class EmployeeMobileGuardTest {
     @MockitoBean
     private RPTCache rptCache;
 
+    /**
+     * Every persona below stubs the exact role list each endpoint asks for, rather than answering
+     * true to any list at all.
+     *
+     * <p>Stubbing {@code hasAnyOrgRoleForCurrentTenant(any(String[].class))} as true would make
+     * these tests pass whatever roles the guards named: a listing that dropped
+     * {@code project-manager}, or a delete that quietly admitted it, would look identical from
+     * here. The role list is the substance of this repair, so it is the thing the mock has to be
+     * particular about. The broad stub is kept, returning false, so an endpoint asking for a list
+     * no persona grants is refused rather than falling through to a Mockito default that happens
+     * to agree.
+     */
+    private static final String[] DIRECTORY_ROLES = {"system-admin", "hr-admin", "project-manager"};
+    private static final String[] ADMIN_ROLES = {"system-admin", "hr-admin"};
+
     /** Nobody: no org role anywhere, not the employee in question, no organization entitlement. */
     private void callerHoldsNoRole() {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
@@ -101,12 +116,35 @@ class EmployeeMobileGuardTest {
         when(orgSecurity.isCurrentTenant(anyLong())).thenReturn(false);
     }
 
-    /** An HR admin of the organization the session is scoped to, holding no Keycloak authority. */
+    /**
+     * An HR admin of the organization the session is scoped to, holding no Keycloak authority.
+     * Satisfies both role lists, and the self-or-admin check on any employee.
+     */
     private void callerIsAnHrAdminOf(long orgId) {
-        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(true);
-        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), any(String[].class))).thenReturn(true);
-        when(orgSecurity.isCurrentTenant(anyLong())).thenReturn(false);
+        callerHoldsNoRole();
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(DIRECTORY_ROLES)).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(ADMIN_ROLES)).thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), eq("system-admin"), eq("hr-admin"))).thenReturn(true);
         when(orgSecurity.isCurrentTenant(eq(orgId))).thenReturn(true);
+    }
+
+    /**
+     * A project manager. Reads the directory and writes nothing, which is the difference between
+     * the two role lists and the reason the listings and the writes are not gated alike.
+     */
+    private void callerIsAProjectManagerOf(long orgId) {
+        callerHoldsNoRole();
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(DIRECTORY_ROLES)).thenReturn(true);
+        when(orgSecurity.isCurrentTenant(eq(orgId))).thenReturn(true);
+    }
+
+    /**
+     * The employee whose record it is, holding no role at all. Only the single-record PATCH admits
+     * them, through its self clause.
+     */
+    private void callerIsTheEmployeeThemselves(long employeeId) {
+        callerHoldsNoRole();
+        when(orgSecurity.isSelfOrHasAnyOrgRole(eq(employeeId), eq("system-admin"), eq("hr-admin"))).thenReturn(true);
     }
 
     private void listingsAnswer() {
@@ -136,6 +174,20 @@ class EmployeeMobileGuardTest {
     @Test
     void theListing_answersARoleHolderWhoHoldsNoAuthorityAtAll() throws Exception {
         callerIsAnHrAdminOf(OWN_ORG);
+        listingsAnswer();
+
+        mockMvc.perform(get("/api/v1/employee").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * A project manager reads the directory. This is the case that makes the listing's role list
+     * load-bearing: drop {@code project-manager} from it and only this fails, while every other
+     * case in the file still passes.
+     */
+    @Test
+    void theListing_answersAProjectManager() throws Exception {
+        callerIsAProjectManagerOf(OWN_ORG);
         listingsAnswer();
 
         mockMvc.perform(get("/api/v1/employee").with(jwt()))
@@ -200,7 +252,7 @@ class EmployeeMobileGuardTest {
     }
 
     @Test
-    void theUpdate_answersTheEmployeeThemselvesOrAnAdmin() throws Exception {
+    void theUpdate_answersAnAdminOfTheCurrentOrganization() throws Exception {
         callerIsAnHrAdminOf(OWN_ORG);
 
         mockMvc.perform(patch("/api/v1/employee/" + EMPLOYEE)
@@ -208,6 +260,36 @@ class EmployeeMobileGuardTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(PATCH_BODY))
                 .andExpect(status().isOk());
+    }
+
+    /**
+     * The self clause, which is the whole reason this endpoint is not gated like the batch beside
+     * it: a person maintaining their own record from the phone holds no role at all. Lose the self
+     * clause and only this case fails.
+     */
+    @Test
+    void theUpdate_answersTheEmployeeThemselvesWithNoRole() throws Exception {
+        callerIsTheEmployeeThemselves(EMPLOYEE);
+
+        mockMvc.perform(patch("/api/v1/employee/" + EMPLOYEE)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PATCH_BODY))
+                .andExpect(status().isOk());
+    }
+
+    /** Somebody else's record, from a caller who is nobody's admin. */
+    @Test
+    void theUpdate_isRefusedOnAColleaguesRecord() throws Exception {
+        callerIsTheEmployeeThemselves(EMPLOYEE);
+
+        mockMvc.perform(patch("/api/v1/employee/" + (EMPLOYEE + 1))
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PATCH_BODY))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
     }
 
     // ---- PATCH /batch : maintaining a set ----------------------------------------------
@@ -242,6 +324,20 @@ class EmployeeMobileGuardTest {
                 .andExpect(status().isOk());
     }
 
+    /** Bulk personnel maintenance is administration, not something a project manager does. */
+    @Test
+    void theBatchUpdate_isRefusedToAProjectManager() throws Exception {
+        callerIsAProjectManagerOf(OWN_ORG);
+
+        mockMvc.perform(patch("/api/v1/employee/batch")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BATCH_BODY))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
+    }
+
     // ---- DELETE /{id} : ending a membership ---------------------------------------------
 
     @Test
@@ -262,6 +358,22 @@ class EmployeeMobileGuardTest {
 
         mockMvc.perform(delete("/api/v1/employee/" + EMPLOYEE).with(jwt()))
                 .andExpect(status().isOk());
+    }
+
+    /**
+     * A project manager reads the directory and does not end memberships. This pair with
+     * {@code theBatchUpdate_isRefusedToAProjectManager} is what keeps the two role lists apart: if
+     * the writes were widened to the directory's three roles, both of these would fail and nothing
+     * else would.
+     */
+    @Test
+    void theDelete_isRefusedToAProjectManager() throws Exception {
+        callerIsAProjectManagerOf(OWN_ORG);
+
+        mockMvc.perform(delete("/api/v1/employee/" + EMPLOYEE).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(employeeService);
     }
 
     @TestConfiguration


### PR DESCRIPTION
Six `@PreAuthorize` expressions on the mobile `EmployeeController` name a bare `resource:scope` authority. `JwtAuthConverter` mints those in one place, `extractPermissions`, which reads the `authorization` claim of an RPT, and the realm defines no authorization scopes, so each of the six has refused every caller since it was written.

Five are repaired to what the workflow behind them needs. The sixth is proposed for removal instead, with the evidence below.

Measuring the red first: this opens with the tests only, so CI records which of them the current code fails. The fix follows in the next commit.

## What each of the five is gated to, and why

| endpoint | guard | who needs it |
|---|---|---|
| `GET /` | `hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')` | the employee directory. `EmployeeDto` carries salary, date of birth, address and phone, so this is the personnel record; a member who only needs to pick a colleague has `/web/lookup`. Matches the web twin's listings. |
| `GET /organization/{id}` | `isCurrentTenant(#id) and hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')` | the same directory with the organization named. The organization clause changed shape rather than being substituted: `isMember(#id)` establishes that the caller belongs to the organization they named and leaves the organization the request is scoped to unexamined. `Organization` is the tenant root, outside the `orgFilter` and outside the load listener, so a caller-supplied id has no ambient protection. |
| `PATCH /{id}` | `isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin')` | maintaining a record, your own from the phone or anyone's as an admin. Identical to the web twin, and level with the `GET /{id}` beside it that #710 set to the same expression. |
| `PATCH /batch` | `hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')` | personnel maintenance across a set at once. No self clause: the ids arrive in the body, so there is nothing for `#id` to bind to, and a person maintaining their own record has the single-record route. |
| `DELETE /{id}` | `hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')` | ending a membership, which also takes the Keycloak group away. Administration, not day-to-day management. Matches the web twin. |

## The guard-versus-service key

Every one of these was checked against what the service then loads, because a guard that reads one id while the service loads by another is the shape that has produced ten closed issues here.

- `PATCH /{id}` and `DELETE /{id}`: the service uses `findByIdAndOrganizationId(id, TenantContext.getCurrentOrgId())`, the same id and the same organization the guard resolves.
- `GET /organization/{id}`: the guard checks the id the service then filters on.
- `PATCH /batch` and `GET /`: the guard names no id, so there is nothing to disagree about. The rows are still tenant-bound underneath, by the `orgFilter` and `TenantIsolationLoadListener` inside the `@Transactional` service method.

`isCurrentTenant` cannot lock a live caller out, either. `TenantFilter` sets the current organization only from a membership the caller holds: with the `X-Organization-Id` header it refuses one the caller is not a member of, and with no header it infers a single membership and refuses a multi-membership caller with a 400 before any guard runs.

## The sixth: `POST /` is proposed for removal, not repaired

Closes #675 as well, whose subject is the same route. The commented-out `createEmployee` on `EmployeeControllerWeb` is deleted here; the live route on this prefix is left refusing, because repairing its guard is the one change that would make things worse.

- **Nothing calls it.** echno-core publishes no direct employee create and pins that with a regression test; echno-web has no create call site, no create hook and no create form, only the invitation flow; the Flutter client's single employee call is `GET /employee/organization/{id}`, one of the five repaired above. The web BFF is a catch-all proxy, so this is an absence of callers rather than an absence of reach.
- **It cannot succeed.** `addEmployee` never sets `user`, and `Employee.user` is a `nullable = false` join column, so the save ends in a constraint violation whatever the caller sends.
- **It discards what it demands.** `EmployeeObjectMapper` writes neither `designation` nor `department`, both `@NotBlank` on the payload, along with `joiningDate`, `employeeId` and `salary`. That is the defect `status` was removed from the payload for.
- **It picks the tenant out of the body.** The organization is resolved by `organizationName`, and `Organization` is the tenant root, so nothing narrows that lookup to the caller's own. Repairing the guard alone would convert a route nobody can reach into a cross-tenant write.

The gap it looks like it fills, an administrator adding somebody who has never signed in, is real. The answer to it is a designed route that says what it does about the Keycloak user, not this one.

Also deleted: the commented-out `GET /organization/{id}` and `PATCH /batch` blocks on the web twin, the same artifact class as the create block, kept for the same reason and misleading in the same way. Both are live on the mobile prefix, and repaired above.

Closes #716
Closes #675

https://claude.ai/code/session_018LUw1wk1SqVZN55TQDKRHn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added security coverage for employee endpoints using organization-role-based access.
  - Verified legacy employee authorities are rejected.
  - Covered directory access, tenant isolation, individual and batch updates, and deletion.
  - Confirmed unauthorized requests do not trigger service operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->