### PR TITLE
Fix the three defects the nullability pass surfaced

### DIFF
--- a/docs/ATTENDANCE_MODULE.md
+++ b/docs/ATTENDANCE_MODULE.md
@@ -131,15 +131,14 @@ Multi-tenancy is enforced via a Hibernate `orgFilter` that automatically scopes 
 | `longitude` | Double | GPS longitude (optional) |
 | `gpsAccuracy` | Double | GPS accuracy in meters |
 | `altitude` | Double | GPS altitude |
-| `photoUrl` | String | Photo taken at clock event |
 | `devicePlatform` | String | "android" / "ios" / "web" |
 | `deviceId` | String | Device identifier |
 | `ipAddress` | String | Client IP address |
 | `isWithinGeofence` | Boolean | Whether location is within project geofence |
 | `distanceFromProject` | Double | Distance from project location in meters |
-| `verifiedBy` | String | Supervisor who verified this event |
 | `isRegularized` | Boolean | Whether this event was added via regularization |
 | `regularizationReason` | String | Reason for regularization |
+| `attachments` | List&lt;Attachment&gt; | Photos taken with the punch, each returned with a signed download URL |
 
 ---
 
@@ -556,7 +555,6 @@ Record any subsequent clock event (lunch out, lunch in, clock-out) on an existin
   "longitude": 77.5946,
   "gpsAccuracy": 5.0,
   "altitude": 920.0,
-  "photoUrl": null,
   "devicePlatform": "android",
   "deviceId": "device-uuid-123",
   "ipAddress": "192.168.1.10",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1357,7 +1357,7 @@
         "description": "A single day's attendance record for an employee, with its clock events, movements, regularizations and approval state.",
         "properties": {
           "afternoonSessionMinutes": {
-            "description": "Minutes worked in the afternoon session, after the lunch break. Null whenever the day's totals have not been computed.",
+            "description": "Minutes worked in the afternoon session, after the lunch break. Null on the same terms as totalWorkMinutes.",
             "example": 255,
             "format": "int32",
             "type": [
@@ -1408,7 +1408,7 @@
             "type": "string"
           },
           "breakDurationMinutes": {
-            "description": "Total minutes spent on breaks during the day. Null whenever the day's totals have not been computed; a computed zero means no break was punched.",
+            "description": "Total minutes spent on breaks during the day. Zero when no break was punched. Null on the same terms as totalWorkMinutes.",
             "example": 60,
             "format": "int32",
             "type": [
@@ -1491,7 +1491,7 @@
             ]
           },
           "morningSessionMinutes": {
-            "description": "Minutes worked in the morning session, before the lunch break. Null whenever the day's totals have not been computed.",
+            "description": "Minutes worked in the morning session, before the lunch break. Null on the same terms as totalWorkMinutes.",
             "example": 225,
             "format": "int32",
             "type": [
@@ -1507,7 +1507,7 @@
             "type": "array"
           },
           "overtimeMinutes": {
-            "description": "Minutes worked beyond the shift's overtime threshold. Null whenever the day's totals have not been computed, which is different from a computed zero meaning no overtime was earned.",
+            "description": "Minutes worked beyond the shift's overtime threshold. Zero when no overtime was earned. Null on the same terms as totalWorkMinutes.",
             "example": 30,
             "format": "int32",
             "type": [
@@ -1575,7 +1575,7 @@
             "type": "string"
           },
           "totalWorkMinutes": {
-            "description": "Total minutes worked across all sessions. Null until the day is computed, which never happens on a record with no shift or one raised by marking someone absent or on leave. Null means nothing was calculated and must not be read as zero minutes worked.",
+            "description": "Total minutes worked across all sessions. Zero on a day nobody worked, including one raised by marking someone absent or on leave. Null only on a record written before absences began storing a zero here; those rows were left as they are, so a client reading history still has to allow for it.",
             "example": 480,
             "format": "int32",
             "type": [
@@ -2999,13 +2999,6 @@
               "null"
             ]
           },
-          "photoUrl": {
-            "description": "Always null. The mapper ignores this field and the clock event has no photo of its own; photos taken with a punch are returned in attachments instead, each with its own signed download URL.",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "projectId": {
             "description": "Id of the project the event was recorded against.",
             "example": 12,
@@ -3037,23 +3030,6 @@
           "remarks": {
             "description": "Optional remarks about the event. Null where none were given, and always null on an event written by a regularization.",
             "example": "Reported directly to the second floor slab pour",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "verifiedAt": {
-            "description": "When the event was verified. Null on the same terms as verifiedBy, and the two are written together if anything ever writes them.",
-            "example": "2026-01-16T11:00:00",
-            "format": "date-time",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "verifiedBy": {
-            "description": "Who verified the event. The column exists but no code path in the application writes it, so it is null on every event this server records.",
-            "example": "Anand Rajashekar",
             "type": [
               "string",
               "null"
@@ -6094,7 +6070,7 @@
             "type": "boolean"
           },
           "projectId": {
-            "description": "Project the goods were received for. The column permits null and rows exist without it, although the entity declares the association non-optional.",
+            "description": "Project the goods were received for. The column permits null. Every route the application offers requires a project, so a null here names a row that did not come through one, such as a database migrated from before the column existed.",
             "example": 42,
             "format": "int64",
             "type": [
@@ -13460,7 +13436,7 @@
             "type": "string"
           },
           "projectId": {
-            "description": "Id of the project the amount is charged to. The column permits null and rows exist without it, although the entity declares the association non-optional.",
+            "description": "Id of the project the amount is charged to. The column permits null. Every route the application offers requires a project, so a null here names a row that did not come through one, such as a database migrated from before the column existed.",
             "format": "int64",
             "type": [
               "integer",
@@ -14983,7 +14959,7 @@
             "type": "string"
           },
           "projectId": {
-            "description": "Id of the project the materials are for. The column permits null and rows exist without it, although the entity declares the association non-optional.",
+            "description": "Id of the project the materials are for. The column permits null. Every route the application offers requires a project, so a null here names a row that did not come through one, such as a database migrated from before the column existed.",
             "example": 3,
             "format": "int64",
             "type": [

--- a/src/main/java/org/tornotron/echno_backend/attendance/Attendance.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/Attendance.java
@@ -73,18 +73,23 @@ public class Attendance implements TenantScopedEntity {
     @OrderBy("eventTimestamp ASC")
     private List<ClockEvent> clockEvents = new ArrayList<>();
 
+    @Builder.Default
     @Column(name = "total_work_minutes")
     private Integer totalWorkMinutes = 0;
 
+    @Builder.Default
     @Column(name = "morning_session_minutes")
     private Integer morningSessionMinutes = 0;
 
+    @Builder.Default
     @Column(name = "afternoon_session_minutes")
     private Integer afternoonSessionMinutes = 0;
 
+    @Builder.Default
     @Column(name = "overtime_minutes")
     private Integer overtimeMinutes = 0;
 
+    @Builder.Default
     @Column(name = "break_duration_minutes")
     private Integer breakDurationMinutes = 0;
 
@@ -115,6 +120,7 @@ public class Attendance implements TenantScopedEntity {
     @OrderBy("startTime ASC")
     private List<MovementRecord> movements = new ArrayList<>();
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "approval_status", nullable = false)
     private ApprovalStatus approvalStatus = ApprovalStatus.PENDING;
@@ -166,6 +172,7 @@ public class Attendance implements TenantScopedEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Builder.Default
     @OneToMany(mappedBy = "attendance")
     private List<Attachment> attachments = new ArrayList<>();
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularization.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularization.java
@@ -68,6 +68,7 @@ public class AttendanceRegularization implements TenantScopedEntity {
     @Column(name = "approved_at")
     private LocalDateTime approvedAt;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private RegularizationStatus status = RegularizationStatus.PENDING;

--- a/src/main/java/org/tornotron/echno_backend/attendance/ClockEvent.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/ClockEvent.java
@@ -126,11 +126,6 @@ public class ClockEvent implements TenantScopedEntity {
     @Column(name = "remarks")
     private String remarks;
 
-    @Column(name = "verified_by")
-    private String verifiedBy;
-
-    @Column(name = "verified_at")
-    private LocalDateTime verifiedAt;
 
     @Builder.Default
     @Column(name = "is_regularized", nullable = false)

--- a/src/main/java/org/tornotron/echno_backend/attendance/ShiftTiming.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/ShiftTiming.java
@@ -43,15 +43,19 @@ public class ShiftTiming implements TenantScopedEntity {
     @Column(name = "lunch_break_end", nullable = false)
     private LocalTime lunchBreakEnd;
 
+    @Builder.Default
     @Column(name = "grace_period_minutes", nullable = false)
     private Integer gracePeriodMinutes = 15;
 
+    @Builder.Default
     @Column(name = "minimum_work_hours", nullable = false, precision = 4, scale = 2)
     private BigDecimal minimumWorkHours = BigDecimal.valueOf(8.0);
 
+    @Builder.Default
     @Column(name = "half_day_work_hours", nullable = false, precision = 4, scale = 2)
     private BigDecimal halfDayWorkHours = BigDecimal.valueOf(4.0);
 
+    @Builder.Default
     @Column(name = "overtime_threshold", nullable = false, precision = 4, scale = 2)
     private BigDecimal overtimeThreshold = BigDecimal.valueOf(9.0);
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
@@ -54,30 +54,29 @@ public class AttendanceResponseDto {
             + "rather than null on a day with no punches.")
     private List<ClockEventDto> clockEvents;
 
-    @Schema(description = "Total minutes worked across all sessions. Null until the day is "
-            + "computed, which never happens on a record with no shift or one raised by marking "
-            + "someone absent or on leave. Null means nothing was calculated and must not be read "
-            + "as zero minutes worked.", example = "480", nullable = true)
+    @Schema(description = "Total minutes worked across all sessions. Zero on a day nobody "
+            + "worked, including one raised by marking someone absent or on leave. Null only on "
+            + "a record written before absences began storing a zero here; those rows were left "
+            + "as they are, so a client reading history still has to allow for it.",
+            example = "480", nullable = true)
     private Integer totalWorkMinutes;
 
     @Schema(description = "Minutes worked in the morning session, before the lunch break. Null "
-            + "whenever the day's totals have not been computed.", example = "225",
-            nullable = true)
+            + "on the same terms as totalWorkMinutes.", example = "225", nullable = true)
     private Integer morningSessionMinutes;
 
     @Schema(description = "Minutes worked in the afternoon session, after the lunch break. Null "
-            + "whenever the day's totals have not been computed.", example = "255",
-            nullable = true)
+            + "on the same terms as totalWorkMinutes.", example = "255", nullable = true)
     private Integer afternoonSessionMinutes;
 
-    @Schema(description = "Minutes worked beyond the shift's overtime threshold. Null whenever "
-            + "the day's totals have not been computed, which is different from a computed zero "
-            + "meaning no overtime was earned.", example = "30", nullable = true)
+    @Schema(description = "Minutes worked beyond the shift's overtime threshold. Zero when no "
+            + "overtime was earned. Null on the same terms as totalWorkMinutes.",
+            example = "30", nullable = true)
     private Integer overtimeMinutes;
 
-    @Schema(description = "Total minutes spent on breaks during the day. Null whenever the day's "
-            + "totals have not been computed; a computed zero means no break was punched.",
-            example = "60", nullable = true)
+    @Schema(description = "Total minutes spent on breaks during the day. Zero when no break was "
+            + "punched. Null on the same terms as totalWorkMinutes.", example = "60",
+            nullable = true)
     private Integer breakDurationMinutes;
 
     @Schema(description = "Whether the employee clocked in after the shift's grace period.", example = "false")

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventDto.java
@@ -48,11 +48,6 @@ public class ClockEventDto {
             example = "8.5", nullable = true)
     private Double gpsAccuracy;
 
-    @Schema(description = "Always null. The mapper ignores this field and the clock event has "
-            + "no photo of its own; photos taken with a punch are returned in attachments "
-            + "instead, each with its own signed download URL.", nullable = true)
-    private String photoUrl;
-
     @Schema(description = "Id of the project the event was recorded against.", example = "12")
     private Long projectId;
 
@@ -99,16 +94,6 @@ public class ClockEventDto {
             + "always null on an event written by a regularization.",
             example = "Reported directly to the second floor slab pour", nullable = true)
     private String remarks;
-
-    @Schema(description = "Who verified the event. The column exists but no code path in the "
-            + "application writes it, so it is null on every event this server records.",
-            example = "Anand Rajashekar", nullable = true)
-    private String verifiedBy;
-
-    @Schema(description = "When the event was verified. Null on the same terms as verifiedBy, "
-            + "and the two are written together if anything ever writes them.",
-            example = "2026-01-16T11:00:00", nullable = true)
-    private LocalDateTime verifiedAt;
 
     @Schema(description = "Whether this event was added through a regularization request rather than recorded live.", example = "false")
     private Boolean isRegularized;

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/ClockEventMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/ClockEventMapper.java
@@ -1,7 +1,6 @@
 package org.tornotron.echno_backend.attendance.mapper;
 
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.attendance.ClockEvent;
 import org.tornotron.echno_backend.attendance.dto.ClockEventDto;
 import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
@@ -19,7 +18,5 @@ import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
 @Mapper(componentModel = "spring", uses = AttachmentMapper.class)
 public interface ClockEventMapper {
 
-    /** The entity has no photo URL of its own; the photos are attachments. */
-    @Mapping(target = "photoUrl", ignore = true)
     ClockEventDto toDto(ClockEvent entity);
 }

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNote.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNote.java
@@ -87,8 +87,18 @@ public class GoodsReceivedNote implements TenantScopedEntity {
     @OneToMany(mappedBy = "goodsReceivedNote")
     private List<Payable> payables = new ArrayList<>();
 
+    /**
+     * The project the record is charged to.
+     *
+     * <p>Declared nullable because {@code goods_received_note.project_id} is. Every creation path requires
+     * it, through a {@code @NotNull} on the request and a lookup that throws when the project is
+     * not found, and no update can clear it, so the application does not write one without a
+     * project. The column itself was never constrained, and a database migrated from before the
+     * column existed was not backfilled, so a null row remains possible and the contract says so.
+     * Tightening the column would need a null sweep across every deployed database first.
+     */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
+    @JoinColumn(name = "project_id")
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteDto.java
@@ -58,9 +58,10 @@ public class GoodsReceivedNoteDto {
             nullable = true)
     private Double invoiceAmount;
 
-    @Schema(description = "Project the goods were received for. The column permits null and rows "
-            + "exist without it, although the entity declares the association non-optional.",
-            example = "42", nullable = true)
+    @Schema(description = "Project the goods were received for. The column permits null. Every "
+            + "route the application offers requires a project, so a null here names a row that "
+            + "did not come through one, such as a database migrated from before the column "
+            + "existed.", example = "42", nullable = true)
     private Long projectId;
 
     @Schema(description = "Project name. Null whenever projectId is, and also on a project that "

--- a/src/main/java/org/tornotron/echno_backend/payable/Payable.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/Payable.java
@@ -81,8 +81,18 @@ public class Payable implements TenantScopedEntity {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
+    /**
+     * The project the record is charged to.
+     *
+     * <p>Declared nullable because {@code payable.project_id} is. Every creation path requires
+     * it, through a {@code @NotNull} on the request and a lookup that throws when the project is
+     * not found, and no update can clear it, so the application does not write one without a
+     * project. The column itself was never constrained, and a database migrated from before the
+     * column existed was not backfilled, so a null row remains possible and the contract says so.
+     * Tightening the column would need a null sweep across every deployed database first.
+     */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
+    @JoinColumn(name = "project_id")
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/tornotron/echno_backend/payable/dto/PayableDto.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/dto/PayableDto.java
@@ -52,9 +52,10 @@ public class PayableDto {
             + "goodsReceivedNoteId is.", nullable = true)
     private String grnNumber;
 
-    @Schema(description = "Id of the project the amount is charged to. The column permits null "
-            + "and rows exist without it, although the entity declares the association "
-            + "non-optional.", nullable = true)
+    @Schema(description = "Id of the project the amount is charged to. The column permits null. "
+            + "Every route the application offers requires a project, so a null here names a row "
+            + "that did not come through one, such as a database migrated from before the column "
+            + "existed.", nullable = true)
     private Long projectId;
 
     @Schema(description = "Name of the project. Null whenever projectId is, and also on a project "

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrder.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrder.java
@@ -79,8 +79,18 @@ public class PurchaseOrder implements TenantScopedEntity {
     @Column(name = "total_amount", precision = 15, scale = 2)
     private BigDecimal totalAmount;
 
+    /**
+     * The project the record is charged to.
+     *
+     * <p>Declared nullable because {@code purchase_order.project_id} is. Every creation path requires
+     * it, through a {@code @NotNull} on the request and a lookup that throws when the project is
+     * not found, and no update can clear it, so the application does not write one without a
+     * project. The column itself was never constrained, and a database migrated from before the
+     * column existed was not backfilled, so a null row remains possible and the contract says so.
+     * Tightening the column would need a null sweep across every deployed database first.
+     */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
+    @JoinColumn(name = "project_id")
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderDto.java
@@ -38,9 +38,10 @@ public class PurchaseOrderDto {
             example = "IND-2026-0015", nullable = true)
     private String indentNumber;
 
-    @Schema(description = "Id of the project the materials are for. The column permits null and "
-            + "rows exist without it, although the entity declares the association non-optional.",
-            example = "3", nullable = true)
+    @Schema(description = "Id of the project the materials are for. The column permits null. "
+            + "Every route the application offers requires a project, so a null here names a row "
+            + "that did not come through one, such as a database migrated from before the column "
+            + "existed.", example = "3", nullable = true)
     private Long projectId;
 
     @Schema(description = "Name of the project. Null whenever projectId is, and also on a project "

--- a/src/test/java/org/tornotron/echno_backend/architecture/ProjectJoinColumnMatchesTheChangelogTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ProjectJoinColumnMatchesTheChangelogTest.java
@@ -1,0 +1,134 @@
+package org.tornotron.echno_backend.architecture;
+
+import jakarta.persistence.JoinColumn;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNote;
+import org.tornotron.echno_backend.payable.Payable;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Holds the {@code project} association on the three procurement entities to what the changelog
+ * actually creates.
+ *
+ * <p>Hibernate runs with {@code ddl-auto: validate}, and schema validation compares tables,
+ * columns and types but not nullability. An entity may therefore declare
+ * {@code @JoinColumn(nullable = false)} over a column the changelog left nullable and the
+ * application will start without complaint, which is how the disagreement on
+ * {@code Payable}, {@code PurchaseOrder} and {@code GoodsReceivedNote} survived. The database
+ * wins at runtime, so a client reads a nullable column while the entity claims otherwise.
+ *
+ * <p>The changelog is the authority here, not the annotation, so the expectation is read out of
+ * the changeset rather than written down twice. If a later changeset tightens one of these
+ * columns, this test turns red and the entity can follow.
+ */
+class ProjectJoinColumnMatchesTheChangelogTest {
+
+    private static final String COLUMN = "project_id";
+
+    static Stream<Arguments> associations() {
+        return Stream.of(
+                Arguments.of(Payable.class, "payable",
+                        "db/changelog/v4.0/baseline-005-level4-tables.xml"),
+                Arguments.of(PurchaseOrder.class, "purchase_order",
+                        "db/changelog/v4.0/baseline-003-level2-tables.xml"),
+                Arguments.of(GoodsReceivedNote.class, "goods_received_note",
+                        "db/changelog/v4.0/baseline-004-level3-tables.xml"));
+    }
+
+    @ParameterizedTest(name = "{1}.project_id")
+    @MethodSource("associations")
+    @DisplayName("the entity's join column agrees with the column the changelog creates")
+    void joinColumnAgreesWithTheChangelog(Class<?> entity, String table, String changelog) {
+        boolean columnIsNotNull = changelogDeclaresNotNull(changelog, table);
+        JoinColumn joinColumn = projectJoinColumn(entity);
+
+        assertThat(joinColumn.name())
+                .as("the association is expected to map %s", COLUMN)
+                .isEqualTo(COLUMN);
+        assertThat(joinColumn.nullable())
+                .as("%s.%s is %s in %s, so the entity must say the same",
+                        table, COLUMN, columnIsNotNull ? "NOT NULL" : "nullable", changelog)
+                .isEqualTo(!columnIsNotNull);
+    }
+
+    /** The {@code @JoinColumn} on the entity's {@code project} field. */
+    private JoinColumn projectJoinColumn(Class<?> entity) {
+        try {
+            Field field = entity.getDeclaredField("project");
+            JoinColumn joinColumn = field.getAnnotation(JoinColumn.class);
+            assertThat(joinColumn)
+                    .as("%s.project carries a @JoinColumn", entity.getSimpleName())
+                    .isNotNull();
+            return joinColumn;
+        } catch (NoSuchFieldException e) {
+            return fail("%s has no 'project' field".formatted(entity.getSimpleName()), e);
+        }
+    }
+
+    /**
+     * Whether the changeset that creates {@code table} constrains {@code project_id} to be
+     * NOT NULL. Liquibase expresses that as a {@code <constraints nullable="false"/>} child of
+     * the column, and its absence is what leaves the column nullable.
+     */
+    private boolean changelogDeclaresNotNull(String changelog, String table) {
+        Element column = findColumn(changelog, table);
+        NodeList children = column.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (child instanceof Element element && "constraints".equals(element.getLocalName())) {
+                return "false".equals(element.getAttribute("nullable"));
+            }
+        }
+        return false;
+    }
+
+    /** The {@code project_id} column element inside the {@code createTable} for {@code table}. */
+    private Element findColumn(String changelog, String table) {
+        Document document = parse(changelog);
+        NodeList tables = document.getElementsByTagNameNS("*", "createTable");
+        for (int i = 0; i < tables.getLength(); i++) {
+            Element createTable = (Element) tables.item(i);
+            if (!table.equals(createTable.getAttribute("tableName"))) {
+                continue;
+            }
+            NodeList columns = createTable.getElementsByTagNameNS("*", "column");
+            for (int j = 0; j < columns.getLength(); j++) {
+                Element column = (Element) columns.item(j);
+                if (COLUMN.equals(column.getAttribute("name"))) {
+                    return column;
+                }
+            }
+            return fail("no %s column in the createTable for %s".formatted(COLUMN, table));
+        }
+        return fail("no createTable for %s in %s".formatted(table, changelog));
+    }
+
+    private Document parse(String changelog) {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(changelog)) {
+            assertThat(in).as("%s is on the classpath", changelog).isNotNull();
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            return factory.newDocumentBuilder().parse(in);
+        } catch (Exception e) {
+            return fail("could not read %s".formatted(changelog), e);
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
@@ -145,13 +145,16 @@ final class ReviewedResponseSchemas {
      *       that replaces an empty list with null on purpose.
      *   <li>{@code projectId} and {@code projectName} are nullable on all three schemas, and this
      *       is the trap the vendor pass warned about. {@code Payable}, {@code PurchaseOrder} and
-     *       {@code GoodsReceivedNote} each declare
+     *       {@code GoodsReceivedNote} each declared
      *       {@code @JoinColumn(name = "project_id", nullable = false)} while the Liquibase column
      *       is nullable in every case, and no {@code addNotNullConstraint} anywhere in the
      *       changelog names a {@code project_id}. {@code ddl-auto} is {@code validate}, which
-     *       does not compare nullability, so nothing reports it. The changelog wins.
-     *       {@code projectName} is nullable twice over, since {@code project.project_name} is
-     *       itself a nullable column.
+     *       does not compare nullability, so nothing reported it. The changelog won, and #728
+     *       dropped the three annotations to match rather than tightening the columns, which
+     *       would need a null sweep of every deployed database first;
+     *       {@code ProjectJoinColumnMatchesTheChangelogTest} now reads the expectation out of the
+     *       changeset. {@code projectName} is nullable twice over, since
+     *       {@code project.project_name} is itself a nullable column.
      *   <li>A flattened name is null exactly when its foreign key is: {@code vendorName},
      *       {@code grnNumber}, {@code indentNumber}, {@code purchaseOrderNumber},
      *       {@code storageLocationName} and {@code materialName} all map through an association
@@ -181,19 +184,23 @@ final class ReviewedResponseSchemas {
      *       rows to null precisely so that a placeholder {@code false} could not be read as a
      *       measured verdict. {@code distanceFromProject} and {@code geofenceRadiusMeters} are
      *       written from the same evaluation, so the three are null together or set together.
-     *   <li>The five session-minute fields are nullable for a reason that is neither the column
-     *       nor the mapper. {@code Attendance} is a {@code @Builder} class and those five fields
-     *       carry an inline {@code = 0} with no {@code @Builder.Default}, so Lombok discards the
-     *       initialiser and the builder writes null. Nothing then fills them until
-     *       {@code AttendanceCalculationService.recalculate} runs, which never happens on a
-     *       record raised by marking someone absent or on leave, or on one with no shift. Null
-     *       there means the day was not computed, which is not zero minutes worked.
-     *   <li>{@code photoUrl}, {@code verifiedBy} and {@code verifiedAt} on
-     *       {@code ClockEventDto} are null on every response ever served. The mapper declares
-     *       {@code @Mapping(target = "photoUrl", ignore = true)} and nothing in {@code src/main}
-     *       writes the other two on a clock event. They are recorded as nullable and their
-     *       descriptions say plainly that they are not populated, rather than implying a flow
-     *       that does not exist.
+     *   <li>The five session-minute fields stay nullable, but no longer for the reason the
+     *       original pass gave. {@code Attendance} is a {@code @Builder} class and the five
+     *       carried an inline {@code = 0} with no {@code @Builder.Default}, so Lombok discarded
+     *       the initialiser and the builder wrote null on the one path that never recalculates:
+     *       marking someone absent or on leave, which also leaves the record without a shift and
+     *       so beyond the reach of every later {@code recalculate} call, all of which are guarded
+     *       on the shift. #728 added the annotation, so those records now store the zero the
+     *       declaration always intended, and match a computed day on which nobody punched. The
+     *       properties remain nullable because the rows written before that are still in the
+     *       table and were not rewritten.
+     *   <li>{@code photoUrl}, {@code verifiedBy} and {@code verifiedAt} were null on every
+     *       response the server had ever produced, and #728 took them off
+     *       {@code ClockEventDto} rather than leave the contract promising them.
+     *       {@code photoUrl} was the leftover half of a finished migration to
+     *       {@code Attachment}, and the punch photos it named are returned in
+     *       {@code attachments}; the other two were the unstarted half of a per-punch
+     *       verification that {@code MovementRecord} has and a clock event never grew.
      *   <li>The collections ({@code clockEvents}, {@code regularizations}, {@code movements},
      *       {@code attachments}) are non-null because the entity initialises each and marks it
      *       {@code @Builder.Default}. They are routinely empty, which is a normal state.
@@ -297,10 +304,10 @@ final class ReviewedResponseSchemas {
                                 "approvalStatus", "requiresGeofenceApproval")),
                 new ReviewedSchema(
                         ClockEventDto.class,
-                        Set.of("latitude", "longitude", "gpsAccuracy", "photoUrl",
+                        Set.of("latitude", "longitude", "gpsAccuracy",
                                 "devicePlatform", "isWithinGeofence", "distanceFromProject",
                                 "geofenceRadiusMeters", "geofenceExceptionReason", "recordedById",
-                                "remarks", "verifiedBy", "verifiedAt", "regularizationReason"),
+                                "remarks", "regularizationReason"),
                         Set.of("id", "eventType", "eventTimestamp", "projectId", "projectName",
                                 "isRegularized", "attachments")));
     }

--- a/src/test/java/org/tornotron/echno_backend/attendance/BuilderDefaultsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/BuilderDefaultsTest.java
@@ -1,0 +1,75 @@
+package org.tornotron.echno_backend.attendance;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the field initialisers on the attendance entities to the builder, which is the only way
+ * the application ever constructs them.
+ *
+ * <p>Lombok drops an inline initialiser on a {@code @Builder} class unless the field also carries
+ * {@code @Builder.Default}: the generated builder passes its own uninitialised slot into the
+ * all-args constructor, and the constructor assignment overwrites whatever the initialiser wrote.
+ * The declaration then reads as a default that never applies, and the field arrives null.
+ *
+ * <p>These tests construct through {@code builder()} deliberately. The no-args constructor does
+ * run the initialisers, so a fixture built with {@code new Attendance()} passes whether or not
+ * the annotation is present and proves nothing. So does any builder chain that sets the field
+ * under test explicitly. Every assertion below is on a field the chain leaves alone.
+ */
+class BuilderDefaultsTest {
+
+    @Test
+    @DisplayName("a built attendance carries zero minutes, not null, on every session field")
+    void attendanceSessionMinutesDefaultToZero() {
+        Attendance attendance = Attendance.builder().build();
+
+        assertThat(attendance.getTotalWorkMinutes()).isZero();
+        assertThat(attendance.getMorningSessionMinutes()).isZero();
+        assertThat(attendance.getAfternoonSessionMinutes()).isZero();
+        assertThat(attendance.getOvertimeMinutes()).isZero();
+        assertThat(attendance.getBreakDurationMinutes()).isZero();
+    }
+
+    @Test
+    @DisplayName("a built attendance starts PENDING approval")
+    void attendanceApprovalStatusDefaultsToPending() {
+        assertThat(Attendance.builder().build().getApprovalStatus())
+                .isEqualTo(ApprovalStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("every attendance collection is an empty list, so addAttachment cannot throw")
+    void attendanceCollectionsDefaultToEmptyLists() {
+        Attendance attendance = Attendance.builder().build();
+
+        assertThat(attendance.getClockEvents()).isNotNull().isEmpty();
+        assertThat(attendance.getRegularizations()).isNotNull().isEmpty();
+        assertThat(attendance.getMovements()).isNotNull().isEmpty();
+        assertThat(attendance.getAttachments()).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("a built shift timing carries the declared thresholds")
+    void shiftTimingThresholdsSurviveTheBuilder() {
+        ShiftTiming shift = ShiftTiming.builder().build();
+
+        assertThat(shift.getGracePeriodMinutes()).isEqualTo(15);
+        assertThat(shift.getMinimumWorkHours()).isEqualByComparingTo(BigDecimal.valueOf(8.0));
+        assertThat(shift.getHalfDayWorkHours()).isEqualByComparingTo(BigDecimal.valueOf(4.0));
+        assertThat(shift.getOvertimeThreshold()).isEqualByComparingTo(BigDecimal.valueOf(9.0));
+    }
+
+    @Test
+    @DisplayName("a built regularization starts PENDING")
+    void regularizationStatusDefaultsToPending() {
+        assertThat(AttendanceRegularization.builder().build().getStatus())
+                .isEqualTo(RegularizationStatus.PENDING);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/ClockEventDtoPublishesOnlyWrittenFieldsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/ClockEventDtoPublishesOnlyWrittenFieldsTest.java
@@ -1,0 +1,54 @@
+package org.tornotron.echno_backend.attendance;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.tornotron.echno_backend.attendance.dto.ClockEventDto;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keeps {@link ClockEventDto} to fields something actually writes.
+ *
+ * <p>Three properties were published on every clock-event response while nothing in the
+ * application ever filled them, so they were null on every response the server had ever served.
+ *
+ * <p>{@code photoUrl} was the leftover half of a finished migration: the punch photo moved to
+ * {@code Attachment}, the entity's own {@code photo_url} field was deleted, and the mapper was
+ * left declaring {@code @Mapping(target = "photoUrl", ignore = true)} to fill the hole. The
+ * photos have been returned in {@code attachments} ever since, one per punch, each already
+ * carrying a signed download URL, which is what a client should read.
+ *
+ * <p>{@code verifiedBy} and {@code verifiedAt} were the unstarted half. The columns were created
+ * beside {@code MovementRecord}'s identically named ones, but only the movement's were ever
+ * wired to a service. A clock event has neither the {@code verified_by_id} nor the
+ * {@code is_verified} that make that flow work, and the live "somebody checked this" state for
+ * attendance is the day-level {@code approvalStatus} on {@link Attendance}. Anything that wants
+ * per-punch verification has to design it, and would not inherit these two.
+ *
+ * <p>This is a guard against reintroduction, not a style rule: a field here means the contract
+ * promises a client something it will never receive.
+ */
+class ClockEventDtoPublishesOnlyWrittenFieldsTest {
+
+    @ParameterizedTest(name = "ClockEventDto has no {0}")
+    @ValueSource(strings = {"photoUrl", "verifiedBy", "verifiedAt"})
+    @DisplayName("the fields nothing wrote are off the response contract")
+    void unwrittenFieldsAreNotPublished(String property) {
+        assertThat(Arrays.stream(ClockEventDto.class.getDeclaredFields()).map(Field::getName))
+                .as("%s was null on every response ever served; a client cannot use it", property)
+                .doesNotContain(property);
+    }
+
+    @Test
+    @DisplayName("the punch's photos are still reachable, through attachments")
+    void attachmentsCarryThePunchPhotos() {
+        assertThat(Arrays.stream(ClockEventDto.class.getDeclaredFields()).map(Field::getName))
+                .as("removing photoUrl is only safe while the attachments list remains")
+                .contains("attachments");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/mapper/AttendanceMapperConversionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/mapper/AttendanceMapperConversionTest.java
@@ -188,14 +188,11 @@ class AttendanceMapperConversionTest {
         assertThat(dto.getIsWithinGeofence()).isTrue();
         assertThat(dto.getDistanceFromProject()).isEqualTo(12.0);
         assertThat(dto.getRemarks()).isEqualTo("on time");
-        assertThat(dto.getVerifiedBy()).isEqualTo("Supervisor");
-        assertThat(dto.getVerifiedAt()).isEqualTo(LocalDateTime.of(2026, 3, 4, 10, 0));
         assertThat(dto.getIsRegularized()).isFalse();
         assertThat(dto.getRegularizationReason()).isNull();
 
-        // The entity has no photo URL of its own; the photos are the attachments.
-        assertThat(dto.getPhotoUrl()).isNull();
-
+        // The photos taken with the punch are the attachments; the DTO has no photo URL of its
+        // own, and no verification stamp, because nothing ever wrote either (echno-backend#728).
         assertThat(dto.getAttachments()).hasSize(1);
         assertThat(dto.getAttachments().get(0).getId()).isEqualTo(88L);
         assertThat(dto.getAttachments().get(0).getUrl()).isEqualTo(SIGNED_URL);
@@ -496,8 +493,6 @@ class AttendanceMapperConversionTest {
         event.setIsWithinGeofence(true);
         event.setDistanceFromProject(12.0);
         event.setRemarks("on time");
-        event.setVerifiedBy("Supervisor");
-        event.setVerifiedAt(LocalDateTime.of(2026, 3, 4, 10, 0));
         event.setIsRegularized(false);
         event.setAttachments(List.of(attachment()));
         return event;

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/MarkAbsentZeroesTheDayTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/MarkAbsentZeroesTheDayTest.java
@@ -1,0 +1,131 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import jakarta.validation.Validation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceService;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
+import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Marking someone absent must persist a day of zero minutes, not a day of nulls.
+ *
+ * <p>{@code markAbsent} is the one reachable write path that builds an {@link Attendance} without
+ * a shift, so {@code AttendanceCalculationService.recalculate} never runs on the record: the
+ * check-in path calls it unconditionally, and the two later call sites are both guarded on the
+ * shift being non-null. Whatever the builder writes is therefore what the row keeps for good.
+ *
+ * <p>The record goes to the repository through the real service rather than being assembled in
+ * the test, because the defect this guards against lives in the gap between the field
+ * declarations and the builder. A fixture built any other way, in particular through the no-args
+ * constructor, runs the initialisers itself and would pass with the defect still present.
+ */
+@ExtendWith(MockitoExtension.class)
+class MarkAbsentZeroesTheDayTest {
+
+    private static final Long ORG = 100L;
+    private static final Long EMPLOYEE_ID = 42L;
+    private static final Long PROJECT_ID = 12L;
+    private static final LocalDate DATE = LocalDate.of(2026, 9, 7);
+
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private ShiftTimingRepository shiftTimingRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private ClockEventSequenceValidator sequenceValidator;
+    @Mock private AttendanceMapper attendanceMapper;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private UserContextService userContextService;
+    @Mock private AttendanceSecurityService attendanceSecurity;
+    @Mock private AttendanceGeofenceService geofenceService;
+
+    private AttendanceService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new AttendanceService(attendanceRepository, shiftTimingRepository,
+                employeeRepository, organizationRepository, projectRepository, settingsService,
+                calculationService, sequenceValidator, attendanceMapper, attachmentService,
+                fileStorageService, userContextService,
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
+                attendanceSecurity, geofenceService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    @DisplayName("an absence is stored with zero minutes on every session field")
+    void absenceIsStoredWithZeroedMinutes() {
+        Organization org = new Organization();
+        org.setId(ORG);
+        Employee employee = new Employee();
+        employee.setId(EMPLOYEE_ID);
+        employee.setEmployeeName("Aneesh Johny");
+        Project project = new Project();
+        project.setId(PROJECT_ID);
+        project.setProjectName("Slab pour, tower B");
+
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(org));
+        when(employeeRepository.findByIdAndOrganizationId(EMPLOYEE_ID, ORG))
+                .thenReturn(Optional.of(employee));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG))
+                .thenReturn(Optional.of(project));
+        when(attendanceRepository.findByEmployeeIdAndAttendanceDateAndProjectId(
+                EMPLOYEE_ID, DATE, PROJECT_ID)).thenReturn(Optional.empty());
+        when(attendanceRepository.save(any(Attendance.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.markAbsent(EMPLOYEE_ID, PROJECT_ID, DATE);
+
+        ArgumentCaptor<Attendance> saved = ArgumentCaptor.forClass(Attendance.class);
+        verify(attendanceRepository, atLeastOnce()).save(saved.capture());
+        Attendance stored = saved.getAllValues().get(0);
+
+        assertThat(stored.getShiftTiming())
+                .as("the record has no shift, so nothing will ever recalculate it")
+                .isNull();
+        assertThat(stored.getTotalWorkMinutes()).isZero();
+        assertThat(stored.getMorningSessionMinutes()).isZero();
+        assertThat(stored.getAfternoonSessionMinutes()).isZero();
+        assertThat(stored.getOvertimeMinutes()).isZero();
+        assertThat(stored.getBreakDurationMinutes()).isZero();
+    }
+}


### PR DESCRIPTION
Closes #728. Three defects the nullability pass in #725 surfaced but deliberately did not fix, since #725 was documenting behaviour rather than changing it.

Tests are pushed as their own commit ahead of the fix, so the red is on the record: run [34128370607](https://github.com/tornotron/echno-backend/actions/runs/34128370607) failed **12 tests, all of them new, with no collateral damage**.

## 1. The one serving wrong data: five minute fields null where the code means zero

Lombok drops an inline initialiser on a `@Builder` class unless the field carries `@Builder.Default`. The generated builder hands its own uninitialised slot to the all-args constructor, and that assignment overwrites whatever the initialiser wrote.

**What the null actually does, end to end.** Not an exception and not a corrupted sum, which is worth stating precisely because two of the three plausible answers turned out to be wrong:

- **Backend.** The five fields have exactly two readers outside the mapper, both in `AttendanceCalculationService.buildMonthlySummary`, and both are explicitly coalesced: `a.getTotalWorkMinutes() != null ? a.getTotalWorkMinutes() : 0`. Nothing unboxes to `int`, nothing uses `mapToInt`, and no JPQL or native query touches these columns. So there is no NPE and no arithmetic corruption anywhere in `src/main`. `morningSessionMinutes`, `afternoonSessionMinutes` and `breakDurationMinutes` have no backend reader at all beyond the mapper.
- **Contract.** `AttendanceMapper` copies `Integer` to `Integer`, so the null reaches the client as `"totalWorkMinutes": null`.
- **Client.** `echno-core`'s `parseAttendance` coalesces every one of the five with `?? 0` at a single boundary, into a `WorkDuration` whose members are all plain `number`. `echno-web` never reads the raw field names, only the normalised object.

So the user is shown **`0h 0m`, indistinguishable from a day someone clocked in and out at the same minute**. The distinction the field was carrying is destroyed at the parse boundary in core, and `WorkDuration` has no vocabulary to express it. Where it does bite is the two averaging reduces in `attendance-history.tsx` and `app/users/dashboard/attendance/page.tsx`: they divide by `filtered.length`, so absences fold in as genuine zero-hour days.

**It is a data bug, not a display bug.** The nulls are genuinely persisted, and they are permanent. Hibernate binds an explicit NULL, so the `defaultValueNumeric="0"` on all five columns never fires.

**Which rows.** Only `markAbsent` and `markLeave`, and only when no record existed for that employee, date and project. `checkIn` calls `recalculate` unconditionally with a shift that is guaranteed non-null, so every check-in row already stores explicit zeros. `markAbsent` is live at `POST /api/v1/attendance/mark-absent` on both controllers; `markLeave` currently has no caller. Both build the record **without a shift**, and the three later `recalculate` call sites are all guarded on the shift being non-null, so once such a row exists nothing can ever repair it.

**Why zero is the right answer, not a preserved null.** A day with a shift and no punches already gets an explicit `0` from `recalculate`, which walks its locals from `int morningMinutes = 0`. So "not computed" and "computed as zero" were never distinguishable to begin with, and the inconsistency was that two spellings of the same day gave different answers. The fix makes an absence agree with a no-punch day.

**Stored rows are not rewritten by this PR**, so the five properties stay `nullable: true` and the descriptions now say null means a row written before this change. The repair for the existing rows is proposed separately below rather than committed, because a changeset merged here would run on the next deploy without a second decision.

**The other six.** `Attendance.approvalStatus` and `attachments`, `ShiftTiming`'s four thresholds, and `AttendanceRegularization.status` carry the identical omission. Five of those are masked by a `NOT NULL` column, where the miss fails an insert rather than serving a wrong answer, and `ShiftTiming`'s four are additionally masked by `@NotNull` on the creation DTO. `Attendance.attachments` is not masked at all: `markAbsent` leaves it null, which makes `addAttachment` an NPE waiting on that row. All eleven are fixed, since it is one line each and the next creation path would hit them.

Worth noting for anyone reading the diff: `@Builder.Default` applies only when the builder method is never called. A site that passes an explicit null still writes null, so none of the masked six changes any current behaviour.

## 2. `@JoinColumn(nullable = false)` over a nullable column: the annotation is wrong

Derived from the changelog, not the entity. The include graph was checked to be complete first (199 includes, 200 files, no `includeAll`, no nested includes, no orphans), so a negative result over the tree means something.

| | `payable` | `purchase_order` | `goods_received_note` |
|---|---|---|---|
| Changeset | `v4-005-create-payable` | `v4-003-create-purchase-order` | `v4-004-create-goods-received-note` |
| Column | `<column name="project_id" type="BIGINT"/>` | same | same |
| `<constraints>` child | none | none | none |
| Later tightening | none anywhere | none | none |
| Create DTO | `@NotNull` | `@NotNull` | `@NotNull` |
| Can the app write a null? | no | no | no |

The omission is not a file-wide style: `vendor_id` in the same `createTable` does carry `<constraints nullable="false"/>`, and `task`, `wbs_element`, `current_stock` and `attendance` all have a `NOT NULL` `project_id`. These three are the exceptions. Same result on the v3 and the v1/v2 paths, where `080-add-project-id-to-goods-management.xml` added the column nullable to already-populated tables **with no backfill**.

**Decision, the same for all three: correct the annotation, do not tighten the column.**

- Tightening is the risky half and buys nothing today. `addNotNullConstraint` would pass on a fresh v4 install and **fail the migration on any database carrying a pre-`080` row**, which is the worst shape of migration bug: green on the lab staging, red on a client. That risk lands squarely on the per-client production instances.
- `nullable = false` on `@JoinColumn` is not an enforced check. Hibernate uses it for DDL generation, which is off under `ddl-auto: validate`. Removing it loses no protection.
- The real guard already sits where it belongs and is better than a constraint: `@NotNull` on all three creation DTOs with `@Valid` on all six endpoints, plus an unconditional `setProject` after a lookup that throws. That answers a bad request with a 400 or 404 rather than a 500.
- The published contract, the DTO descriptions and `ReviewedResponseSchemas` all already say nullable. Tightening would mean reversing all of it.

Tightening stays available once someone confirms no null rows exist across every deployed database. The sweep is in the report; it is a read, so it is safe to run anywhere.

`ProjectJoinColumnMatchesTheChangelogTest` now reads the expectation out of the changeset rather than writing it down twice, so if a later changeset does tighten one of these columns the test turns red and the entity can follow.

## 3. Three fields nothing has ever written: remove

**`photoUrl` is the leftover half of a migration that finished.** `63af5e41` replaced the photo URL with attachments across check-in and clock events; the entity's own field went in `cfb5322e`; `ClockEventDto.photoUrl` was left behind with the mapper carrying `@Mapping(target = "photoUrl", ignore = true)` to fill the hole.

The selfie path is live and lands one level more precisely than `photoUrl` did. `POST /check-in` and `POST /clock-event` take a `photo` part, gated on `photoRequiredOnCheckIn` / `photoRequiredOnCheckOut`, uploaded as `CLOCK_EVENT_CHECK_IN` or `CLOCK_EVENT_CHECK_OUT`, and linked **per punch** through `Attachment.clockEvent` (FK `fk_attachment_clock_event`). `AttachmentMapper` already signs each one with a one-hour download URL, and `ClockEventDto.attachments` is declared non-null. Deriving `photoUrl` would re-add a single-value view of a list the DTO already returns in full.

**`verifiedBy` and `verifiedAt` are the unstarted half.** Born in `072-create-clock-event` beside `MovementRecord`'s identically named columns; only the movement's were ever wired. That flow needed two more columns (`verified_by_id`, `is_verified`) and a service that takes the verifier from the session, locks the row and refuses to overwrite a stamp. A clock event has none of it. The live "somebody checked this" state for attendance is `Attendance.approvalStatus` / `approvedBy` / `approvedById` / `approvedAt`, decided at day level even though the geofence verdict is computed per punch. Anything that wants per-punch verification has to design it, and would not inherit these two.

**Removal does not break the client**, which matters because `echno-core` is hand-maintained with no codegen, so a break would show up at runtime rather than at compile time. Checked rather than assumed:

- `echno-core`'s `ClockEventResponseSchema` declares all three through `nullableString` / `backendDate`, both `z.string().nullish()`. `.nullish()` is `.nullable().optional()`, so an **absent key parses cleanly**; the object is non-strict besides.
- `parseClockEvent` does `verifiedAt: parseUTCDate(raw.verifiedAt) ?? undefined`, which yields `undefined` either way.
- `echno-web` has **zero** read sites for any of the three on a clock event. Every `verifiedBy` / `verifiedAt` hit in web belongs to `ConstructionPayment`, `MovementRecord` or `NcrReport`; the one `photoUrl` hit is an employee profile photo in a mock-data file.
- There is precedent: #631 removed `verifiedBy` and `verifiedAt` from the payment DTOs, and core absorbed it.

`ClockEvent`'s entity fields go with them. The `clock_event.photo_url`, `verified_by` and `verified_at` **columns are left in place**: dropping a column is irreversible and is its own decision, and `validate` does not object to a column with no mapped field.

## Follow-ups this turned up, not fixed here

1. **`echno-core` should drop the three from `ClockEvent`.** Nothing breaks while it keeps them, since they simply stop arriving, but the type says the server sends something it no longer does. `photoUrl: string` is already declared non-optional there while the server has been sending null, so it was wrong before this PR too.
2. **`AttachmentService.linkToEntity` mixes two ids.** `case "attendance"` does `attachment.setAttendance(attendanceRepository.findById(entityId)...)`, and the attendance photo path passes `entityId = clockEvent.getId()` with `folder = "attendance"`. A punch photo's `attendance_id` is therefore set from a clock-event id, pointing at an unrelated attendance row or at nothing. The `clock_event_id` link is correct, because `addAttachment` sets it afterwards, which is why nothing has noticed.
3. **Request-side `photoUrl` orphans**: `ClockEventCreationDto.photoUrl` and `AttendanceClockEventDto.photoUrl` are accepted on the wire and read by nothing. Also published in `docs/openapi.json` as a non-nullable string with an example URL. Request-side is out of scope here as it was in #670, #678 and #725.
4. **`InventoryEventListener.handleGrnCreated`** dereferences `grn.getProject().getId()` three times with no guard. It only ever runs on a GRN the service just created, so it cannot reach a legacy null row, but it is the one place where one would throw rather than degrade.
5. **`markLeave` has no caller** anywhere in `src/main` or `src/test`. It is fixed here alongside `markAbsent` rather than left as a trap, but it is dead code and should either be wired to the leave approval flow or removed.

---

https://claude.ai/code/session_018LUw1wk1SqVZN55TQDKRHn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Attendance**
  - Clock-event responses now provide punch photos through attachments with signed download URLs.
  - Removed unused photo URL and verification timestamp fields from clock-event data.
  - Attendance and shift calculations now reliably default to zero or configured values when records are created.
  - Absence records store zero duration values when no work was performed.

- **Data Compatibility**
  - Project associations now support legacy records without a project while application-created records continue to require one.

- **Documentation**
  - Updated API descriptions to clarify attendance totals and legacy nullable project values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->