### PR TITLE
Let the author of an issue comment correct it, on the record

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7619,6 +7619,13 @@
             "format": "date-time",
             "type": "string"
           },
+          "edited": {
+            "type": "boolean"
+          },
+          "editedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
           "id": {
             "format": "int64",
             "type": "integer"
@@ -7639,11 +7646,34 @@
             "format": "date-time",
             "type": "string"
           },
+          "edited": {
+            "type": "boolean"
+          },
+          "editedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
           "id": {
             "format": "int64",
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "IssueCommentUpdateDto": {
+        "description": "Payload to change the text of a comment. Only the comment's own author may send it, and the comment is marked edited once they do.",
+        "properties": {
+          "comment": {
+            "description": "The corrected comment text.",
+            "example": "Rebar spacing on the east face still needs checking, west face is signed off.",
+            "maxLength": 500,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "comment"
+        ],
         "type": "object"
       },
       "IssueCreationDto": {
@@ -57951,6 +57981,127 @@
           }
         },
         "summary": "Get an issue comment by id",
+        "tags": [
+          "Issue Comments"
+        ]
+      },
+      "patch": {
+        "description": "Changes the text of the caller's own comment and marks it edited, with the time of the edit. Only the comment's author may do this: a system admin or project manager may delete a comment but not rewrite it.",
+        "operationId": "updateIssueComment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IssueCommentUpdateDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueCommentDto"
+                }
+              }
+            },
+            "description": "Comment updated"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "The comment is blank or longer than 500 characters"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller is not a member of the current tenant, or is not the comment's author"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No comment with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Edit an issue comment",
         "tags": [
           "Issue Comments"
         ]
@@ -108863,11 +109014,11 @@
       "name": "Inventory Transactions (Web)"
     },
     {
-      "description": "Web-client twin of the issue comment endpoints. Adds a single-comment read and a lookup of every comment on an issue, alongside the same create, paginated listing and delete operations as the base API. Access is gated by tenant membership, with delete restricted to a system admin or project manager.",
+      "description": "A comment left on an issue, carrying the comment text, its author and a timestamp. Endpoints cover creation, paginated listing and deletion, gated by the issue-comment authorities, with an admin authority that grants all operations.",
       "name": "Issue Comments"
     },
     {
-      "description": "A comment left on an issue, carrying the comment text, its author and a timestamp. Endpoints cover creation, paginated listing and deletion, gated by the issue-comment authorities, with an admin authority that grants all operations.",
+      "description": "Web-client twin of the issue comment endpoints. Adds a single-comment read and a lookup of every comment on an issue, alongside the same create, paginated listing and delete operations as the base API. Access is gated by tenant membership. An edit is restricted to the comment's own author, and a delete to a system admin or project manager.",
       "name": "Issue Comments"
     },
     {

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueComment.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueComment.java
@@ -38,4 +38,22 @@ public class IssueComment implements TenantScopedEntity {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    /**
+     * Whether the author has changed the text since posting it.
+     *
+     * <p>Set only by {@code IssueCommentService.updateIssueComment}, never by
+     * {@code @UpdateTimestamp} or a JPA auditing listener. Those fire on every save, including the
+     * one that creates the row, so a comment would be born marked edited. Issues are the QA trail
+     * and this flag is read as a statement about the record, so it has to mean what it says.
+     *
+     * <p>Two columns rather than a null check on one, matching {@code ChatMessage}, which has
+     * carried {@code isEdited} and {@code editedAt} together since the chat module was built.
+     */
+    @Column(name = "is_edited", nullable = false)
+    private boolean edited = false;
+
+    /** When the author last changed the text, or null if they never have. */
+    @Column(name = "edited_at")
+    private LocalDateTime editedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentCreationDto;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentDto;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentSimpleDto;
+import org.tornotron.echno_backend.IssueComment.dto.IssueCommentUpdateDto;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 
@@ -26,8 +27,9 @@ import java.util.List;
         name = "Issue Comments",
         description = "Web-client twin of the issue comment endpoints. Adds a single-comment read and a "
                 + "lookup of every comment on an issue, alongside the same create, paginated listing "
-                + "and delete operations as the base API. Access is gated by tenant membership, with "
-                + "delete restricted to a system admin or project manager."
+                + "and delete operations as the base API. Access is gated by tenant membership. An "
+                + "edit is restricted to the comment's own author, and a delete to a system admin or "
+                + "project manager."
 )
 public class IssueCommentControllerWeb {
 
@@ -98,6 +100,43 @@ public class IssueCommentControllerWeb {
     })
     public ResponseEntity<List<IssueCommentDto>> getAllIssueCommentsByIssueId(@PathVariable Long issueId) {
         return ResponseEntity.status(HttpStatus.OK).body(issueCommentService.getAllIssueCommentsByIssueId(issueId));
+    }
+
+    /**
+     * Corrects the text of a comment the caller wrote.
+     *
+     * <p>The guard is tenant membership, and the authorship check is in
+     * {@link IssueCommentService#updateIssueComment}, next to the write it authorises, so the row
+     * the author is read from is the row the text is written to.
+     * {@code ChatControllerWeb.editMessage} is annotated the same way for the same reason.
+     *
+     * <p>There is no twin of this on {@link IssueCommentController}. Every guard on that
+     * controller names an {@code issue-comment:*} authority, and those are bare
+     * {@code resource:scope} strings that the realm has no authorization scopes to issue, so an
+     * edit added there would arrive refusing every caller. Repairing that surface is the
+     * phantom-guard family and belongs with it, not inside this feature.
+     *
+     * @param id The comment to correct.
+     * @param dto The replacement text.
+     * @return The updated comment, carrying the edited marker.
+     */
+    @PatchMapping("{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Edit an issue comment",
+            description = "Changes the text of the caller's own comment and marks it edited, with the "
+                    + "time of the edit. Only the comment's author may do this: a system admin or "
+                    + "project manager may delete a comment but not rewrite it."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Comment updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The comment is blank or longer than 500 characters"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or is not the comment's author"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No comment with the given id")
+    })
+    public ResponseEntity<IssueCommentDto> updateIssueComment(@PathVariable Long id,
+                                                              @Valid @RequestBody IssueCommentUpdateDto dto) {
+        return ResponseEntity.status(HttpStatus.OK).body(issueCommentService.updateIssueComment(id, dto.getComment()));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentService.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentService.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.IssueComment.mapper.IssueCommentMapper;
@@ -13,9 +14,9 @@ import org.tornotron.echno_backend.IssueComment.dto.IssueCommentSimpleDto;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
-import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.issue.IssueRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -83,6 +84,59 @@ public class IssueCommentService {
         return issueCommentRepository.findAllByIssue_IdAndOrganization_Id(issueId,TenantContext.getCurrentOrgId()).stream()
                 .map(issueCommentMapper::toDto)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Corrects the text of a comment the caller wrote, and marks it edited.
+     *
+     * <p><b>The author, and nobody else.</b> Not a system admin, not a project manager. The two of
+     * them may already delete a comment, which is a visible act that leaves the thread obviously
+     * shorter; changing the words inside somebody else's name is not visible at all, and a reader
+     * has no way to tell it from what the author wrote. That is a worse artifact than the gap this
+     * closes.
+     *
+     * <p><b>The check is here rather than in a {@code @PreAuthorize} expression</b>, and that is
+     * deliberate. A guard that took the comment id would have to load the row to find its author,
+     * and the service then loads it again to write to it: two lookups that can drift apart, which
+     * is the shape a run of defects in this codebase has come from. Here the row the author is
+     * read from is the row the text is written to, so they cannot disagree.
+     * {@code ChatService.editMessage} settles the same question the same way, and the endpoint
+     * carries {@code isMemberOfCurrentTenant} exactly as the chat one does.
+     *
+     * <p>A comment in another organization is not found rather than refused. The finder is scoped
+     * to the tenant, so a foreign id yields the 404 a nonexistent id yields, and a caller cannot
+     * use the difference between 403 and 404 to learn that a comment exists somewhere they cannot
+     * see.
+     *
+     * <p>There is no time window. A five-minute edit window is a rule about how long a mistake
+     * stays fixable, and nobody has asked for one; the marker is what keeps the record honest, not
+     * the deadline. Adding one later changes no stored state.
+     *
+     * @param id The comment to correct.
+     * @param comment The replacement text.
+     * @return The updated comment, carrying the edited marker.
+     * @throws org.springframework.security.access.AccessDeniedException if the caller has no
+     *     employee record in this organization, or is not the comment's author.
+     * @throws ResourceNotFoundException if no such comment is in this organization.
+     */
+    @Transactional
+    public IssueCommentDto updateIssueComment(Long id, String comment) {
+        Long callerEmployeeId = currentEmployeeService.requireCurrentEmployee("edit a comment").getId();
+
+        IssueComment issueComment = issueCommentRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Issue comment with ID " + id + " was not found in this organization"));
+
+        if (!callerEmployeeId.equals(issueComment.getAuthorId())) {
+            throw new AccessDeniedException("Only the author can edit this comment");
+        }
+
+        issueComment.setComment(comment);
+        issueComment.setEdited(true);
+        issueComment.setEditedAt(LocalDateTime.now());
+
+        return issueCommentMapper.toDto(issueCommentRepository.save(issueComment));
     }
 
     @Transactional

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/dto/IssueCommentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/dto/IssueCommentDto.java
@@ -10,4 +10,14 @@ public class IssueCommentDto {
     private String comment;
     private Long authorId;
     private LocalDateTime createdAt;
+
+    /**
+     * Whether the author changed the text after posting it. False on every comment written before
+     * the marker existed, which is accurate: none of them could have been edited, because there
+     * was no route to edit them with.
+     */
+    private boolean edited;
+
+    /** When the author last changed the text, or null if they never have. */
+    private LocalDateTime editedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/dto/IssueCommentSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/dto/IssueCommentSimpleDto.java
@@ -11,4 +11,9 @@ public class IssueCommentSimpleDto {
     private Long authorId;
     private LocalDateTime createdAt;
 
+    /** Whether the author changed the text after posting it. */
+    private boolean edited;
+
+    /** When the author last changed the text, or null if they never have. */
+    private LocalDateTime editedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/dto/IssueCommentUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/dto/IssueCommentUpdateDto.java
@@ -1,0 +1,32 @@
+package org.tornotron.echno_backend.IssueComment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Payload to change the text of a comment already posted.
+ *
+ * <p>The text is the only thing an edit may change. The issue a comment belongs to is not
+ * editable, because moving a comment between issues would rewrite two threads rather than correct
+ * one sentence; the author is not editable for the reason
+ * {@link IssueCommentCreationDto} records, that a comment is read as its author's own statement.
+ * Both are therefore absent rather than ignored, so a client sending either is told nothing was
+ * done with it by the field simply not existing.
+ *
+ * <p>Same {@code @NotBlank} and 500-character bound as the create payload. An edit that empties a
+ * comment is a delete wearing an edit's clothes, and the thread should show a deletion if that is
+ * what happened.
+ */
+@Schema(description = "Payload to change the text of a comment. Only the comment's own author may "
+        + "send it, and the comment is marked edited once they do.")
+@Data
+public class IssueCommentUpdateDto {
+
+    @Schema(description = "The corrected comment text.",
+            example = "Rebar spacing on the east face still needs checking, west face is signed off.")
+    @NotBlank(message = "comment is required")
+    @Size(max = 500, message = "Comment must not exceed 500 characters")
+    private String comment;
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -409,4 +409,7 @@
     <!-- v4.0 - Attendance: index the approval queue's predicate, which nothing queried before -->
     <include file="db/changelog/v4.0/091-index-attendance-approval-queue.xml"/>
 
+    <!-- v4.0 - Issue comments: let an author correct their own comment, and say on the record that they did -->
+    <include file="db/changelog/v4.0/092-issue-comment-edited-marker.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/092-issue-comment-edited-marker.xml
+++ b/src/main/resources/db/changelog/v4.0/092-issue-comment-edited-marker.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="092-issue-comment-edited-marker" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="issue_comments" columnName="is_edited"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Give an issue comment somewhere to record that it was changed after it was posted.
+            A comment can be posted and deleted and that is all, so a typo is fixed today by
+            deleting and reposting, which moves the comment to the bottom of the thread and
+            restamps its time. Issues are the QA trail, so the edit cannot be silent either: a
+            comment that changes with no trace is a worse record than one that cannot change.
+            Two columns rather than one, matching chat_message, which has carried exactly this
+            pair since 051: is_edited answers the question a reader asks and edited_at answers
+            when, and a boolean the reader can trust is cheaper to render than a null check on a
+            timestamp. NOT NULL with a false default on the flag, because every comment written
+            before this changeset was demonstrably not edited and false states that correctly.
+            Nullable with no default on the timestamp, because there is no moment to record for
+            those rows and picking one would assert something nobody observed.
+        </comment>
+
+        <addColumn tableName="issue_comments">
+            <column name="is_edited" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="edited_at" type="TIMESTAMP"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/IssueComment/IssueCommentEditTest.java
+++ b/src/test/java/org/tornotron/echno_backend/IssueComment/IssueCommentEditTest.java
@@ -1,0 +1,203 @@
+package org.tornotron.echno_backend.IssueComment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.IssueComment.dto.IssueCommentDto;
+import org.tornotron.echno_backend.IssueComment.mapper.IssueCommentMapper;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.issue.IssueRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who may change a comment after it is posted, and what the record says afterwards.
+ *
+ * <p>A comment could be posted and deleted and nothing else, so fixing a typo meant deleting and
+ * reposting, which moved the comment to the bottom of the thread and restamped its time. See #676.
+ *
+ * <p>Three things are pinned, and each answers one of the questions that made this more than a
+ * controller method. Only the author may edit, so nobody rewrites words that appear under somebody
+ * else's name. The edit is marked, so a reader of the QA trail can tell a corrected comment from an
+ * original one. And a comment in another organization is not found rather than refused, so the
+ * choice between 404 and 403 does not tell a caller that a comment exists somewhere they cannot
+ * see.
+ *
+ * <p>The authorship check lives in the service rather than in a {@code @PreAuthorize} expression,
+ * which is why these are service tests rather than a web slice. A guard would have to load the row
+ * to find its author and the service would load it again to write to it; here it is one load, so
+ * there is no second lookup to drift. That also makes these tests non-vacuous in the way a mocked
+ * {@code @orgSecurity} in a web slice is not: the decision under test is the real code path, not a
+ * stub of it.
+ */
+@ExtendWith(MockitoExtension.class)
+class IssueCommentEditTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long AUTHOR_EMPLOYEE_ID = 7L;
+    private static final Long COLLEAGUE_EMPLOYEE_ID = 99L;
+    private static final Long COMMENT_ID = 42L;
+
+    private static final String ORIGINAL = "Rebar spacing on the east face still needs cheking.";
+    private static final String CORRECTED = "Rebar spacing on the east face still needs checking.";
+
+    @Mock private IssueCommentRepository issueCommentRepository;
+    @Mock private IssueRepository issueRepository;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private IssueCommentMapper issueCommentMapper;
+
+    private IssueCommentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new IssueCommentService(
+                issueCommentRepository, issueRepository, currentEmployeeService, issueCommentMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private void callerIsEmployee(Long employeeId) {
+        Employee caller = new Employee();
+        caller.setId(employeeId);
+        when(currentEmployeeService.requireCurrentEmployee(any())).thenReturn(caller);
+    }
+
+    private IssueComment existingComment() {
+        IssueComment comment = new IssueComment();
+        comment.setId(COMMENT_ID);
+        comment.setAuthorId(AUTHOR_EMPLOYEE_ID);
+        comment.setComment(ORIGINAL);
+        return comment;
+    }
+
+    @Test
+    void theAuthorMayCorrectTheirOwnComment() {
+        callerIsEmployee(AUTHOR_EMPLOYEE_ID);
+        when(issueCommentRepository.findByIdAndOrganization_Id(COMMENT_ID, ORG_ID))
+                .thenReturn(Optional.of(existingComment()));
+        when(issueCommentRepository.save(any(IssueComment.class))).thenAnswer(call -> call.getArgument(0));
+        lenient().when(issueCommentMapper.toDto(any(IssueComment.class))).thenReturn(new IssueCommentDto());
+
+        service.updateIssueComment(COMMENT_ID, CORRECTED);
+
+        ArgumentCaptor<IssueComment> saved = ArgumentCaptor.forClass(IssueComment.class);
+        verify(issueCommentRepository).save(saved.capture());
+        assertThat(saved.getValue().getComment()).isEqualTo(CORRECTED);
+    }
+
+    /**
+     * The marker is the reason this is not a plain setter. A comment that changes silently is a
+     * worse record than one that cannot change, because a reader of the QA trail has no way to
+     * tell it apart from what was originally written.
+     */
+    @Test
+    void anEditIsMarkedAndTimestamped() {
+        callerIsEmployee(AUTHOR_EMPLOYEE_ID);
+        when(issueCommentRepository.findByIdAndOrganization_Id(COMMENT_ID, ORG_ID))
+                .thenReturn(Optional.of(existingComment()));
+        when(issueCommentRepository.save(any(IssueComment.class))).thenAnswer(call -> call.getArgument(0));
+        lenient().when(issueCommentMapper.toDto(any(IssueComment.class))).thenReturn(new IssueCommentDto());
+
+        service.updateIssueComment(COMMENT_ID, CORRECTED);
+
+        ArgumentCaptor<IssueComment> saved = ArgumentCaptor.forClass(IssueComment.class);
+        verify(issueCommentRepository).save(saved.capture());
+        assertThat(saved.getValue().isEdited()).isTrue();
+        assertThat(saved.getValue().getEditedAt()).isNotNull();
+    }
+
+    /** A comment nobody has touched must not claim to have been edited. */
+    @Test
+    void aFreshCommentIsNotMarkedEdited() {
+        IssueComment fresh = new IssueComment();
+
+        assertThat(fresh.isEdited()).isFalse();
+        assertThat(fresh.getEditedAt()).isNull();
+    }
+
+    /**
+     * A colleague, including one who may delete the comment. Deleting is a visible act that leaves
+     * the thread obviously shorter; rewriting the words under somebody else's name is not visible
+     * at all.
+     */
+    @Test
+    void aColleagueMayNotEditSomebodyElsesComment() {
+        callerIsEmployee(COLLEAGUE_EMPLOYEE_ID);
+        when(issueCommentRepository.findByIdAndOrganization_Id(COMMENT_ID, ORG_ID))
+                .thenReturn(Optional.of(existingComment()));
+
+        assertThatThrownBy(() -> service.updateIssueComment(COMMENT_ID, CORRECTED))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(issueCommentRepository, never()).save(any());
+    }
+
+    /**
+     * The refusal has to land before the write. A refusal after the save would leave the corrected
+     * text behind and only report that it should not have been allowed.
+     */
+    @Test
+    void aRefusedEditLeavesTheOriginalTextAlone() {
+        callerIsEmployee(COLLEAGUE_EMPLOYEE_ID);
+        IssueComment existing = existingComment();
+        when(issueCommentRepository.findByIdAndOrganization_Id(COMMENT_ID, ORG_ID))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.updateIssueComment(COMMENT_ID, CORRECTED))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(existing.getComment()).isEqualTo(ORIGINAL);
+        assertThat(existing.isEdited()).isFalse();
+    }
+
+    /**
+     * The finder is tenant-scoped, so a comment belonging to another organization is absent rather
+     * than forbidden. That is deliberate: a 403 here would confirm the comment exists.
+     */
+    @Test
+    void aCommentInAnotherOrganizationIsNotFoundRatherThanForbidden() {
+        callerIsEmployee(AUTHOR_EMPLOYEE_ID);
+        when(issueCommentRepository.findByIdAndOrganization_Id(COMMENT_ID, ORG_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateIssueComment(COMMENT_ID, CORRECTED))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(issueCommentRepository, never()).save(any());
+    }
+
+    /**
+     * The author is resolved through {@code requireCurrentEmployee}, so a caller with no employee
+     * record in this organization is refused rather than compared against a null id.
+     */
+    @Test
+    void aCallerWithNoEmployeeRecordIsRefused() {
+        when(currentEmployeeService.requireCurrentEmployee(any()))
+                .thenThrow(new AccessDeniedException("no employee record"));
+
+        assertThatThrownBy(() -> service.updateIssueComment(COMMENT_ID, CORRECTED))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(issueCommentRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
A comment can be posted and deleted and that is all, so a typo is fixed today by deleting and reposting, which loses the comment's place in the thread and its timestamp. `PATCH /api/v1/issues/comments/web/{id}` changes the text instead.

Closes #676.

## The three things the issue said had to be settled first

**Who may edit: the author, and nobody else.** Not a system admin, not a project manager. Those two may already delete a comment, which is a visible act that leaves the thread obviously shorter. Rewriting the words inside somebody else's name is not visible at all, and a reader has no way to tell it from what the author wrote. That is a worse artifact than the gap being closed.

**Whether an edit shows: yes.** `is_edited` and `edited_at`, the pair `ChatMessage` has carried since the chat module was built. Issues are the QA trail, and a comment that changes silently is a worse record than one that cannot change. Neither column is written by `@UpdateTimestamp` or a JPA auditing listener, because those fire on the save that creates the row and every comment would be born marked edited; the service sets them, on the edit only. The flag is `NOT NULL` defaulting to false, which is accurate for every comment already stored since there was no route to edit them with. The timestamp is nullable with no default, because there is no moment to record for those rows and choosing one would assert something nobody observed. That is the argument `073-01` made for `project.updated_at`.

**Whether there is a window: no.** How long a mistake stays fixable is a separate rule and nobody has asked for one. The marker is what keeps the record honest, not a deadline. Adding a window later changes no stored state.

## Delete: not included, deliberately

A soft delete raises what the thread reads like afterwards, whether a removed comment leaves a tombstone, and what replies to it then refer to. That is a larger design question than an edit, and the existing admin delete already covers removing a comment outright. Worth its own issue if the thread wants tombstones.

## Where the authorship check lives, and why it is not in the guard

In `IssueCommentService.updateIssueComment`, not in a `@PreAuthorize` expression. A guard taking the comment id would have to load the row to find its author, and the service then loads it again to write to it: two lookups that can drift apart, which is the shape a run of defects in this repo has come from. Here the row the author is read from is the row the text is written to, so they cannot disagree. `ChatService.editMessage` settles the same question the same way, and its endpoint carries `@orgSecurity.isMemberOfCurrentTenant()` exactly as this one does.

A comment in another organization is not found rather than refused. The finder is tenant-scoped, so a foreign id yields the 404 a nonexistent id yields, and the difference between 403 and 404 cannot be used to learn that a comment exists somewhere the caller cannot see.

## The twin

Web only. Every guard on `IssueCommentController` names an `issue-comment:*` authority, and those are bare `resource:scope` strings the realm has no authorization scopes to issue, so an edit added there would arrive refusing every caller. That controller's three existing guards are dead for the same reason and are the phantom-guard family; repairing them belongs with that family rather than inside this feature.

## On the red

This one lands as a single commit rather than tests-then-fix. The endpoint, the service method and the columns are all new, so a tests-first commit would fail to compile rather than fail an assertion, and a compile error measures nothing about behaviour. The tests are service-level against the real `IssueCommentService`, not a web slice with a mocked `@orgSecurity`, so they exercise the decision itself.

https://claude.ai/code/session_018LUw1wk1SqVZN55TQDKRHn