### PR TITLE
Make the org role reconcile report rather than repair

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -248,7 +248,7 @@ public class KeycloakInitializer {
         // Ensure admin-only MFA (conditional TOTP) is codified even if realm exists
         ensureAdminMfa();
         // Repair any org role held without membership of the organization that role names
-        ensureOrgRoleHoldersAreMembers();
+        reportOrgRoleHoldersWithoutMembership();
         // Ensure service account roles are assigned even if realm exists
         assignServiceAccountRoles();
         // Ensure authorization setup (JS policy, resource, permission) exists
@@ -892,7 +892,7 @@ public class KeycloakInitializer {
     /** Page size for a group's member listing, matching the subgroup walk above. */
     private static final int GROUP_MEMBER_PAGE = 1000;
 
-    private void ensureOrgRoleHoldersAreMembers() {
+    private void reportOrgRoleHoldersWithoutMembership() {
         try {
             List<GroupRepresentation> orgGroups = admin.realm(REALM_ID).groups().groups().stream()
                     .filter(group -> group.getName() != null && group.getName().startsWith("org-"))
@@ -904,7 +904,7 @@ public class KeycloakInitializer {
 
             int repaired = 0;
             for (GroupRepresentation orgGroup : orgGroups) {
-                repaired += ensureRoleHoldersAreMembersOf(orgGroup);
+                repaired += reportRoleHoldersWithoutMembershipIn(orgGroup);
             }
             if (repaired == 0) {
                 log.info("Every org role holder is a member of the organization their role names");
@@ -917,7 +917,7 @@ public class KeycloakInitializer {
     }
 
     /** @return how many users were added to this organization's parent group. */
-    private int ensureRoleHoldersAreMembersOf(GroupRepresentation orgGroup) {
+    private int reportRoleHoldersWithoutMembershipIn(GroupRepresentation orgGroup) {
         List<GroupRepresentation> roleSubgroups =
                 admin.realm(REALM_ID).groups().group(orgGroup.getId()).getSubGroups(0, 1000, false);
         if (roleSubgroups == null || roleSubgroups.isEmpty()) {
@@ -981,7 +981,7 @@ public class KeycloakInitializer {
         assignServiceAccountRoles();
         ensureAuthorizationSetup();
         ensureAdminMfa();
-        ensureOrgRoleHoldersAreMembers();
+        reportOrgRoleHoldersWithoutMembership();
         ensureCompositeJobRoles();
         ensureDevClient();
     }

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -247,7 +247,7 @@ public class KeycloakInitializer {
         syncRealmSecuritySettings();
         // Ensure admin-only MFA (conditional TOTP) is codified even if realm exists
         ensureAdminMfa();
-        // Repair any org role held without membership of the organization that role names
+        // Report any org role held without membership of the organization that role names
         reportOrgRoleHoldersWithoutMembership();
         // Ensure service account roles are assigned even if realm exists
         assignServiceAccountRoles();
@@ -866,57 +866,86 @@ public class KeycloakInitializer {
         }
     }
 
+    /** Page size for a group's member listing, matching the subgroup walk above. */
+    private static final int GROUP_MEMBER_PAGE = 1000;
+
     /**
-     * Adds the parent organization membership to anyone who holds a role subgroup beneath an
-     * {@code org-*} group without it, on every startup.
+     * Reports, and deliberately does not repair, anyone holding a role subgroup beneath an
+     * {@code org-*} group without membership of that group.
      *
      * <p>Keycloak stores membership of {@code /org-5} and of {@code /org-5/system-admin} as two
      * independent rows, so the two can come apart. {@code JwtAuthConverter} then mints
      * {@code ORG_5_ROLE_system-admin} with no {@code ORG_MEMBER_5} beside it, and
-     * {@code TenantFilter} resolves a tenant from the membership authority alone: the holder is
-     * refused on every endpoint, including the ones their role names. The application no longer
-     * produces that state, since {@code KeycloakGroupService} grants membership with the role and
-     * clears the role subgroups with the membership. This is the other half, for a realm that
-     * already holds it, which the QA seed can carry in because it replays a captured export
-     * verbatim.
+     * {@code TenantFilter} resolves a tenant from the membership authority alone, so the holder is
+     * refused everywhere, including on the endpoints their role names. The application no longer
+     * produces the split, since {@code KeycloakGroupService} grants membership with a role and
+     * clears the role subgroups with the membership. This is about a realm that already holds it,
+     * which the QA seed can carry in because it replays a captured export verbatim.
      *
-     * <p>Deliberately one-directional and minimal: it adds the membership the role already
-     * implies and never grants, removes or alters a role, a credential or an account. Membership
-     * is the weaker of the two, so adding it can only widen a caller's access to an organization
-     * they were already recorded as an administrator of. Where a role turns out to be the thing
-     * that should not be there, the fix is to remove the role, which is a decision for whoever
-     * owns the organization rather than for a startup reconcile.
+     * <h4>Why it reports instead of repairing</h4>
+     *
+     * <p>Two different situations produce byte-identical Keycloak state, and they need opposite
+     * repairs:
+     *
+     * <ul>
+     *   <li>a role holder who was never given membership, who needs the <b>membership added</b>;
+     *   <li>an <b>offboarded employee whose role was never cleared</b>, who needs the <b>role
+     *       removed</b>. Before the fix in {@code KeycloakGroupService},
+     *       {@code EmployeeService.deleteAnEmployee} left the parent group and stopped, so this is
+     *       what every historical offboarding produced.
+     * </ul>
+     *
+     * <p>The second is the larger population, because the first is not reachable through the
+     * application at all: {@code assignOrgRole} resolves the employee against the tenant before
+     * granting, and {@code joinOrganization} writes the employee row and the group membership in
+     * one transaction. An earlier version of this method added the membership, which would have
+     * handed every offboarded administrator their organization back on the next startup.
+     *
+     * <p>Nothing on the Keycloak side separates the two: offboarding hard-deletes the employee row,
+     * leaves the Keycloak account enabled, and records nothing. The application database does
+     * separate them, and it is still not safe to read here: the QA seed imports the realm before it
+     * restores the database ({@code roles/seed/tasks/main.yml} runs {@code keycloak.yml} then
+     * {@code db.yml}), so a backend starting between the two halves sees a fully seeded realm and an
+     * empty database, and would read every seeded role holder as offboarded.
+     *
+     * <p>So this refuses to choose. Each case is logged at WARN with both readings and both
+     * repairs, and a human resolves it. Silence here means the realm is clean, not that a decision
+     * was made quietly.
      *
      * <p>Guarded like the rest of the reconcile: a failure logs and never aborts startup.
      */
-    /** Page size for a group's member listing, matching the subgroup walk above. */
-    private static final int GROUP_MEMBER_PAGE = 1000;
-
     private void reportOrgRoleHoldersWithoutMembership() {
         try {
             List<GroupRepresentation> orgGroups = admin.realm(REALM_ID).groups().groups().stream()
                     .filter(group -> group.getName() != null && group.getName().startsWith("org-"))
                     .toList();
             if (orgGroups.isEmpty()) {
-                log.info("No 'org-*' groups found yet; no role memberships to reconcile");
+                log.info("No 'org-*' groups found yet; no org role memberships to check");
                 return;
             }
 
-            int repaired = 0;
+            int found = 0;
             for (GroupRepresentation orgGroup : orgGroups) {
-                repaired += reportRoleHoldersWithoutMembershipIn(orgGroup);
+                found += reportRoleHoldersWithoutMembershipIn(orgGroup);
             }
-            if (repaired == 0) {
+            if (found == 0) {
                 log.info("Every org role holder is a member of the organization their role names");
             } else {
-                log.warn("Added the missing organization membership for {} org role holder(s)", repaired);
+                log.warn("{} org role holder(s) are not members of the organization their role names. "
+                                + "Nothing was changed: the two situations that produce this need opposite "
+                                + "repairs and cannot be told apart from here. Resolve each of the cases "
+                                + "logged above by hand.", found);
             }
         } catch (Exception e) {
-            log.error("Failed to reconcile org role holders against organization membership: {}", e.getMessage());
+            log.error("Failed to check org role holders against organization membership: {}", e.getMessage());
         }
     }
 
-    /** @return how many users were added to this organization's parent group. */
+    /**
+     * Logs every role holder in this organization who is not a member of it, and changes nothing.
+     *
+     * @return how many were found
+     */
     private int reportRoleHoldersWithoutMembershipIn(GroupRepresentation orgGroup) {
         List<GroupRepresentation> roleSubgroups =
                 admin.realm(REALM_ID).groups().group(orgGroup.getId()).getSubGroups(0, 1000, false);
@@ -924,25 +953,30 @@ public class KeycloakInitializer {
             return 0;
         }
 
-        // Every member, not the first page of them. A truncated parent listing would make the
-        // reconcile treat existing members as repairs: harmless in effect, since joinGroup is
-        // idempotent, but it would report work that was not needed and hide work that was.
-        Set<String> members = new HashSet<>(allMembersOf(orgGroup.getId()));
+        // Every member, not the first page of them. A truncated parent listing would report
+        // existing members as splits, which is the one way a report-only check can still do harm:
+        // by sending someone to remove a role that was never stale.
+        Set<String> members = allMembersOf(orgGroup.getId());
 
-        int repaired = 0;
+        // Counted per user, reported per role. Someone holding two stale roles is one person to
+        // decide about, and both roles have to be named or half of the removal gets missed.
+        Set<String> holders = new HashSet<>();
         for (GroupRepresentation roleSubgroup : roleSubgroups) {
-            List<UserRepresentation> roleHolders = allMemberRepresentationsOf(roleSubgroup.getId());
-            for (UserRepresentation roleHolder : roleHolders) {
-                if (roleHolder.getId() == null || !members.add(roleHolder.getId())) {
+            for (UserRepresentation roleHolder : allMemberRepresentationsOf(roleSubgroup.getId())) {
+                if (roleHolder.getId() == null || members.contains(roleHolder.getId())) {
                     continue;
                 }
-                admin.realm(REALM_ID).users().get(roleHolder.getId()).joinGroup(orgGroup.getId());
-                repaired++;
-                log.warn("User '{}' held '{}' without membership of '{}'; membership added",
-                        roleHolder.getUsername(), roleSubgroup.getPath(), orgGroup.getPath());
+                holders.add(roleHolder.getId());
+                log.warn("User '{}' (id {}) holds '{}' but is not a member of '{}'. Nothing was "
+                                + "changed. Either they were never given membership, in which case add "
+                                + "them to '{}', or they were offboarded and the role outlived them, in "
+                                + "which case remove them from '{}'. Their employee record decides "
+                                + "which, and it cannot be read safely from here.",
+                        roleHolder.getUsername(), roleHolder.getId(), roleSubgroup.getPath(),
+                        orgGroup.getPath(), orgGroup.getPath(), roleSubgroup.getPath());
             }
         }
-        return repaired;
+        return holders.size();
     }
 
     /** Every member of a group, paged, since a group listing returns one page at a time. */

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/OrgRoleMembershipReconcileIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/OrgRoleMembershipReconcileIT.java
@@ -1,0 +1,190 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.CreatedResponseUtil;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves that the startup reconcile <b>changes nothing</b> when it finds an org role held without
+ * membership of that organization, against a real Keycloak.
+ *
+ * <p>This is the correction of a mistake that was merged and caught before it deployed. The first
+ * version of the reconcile added the missing membership, on the reasoning that membership is the
+ * weaker of the two authorities so granting it could only widen access to an organization the user
+ * was already recorded as an administrator of. That reasoning had the population backwards.
+ *
+ * <p>The split state is not mainly produced by provisioning. It is produced by <b>offboarding</b>:
+ * before the fix in {@code KeycloakGroupService}, {@code EmployeeService.deleteAnEmployee} left the
+ * parent group and stopped, and Keycloak keeps the two memberships as independent rows, so a
+ * removed employee kept {@code ORG_5_ROLE_system-admin} and lost only {@code ORG_MEMBER_5}. The
+ * provisioning case is not reachable through the application at all, because {@code assignOrgRole}
+ * resolves the employee against the tenant first and {@code joinOrganization} writes the employee
+ * row and the group membership in one transaction. So a reconcile that adds membership would have
+ * handed every offboarded administrator their organization back, silently, on the next startup.
+ *
+ * <p>The two situations are byte-identical in Keycloak, and nothing in the realm separates them:
+ * offboarding hard-deletes the employee row, leaves the account enabled, and records nothing. The
+ * application database does separate them and still cannot be read here, because the QA seed
+ * imports the realm before it restores the database, so a backend starting between the halves
+ * would read every seeded role holder as offboarded.
+ *
+ * <p>Since a reconcile cannot choose correctly, it does not choose. These tests pin that: both
+ * directions of change are asserted absent, so neither a re-added membership nor an automatic role
+ * removal can be reintroduced without a failure here.
+ */
+class OrgRoleMembershipReconcileIT {
+
+    private static final String TEST_REALM = "echno-reconcile-it-realm";
+    private static final String ORG_GROUP = "org-5";
+    private static final String ROLE_SUBGROUP = "system-admin";
+    private static final String ORG_GROUP_PATH = "/" + ORG_GROUP;
+    private static final String ROLE_SUBGROUP_PATH = ORG_GROUP_PATH + "/" + ROLE_SUBGROUP;
+
+    private static final KeycloakContainer KEYCLOAK =
+            new KeycloakContainer("quay.io/keycloak/keycloak:26.0.7");
+
+    private static Keycloak master;
+    private static KeycloakInitializer initializer;
+
+    /** In the role subgroup only, which is what an offboarding used to leave behind. */
+    private static String splitUserId;
+    /** In both groups, the ordinary state, present so the check is shown not to disturb it. */
+    private static String properUserId;
+
+    @BeforeAll
+    static void setUp() {
+        KEYCLOAK.start();
+
+        master = KeycloakBuilder.builder()
+                .serverUrl(KEYCLOAK.getAuthServerUrl())
+                .realm("master")
+                .clientId("admin-cli")
+                .username(KEYCLOAK.getAdminUsername())
+                .password(KEYCLOAK.getAdminPassword())
+                .grantType(OAuth2Constants.PASSWORD)
+                .build();
+
+        RealmRepresentation realm = new RealmRepresentation();
+        realm.setRealm(TEST_REALM);
+        realm.setEnabled(true);
+        master.realms().create(realm);
+
+        String orgGroupId = createGroup();
+        String roleSubgroupId = createRoleSubgroup(orgGroupId);
+
+        splitUserId = createUser("offboarded-admin");
+        master.realm(TEST_REALM).users().get(splitUserId).joinGroup(roleSubgroupId);
+
+        properUserId = createUser("current-admin");
+        master.realm(TEST_REALM).users().get(properUserId).joinGroup(orgGroupId);
+        master.realm(TEST_REALM).users().get(properUserId).joinGroup(roleSubgroupId);
+
+        initializer = newInitializer();
+        runTheReconcile();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (master != null) {
+            master.close();
+        }
+        KEYCLOAK.stop();
+    }
+
+    @Test
+    void theReconcileDoesNotAddTheMissingMembership() {
+        // The whole point. Adding it here would restore an offboarded administrator's access to
+        // the organization they were removed from.
+        assertThat(groupPathsOf(splitUserId)).doesNotContain(ORG_GROUP_PATH);
+    }
+
+    @Test
+    void theReconcileDoesNotRemoveTheRoleEither() {
+        // The opposite repair is equally unsafe to automate: on the reading where the user was
+        // never given membership, removing the role takes away access they should have.
+        assertThat(groupPathsOf(splitUserId)).contains(ROLE_SUBGROUP_PATH);
+    }
+
+    @Test
+    void theSplitUserIsLeftInExactlyTheStateTheyWereFoundIn() {
+        assertThat(groupPathsOf(splitUserId)).containsExactly(ROLE_SUBGROUP_PATH);
+    }
+
+    @Test
+    void anOrdinaryRoleHolderIsNotDisturbed() {
+        assertThat(groupPathsOf(properUserId))
+                .containsExactlyInAnyOrder(ORG_GROUP_PATH, ROLE_SUBGROUP_PATH);
+    }
+
+    /** Invokes the private reconcile directly, so the test covers it and not the whole startup. */
+    private static void runTheReconcile() {
+        ReflectionTestUtils.invokeMethod(initializer, "reportOrgRoleHoldersWithoutMembership");
+    }
+
+    private static List<String> groupPathsOf(String userId) {
+        return master.realm(TEST_REALM).users().get(userId).groups().stream()
+                .map(GroupRepresentation::getPath)
+                .toList();
+    }
+
+    private static KeycloakInitializer newInitializer() {
+        KeycloakInitializerConfigurationProperties props = new KeycloakInitializerConfigurationProperties();
+        props.setMasterRealm("master");
+        props.setApplicationRealm(TEST_REALM);
+        props.setClientId("admin-cli");
+        props.setUsername(KEYCLOAK.getAdminUsername());
+        props.setPassword(KEYCLOAK.getAdminPassword());
+        props.setUrl(KEYCLOAK.getAuthServerUrl());
+
+        KeycloakInitializer built = new KeycloakInitializer(
+                master, props, new ObjectMapper(),
+                Mockito.mock(KeycloakConfig.class), Mockito.mock(DevFixtureProvisioner.class));
+
+        // REALM_ID is static and normally set from ApplicationReadyEvent; the reconcile reads it
+        // and the admin client, so both are set directly here.
+        ReflectionTestUtils.setField(KeycloakInitializer.class, "REALM_ID", TEST_REALM);
+        ReflectionTestUtils.setField(built, "admin", master);
+        return built;
+    }
+
+    private static String createGroup() {
+        GroupRepresentation group = new GroupRepresentation();
+        group.setName(ORG_GROUP);
+        try (Response response = master.realm(TEST_REALM).groups().add(group)) {
+            return CreatedResponseUtil.getCreatedId(response);
+        }
+    }
+
+    private static String createRoleSubgroup(String orgGroupId) {
+        GroupRepresentation subgroup = new GroupRepresentation();
+        subgroup.setName(ROLE_SUBGROUP);
+        try (Response response = master.realm(TEST_REALM).groups().group(orgGroupId).subGroup(subgroup)) {
+            return CreatedResponseUtil.getCreatedId(response);
+        }
+    }
+
+    private static String createUser(String username) {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(username);
+        user.setEnabled(true);
+        try (Response response = master.realm(TEST_REALM).users().create(user)) {
+            return CreatedResponseUtil.getCreatedId(response);
+        }
+    }
+}


### PR DESCRIPTION
Measuring the red first. The fix follows in the next commit.

Refs #717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup reconciliation no longer automatically adds organization role holders to missing organization memberships.
  * Existing mismatched role memberships are preserved while being reported for review.
* **Tests**
  * Added integration coverage confirming that reconciliation leaves split membership states unchanged and does not affect valid role holders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->