### PR TITLE
Scope what a person may change about their own employee record

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5404,7 +5404,7 @@
         "type": "object"
       },
       "EmployeeUpdateFieldsDto": {
-        "description": "Fields a partial employee update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
+        "description": "Fields a partial employee update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored. Not every field is open to every caller: an employee editing their own record may change employeeName, phoneNumber, emailAddress and dateOfBirth, while employeeId, status, designation, department, joiningDate, salary, shiftTimingId and managerId are set by a system admin or an HR admin. Naming one of those without either role is refused with a 403 and no part of the update is applied.",
         "properties": {
           "dateOfBirth": {
             "description": "Date of birth.",
@@ -36129,7 +36129,7 @@
         ]
       },
       "patch": {
-        "description": "Applies the given field updates to the employee with the given id. Callable by the employee themselves or by a system or HR admin.",
+        "description": "Applies the given field updates to the employee with the given id. Callable by the employee themselves or by a system or HR admin. An employee editing their own record may change employeeName, phoneNumber, emailAddress and dateOfBirth; the remaining fields are set by a system admin or an HR admin, and naming one of them without those roles is refused.",
         "operationId": "partialUpdateAnEmployee_1",
         "parameters": [
           {
@@ -36191,7 +36191,7 @@
                 }
               }
             },
-            "description": "Caller is neither the employee nor a system or HR admin"
+            "description": "Caller is neither the employee nor a system or HR admin, or is the employee and named a field only those roles may set"
           },
           "404": {
             "content": {
@@ -36474,7 +36474,7 @@
         ]
       },
       "patch": {
-        "description": "Applies the supplied map of fields to the employee with the given id, changing only the fields present in the request. Callable by the employee themselves or by a system admin or HR admin.",
+        "description": "Applies the supplied map of fields to the employee with the given id, changing only the fields present in the request. Callable by the employee themselves or by a system admin or HR admin. An employee editing their own record may change employeeName, phoneNumber, emailAddress and dateOfBirth; the remaining fields are set by a system admin or an HR admin, and naming one of them without those roles is refused.",
         "operationId": "partialUpdateAnEmployee",
         "parameters": [
           {
@@ -36536,7 +36536,7 @@
                 }
               }
             },
-            "description": "Caller is neither the employee nor a system admin or HR admin"
+            "description": "Caller is neither the employee nor a system admin or HR admin, or is the employee and named a field only those roles may set"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
@@ -260,6 +260,13 @@ public class EmployeeController {
      * guard resolves and the same organization, so the guard and the write cannot land on
      * different rows.
      *
+     * <p><b>The guard decides the record, not the field.</b> A caller holding neither role reaches
+     * this endpoint only through the self clause, and the map they may send is narrowed to what is
+     * genuinely theirs by {@link EmployeePatchFieldScope}, which runs in the service and therefore
+     * covers this endpoint, its web twin and the batch alike. Naming a field outside that set is
+     * refused with a 403 rather than dropped. See #735 for why the answer is the field list and
+     * not the guard.
+     *
      * @param updates A map of fields to update.
      * @param id      The ID of the employee to update.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
@@ -270,12 +277,15 @@ public class EmployeeController {
             summary = "Partially update an employee",
             description = "Applies the supplied map of fields to the employee with the given id, "
                     + "changing only the fields present in the request. Callable by the employee "
-                    + "themselves or by a system admin or HR admin."
+                    + "themselves or by a system admin or HR admin. An employee editing their own "
+                    + "record may change employeeName, phoneNumber, emailAddress and dateOfBirth; "
+                    + "the remaining fields are set by a system admin or an HR admin, and naming "
+                    + "one of them without those roles is refused."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the supplied fields is not valid"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system admin or HR admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system admin or HR admin, or is the employee and named a field only those roles may set"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<ApiResponse> partialUpdateAnEmployee(

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -184,6 +184,13 @@ public class EmployeeControllerWeb {
     /**
      * Partially updates an existing employee.
      *
+     * <p><b>The guard decides the record, not the field.</b> A caller holding neither role reaches
+     * this endpoint only through the self clause, and the map they may send is narrowed to what is
+     * genuinely theirs by {@link EmployeePatchFieldScope}, which runs in the service and therefore
+     * covers this endpoint, its mobile twin and the batch alike. Naming a field outside that set is
+     * refused with a 403 rather than dropped. See #735 for why the answer is the field list and
+     * not the guard.
+     *
      * @param updates A map of fields to update.
      * @param id      The ID of the employee to update.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
@@ -193,12 +200,15 @@ public class EmployeeControllerWeb {
     @Operation(
             summary = "Partially update an employee",
             description = "Applies the given field updates to the employee with the given id. Callable "
-                    + "by the employee themselves or by a system or HR admin."
+                    + "by the employee themselves or by a system or HR admin. An employee editing "
+                    + "their own record may change employeeName, phoneNumber, emailAddress and "
+                    + "dateOfBirth; the remaining fields are set by a system admin or an HR admin, "
+                    + "and naming one of them without those roles is refused."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the updated fields failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system or HR admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system or HR admin, or is the employee and named a field only those roles may set"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<ApiResponse> partialUpdateAnEmployee(

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeePatchFieldScope.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeePatchFieldScope.java
@@ -1,0 +1,155 @@
+package org.tornotron.echno_backend.employee;
+
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Which fields of an employee record a person may set on themselves, and which belong to personnel.
+ *
+ * <p>{@code PATCH /employee/{id}} and its {@code /web} twin are gated on
+ * {@code isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin')}. The self clause is right for what
+ * it was added for: maintaining your own phone number, email address, name and date of birth from
+ * the phone is ordinary, and taking it away to solve this would take away the whole of employee
+ * self-service. What the guard was never asked is <em>which field</em>, and the map the service
+ * accepts reaches pay, employment status, the organizational identifier and the reporting line.
+ * That is the split written down here. See #735.
+ *
+ * <h2>Why the line falls where it does</h2>
+ *
+ * <p>The eight administrative fields are things done <em>to</em> a person by the organization
+ * rather than <em>by</em> them, and four of them are read elsewhere as statements the person did
+ * not make:
+ *
+ * <ul>
+ *   <li><b>salary</b> is set by the two roles this endpoint already names for everybody else, and
+ *       {@code EmployeeDto} now shows it only to those two roles and to the person themselves. A
+ *       field somebody may not read of a colleague is not a field they may write of themselves.
+ *   <li><b>status</b> is the employment relationship. A closed record that can reopen itself is
+ *       not closed.
+ *   <li><b>employeeId</b> is the organization's identifier for the person, not the person's.
+ *   <li><b>managerId</b> is the reporting line, and two approval flows route through it.
+ *       {@code AttendanceGeofenceService.resolveApprover} sends an away-from-site attendance
+ *       exception to the employee's manager, and {@code LeaveApprovalService.resolveApprovalChain}
+ *       walks the same pointer to build the leave approvers. Both refuse an approver who is the
+ *       subject, and neither can refuse an approver the subject chose. The organization already
+ *       treats this field as personnel's: {@code assignManager} and {@code removeManager} are gated
+ *       on {@code system-admin} and {@code hr-admin} with no self clause, so leaving it writable
+ *       through the map was a way round those two endpoints rather than a decision about it.
+ *   <li><b>designation</b> and <b>department</b> are organizational facts rather than personal
+ *       ones. Both are set for the person at the point they join, off the invite code
+ *       ({@code InviteCodeGenerationDto} requires them and the joiner never supplies them), and
+ *       both are shown to colleagues as the organization's description of the person: designation
+ *       is what a leave approver is labelled with on {@code LeaveApprovalDto}. Neither decides an
+ *       authorization today, which is what was checked before deciding. Department is the closer
+ *       call, and it goes the same way for a second reason: it is already a partition key, the one
+ *       the department leave calendar and the employee search divide on, so a self-set department
+ *       is a person moving themselves between partitions somebody else drew.
+ *   <li><b>joiningDate</b> is not on the list #735 opens with, and belongs there. It is the start
+ *       date leave accrual counts from ({@code LeaveAccrualService.getStartMonth}) and that
+ *       {@code LeaveBalanceService} prorates the first year's balance against, so a person who can
+ *       backdate it grants themselves leave.
+ *   <li><b>shiftTimingId</b> likewise: {@code AttendanceService} prefers the employee's assigned
+ *       shift over the one on the request, and the shift is what late arrival and overtime are
+ *       measured against. Choosing your own shift is choosing when you are late.
+ * </ul>
+ *
+ * <p>What is left is genuinely the person's own: their name, phone number, email address and date
+ * of birth. Nothing in the application decides anything on those four.
+ *
+ * <h2>Why this cannot be forgotten</h2>
+ *
+ * <p>Two things hold it, and the second is the one that matters.
+ *
+ * <p>First, the check runs in {@code EmployeeService.partialUpdateAnEmployee(Map, Employee)}, the
+ * one private method every route into this map funnels through: both single-record twins and the
+ * batch endpoint. A new endpoint accepting the same map reaches the same method and is covered
+ * without its author knowing this class exists. It is deliberately not a second request DTO or a
+ * {@code @JsonView}, because both of those are chosen at the call site and a call site that forgets
+ * them fails open and silently. This one cannot be omitted at a call site because there is no call
+ * site to omit it at.
+ *
+ * <p>Second, {@code EmployeePatchFieldScopeContractTest} reads the {@code case} labels out of that
+ * method's own source, the same way {@code PartialUpdateSchemaContractTest} does, and fails when a
+ * key is accepted that appears in neither set below. A field added to the switch has to be
+ * classified before the build goes green, so the failure mode this replaces, a new field quietly
+ * joining the self-editable surface, is a red build rather than a discovery.
+ *
+ * <p>The decision is on the caller's <em>role</em> and not on whether the record is theirs. An
+ * {@code hr-admin} editing their own record still sets their own pay, because they hold the role
+ * that sets pay; and a caller with neither role can only have reached the record through the self
+ * clause, so refusing the administrative fields to anyone without the roles refuses exactly the
+ * self-caller. Keying it on the role rather than on the subject also means a future endpoint that
+ * admits a third role to this map does not silently hand that role the pay field.
+ */
+public final class EmployeePatchFieldScope {
+
+    /**
+     * The roles that may set the administrative fields. The same pair the PATCH names, the same
+     * pair {@code EmployeeDto} shows pay to.
+     */
+    public static final String[] PERSONNEL_ROLES = {"system-admin", "hr-admin"};
+
+    /** The fields a person may set on their own record. */
+    public static final Set<String> SELF_EDITABLE = Set.of(
+            "employeeName",
+            "phoneNumber",
+            "emailAddress",
+            "dateOfBirth");
+
+    /** The fields only {@link #PERSONNEL_ROLES} may set, on anybody's record including their own. */
+    public static final Set<String> PERSONNEL_ONLY = Set.of(
+            "employeeId",
+            "status",
+            "designation",
+            "department",
+            "joiningDate",
+            "salary",
+            "shiftTimingId",
+            "managerId");
+
+    private EmployeePatchFieldScope() {
+    }
+
+    /**
+     * Refuses an update that names a field the caller may not set.
+     *
+     * <p>Refuses rather than dropping. A silently dropped field answers 200 and changes nothing,
+     * which is the shape that made an issue's type unchangeable for months and the reason
+     * {@code PartialUpdateKeys} exists; a caller told their salary change succeeded, and an
+     * administrator reading the record later, would both be reading a lie. The message names every
+     * refused field rather than the first, so a client is not walked through them one request at a
+     * time.
+     *
+     * <p>The whole update is refused, including the fields the caller was entitled to change.
+     * Applying the permitted half of a payload the caller was not entitled to send would turn a
+     * refusal into a partial success and leave the record in a state neither side asked for.
+     *
+     * @param keys The keys the update carries.
+     * @param callerHoldsPersonnelRole Whether the caller holds one of {@link #PERSONNEL_ROLES} in
+     *     the organization this request is scoped to.
+     * @throws AccessDeniedException if the caller holds neither role and the update names one of
+     *     {@link #PERSONNEL_ONLY}.
+     */
+    public static void refuseFieldsTheCallerMayNotSet(Collection<String> keys,
+                                                      boolean callerHoldsPersonnelRole) {
+        if (callerHoldsPersonnelRole) {
+            return;
+        }
+        List<String> refused = keys.stream()
+                .filter(PERSONNEL_ONLY::contains)
+                .sorted()
+                .toList();
+        if (refused.isEmpty()) {
+            return;
+        }
+        throw new AccessDeniedException(
+                "These fields are set by your organization rather than by you, so this update was "
+                        + "not applied: " + String.join(", ", refused)
+                        + ". Ask a system administrator or an HR administrator to change them. You "
+                        + "can still change " + String.join(", ", SELF_EDITABLE.stream().sorted().toList())
+                        + " on your own record.");
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeLookupDto;
@@ -57,6 +58,7 @@ public class EmployeeService {
     private final EmployeeMapper employeeMapper;
     private final EmployeeHierarchyService employeeHierarchyService;
     private final ShiftTimingRepository shiftTimingRepository;
+    private final OrganizationSecurityService orgSecurity;
 
     /**
      * Constructs an EmployeeService with the necessary repositories.
@@ -66,8 +68,11 @@ public class EmployeeService {
      * @param userRepository         The repository for user data access.
      * @param keycloakGroupService   The service for managing Keycloak groups.
      * @param employeeHierarchyService The service owning the reporting hierarchy.
+     * @param orgSecurity            Answers which org-scoped roles the caller holds, the same bean
+     *                               the guards on these endpoints ask. Used by the partial update
+     *                               to decide the field scope; see {@link EmployeePatchFieldScope}.
      */
-    public EmployeeService(EmployeeRepository employeeRepository, OrganizationRepository organizationRepository, UserRepository userRepository, KeycloakGroupService keycloakGroupService, EmployeeMapper employeeMapper, EmployeeHierarchyService employeeHierarchyService, ShiftTimingRepository shiftTimingRepository) {
+    public EmployeeService(EmployeeRepository employeeRepository, OrganizationRepository organizationRepository, UserRepository userRepository, KeycloakGroupService keycloakGroupService, EmployeeMapper employeeMapper, EmployeeHierarchyService employeeHierarchyService, ShiftTimingRepository shiftTimingRepository, OrganizationSecurityService orgSecurity) {
         this.employeeRepository = employeeRepository;
         this.organizationRepository = organizationRepository;
         this.userRepository = userRepository;
@@ -75,6 +80,7 @@ public class EmployeeService {
         this.employeeMapper = employeeMapper;
         this.employeeHierarchyService = employeeHierarchyService;
         this.shiftTimingRepository = shiftTimingRepository;
+        this.orgSecurity = orgSecurity;
     }
 
     /**
@@ -327,7 +333,19 @@ public class EmployeeService {
         employeeRepository.save(employee);
     }
 
+    /**
+     * Applies a partial update to an already-loaded employee.
+     *
+     * <p>Every route into this map ends here: both single-record twins and the batch endpoint. That
+     * is why the field scope is enforced at the top of this method rather than at a controller. See
+     * {@link EmployeePatchFieldScope} for the split and for why it is keyed on the caller's role
+     * rather than on whose record this is.
+     */
     private void partialUpdateAnEmployee(Map<String, Object> updates, Employee employee) {
+        EmployeePatchFieldScope.refuseFieldsTheCallerMayNotSet(
+                updates.keySet(),
+                orgSecurity.hasAnyOrgRoleForCurrentTenant(EmployeePatchFieldScope.PERSONNEL_ROLES));
+
         updates.forEach((key, value) -> {
             switch (key) {
                 case "employeeId":

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeUpdateFieldsDto.java
@@ -21,7 +21,11 @@ import java.time.LocalDateTime;
         + "Every field is optional and an absent field is left untouched. A field this schema "
         + "declares nullable is cleared by sending an explicit null; a field it does not declare "
         + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
-        + "ignored.")
+        + "ignored. Not every field is open to every caller: an employee editing their own record "
+        + "may change employeeName, phoneNumber, emailAddress and dateOfBirth, while employeeId, "
+        + "status, designation, department, joiningDate, salary, shiftTimingId and managerId are "
+        + "set by a system admin or an HR admin. Naming one of those without either role is "
+        + "refused with a 403 and no part of the update is applied.")
 @Data
 public class EmployeeUpdateFieldsDto {
 

--- a/src/test/java/org/tornotron/echno_backend/architecture/EmployeePatchFieldScopeContractTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/EmployeePatchFieldScopeContractTest.java
@@ -1,0 +1,158 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.architecture.PartialUpdateSurfaces.UpdateSurface;
+import org.tornotron.echno_backend.employee.EmployeePatchFieldScope;
+import org.tornotron.echno_backend.employee.dto.EmployeeUpdateFieldsDto;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Holds the employee partial update to a decision about every field it accepts.
+ *
+ * <p>{@code PATCH /employee/{id}} admits the subject of the record as well as {@code system-admin}
+ * and {@code hr-admin}, so every key it accepts is a key some employee can set on themselves
+ * unless something says otherwise. {@link EmployeePatchFieldScope} is that something, and this
+ * test is what stops it going stale.
+ *
+ * <p>The failure it exists for is not the one #735 reported. That one is fixed by the class. This
+ * one is the next field: somebody adds a {@code case} to the service switch, adds the matching
+ * property to {@link EmployeeUpdateFieldsDto} because
+ * {@link PartialUpdateSchemaContractTest} makes them, and never learns that a third decision was
+ * owed. An unclassified field would fall through to self-editable, which is the same silent
+ * widening the endpoint already shipped once. So the keys are read out of the service method's own
+ * source, the same way the schema contract reads them, and a key in neither set fails here.
+ *
+ * <p>The twin check is the other half. The mobile and web PATCHes are identical by design: #716
+ * gave the mobile one the web one's guard so the two agree, and #735 is on both because of it. A
+ * fix applied to one and not the other would leave the defect live on the twin, so the two guard
+ * expressions are compared as text.
+ */
+class EmployeePatchFieldScopeContractTest {
+
+    private static final Path SOURCE_ROOT = Path.of("src", "main", "java");
+
+    private static final Pattern CASE_LABEL = Pattern.compile("case\\s+\"([^\"]+)\"");
+
+    /**
+     * The {@code @PreAuthorize} on the PATCH of a controller: the annotation immediately preceding
+     * the {@code partialUpdateAnEmployee} handler.
+     */
+    private static final Pattern PATCH_GUARD = Pattern.compile(
+            "@PatchMapping\\(\"\\{id}\"\\)\\s*@PreAuthorize\\(\"([^\"]+)\"\\)");
+
+    @Test
+    @DisplayName("Every key the employee update accepts is either self-editable or personnel-only")
+    void everyAcceptedKeyIsClassified() throws IOException {
+        Set<String> accepted = acceptedKeys();
+        Set<String> classified = new LinkedHashSet<>(EmployeePatchFieldScope.SELF_EDITABLE);
+        classified.addAll(EmployeePatchFieldScope.PERSONNEL_ONLY);
+
+        assertThat(classified)
+                .as("EmployeePatchFieldScope decides who may set each field the employee PATCH "
+                        + "accepts, and the endpoint admits the subject of the record. A key the "
+                        + "service applies and this class does not name is a field every employee "
+                        + "can set on themselves, which is what #735 was. Put it in SELF_EDITABLE "
+                        + "if it is genuinely the person's own, and in PERSONNEL_ONLY otherwise.")
+                .containsExactlyInAnyOrderElementsOf(accepted);
+    }
+
+    @Test
+    @DisplayName("No field is in both sets")
+    void theTwoSetsAreDisjoint() {
+        assertThat(EmployeePatchFieldScope.SELF_EDITABLE)
+                .as("a field cannot be both the person's own and personnel's; PERSONNEL_ONLY is "
+                        + "what the check reads, so an overlap would read as a decision that was "
+                        + "never taken")
+                .doesNotContainAnyElementsOf(EmployeePatchFieldScope.PERSONNEL_ONLY);
+    }
+
+    @Test
+    @DisplayName("The four fields the self clause exists for stay self-editable")
+    void selfServiceIsNotEmptied() {
+        // Written down so that tightening this further is a deliberate act. The self clause was
+        // added so a person could maintain their own record from the phone; a scope that left
+        // nothing self-editable would answer #735 by removing the feature instead of scoping it.
+        assertThat(EmployeePatchFieldScope.SELF_EDITABLE)
+                .containsExactlyInAnyOrder("employeeName", "phoneNumber", "emailAddress", "dateOfBirth");
+    }
+
+    @Test
+    @DisplayName("The six fields #735 named are personnel-only")
+    void theReportedFieldsArePersonnelOnly() {
+        assertThat(EmployeePatchFieldScope.PERSONNEL_ONLY)
+                .contains("salary", "status", "employeeId", "managerId", "designation", "department");
+    }
+
+    @Test
+    @DisplayName("managerId is personnel-only, so an approver cannot be self-nominated")
+    void managerIdIsPersonnelOnly() {
+        // Two approval flows route on this pointer: AttendanceGeofenceService.resolveApprover
+        // sends an away-from-site attendance exception to the employee's manager, and
+        // LeaveApprovalService.resolveApprovalChain walks it for leave. Both refuse an approver
+        // who is the subject, and neither can refuse an approver the subject appointed. Its own
+        // endpoints, assignManager and removeManager, are already personnel-only.
+        assertThat(EmployeePatchFieldScope.PERSONNEL_ONLY).contains("managerId");
+    }
+
+    @Test
+    @DisplayName("The mobile and web PATCH guards are still the same expression")
+    void bothTwinsCarryTheSameGuard() throws IOException {
+        String mobile = patchGuard("org/tornotron/echno_backend/employee/EmployeeController.java");
+        String web = patchGuard("org/tornotron/echno_backend/employee/EmployeeControllerWeb.java");
+
+        assertThat(mobile)
+                .as("the two employee PATCHes are identical by design (#716). The field scope runs "
+                        + "below both, in the service, so it covers them whatever they say; but a "
+                        + "guard that drifts apart means one client is answering a different "
+                        + "question from the other.")
+                .isEqualTo(web);
+        assertThat(mobile)
+                .as("the self clause is what makes the field scope necessary, and taking it away "
+                        + "would remove self-service rather than scope it")
+                .contains("isSelfOrHasAnyOrgRole");
+    }
+
+    /** The keys the employee update switch names, read out of the method's own source. */
+    private static Set<String> acceptedKeys() throws IOException {
+        UpdateSurface surface = PartialUpdateSurfaces.surfaces().stream()
+                .filter(candidate -> candidate.schema().equals(EmployeeUpdateFieldsDto.class))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "the employee surface has gone from PartialUpdateSurfaces"));
+
+        Set<String> keys = new LinkedHashSet<>();
+        Matcher matcher = CASE_LABEL.matcher(PartialUpdateSurfaces.methodBody(surface));
+        while (matcher.find()) {
+            keys.add(matcher.group(1));
+        }
+        assertThat(keys)
+                .as("no case labels found in %s; the method signature this test looks for has "
+                        + "probably been reworded", surface.methodSignature())
+                .isNotEmpty();
+        return keys;
+    }
+
+    private static String patchGuard(String relativePath) throws IOException {
+        Path source = SOURCE_ROOT.resolve(relativePath);
+        assertThat(source).as("controller source, read relative to the project directory").exists();
+        String text = Files.readString(source);
+
+        Matcher matcher = PATCH_GUARD.matcher(text);
+        assertThat(matcher.find())
+                .as("no @PreAuthorize found on the PATCH {id} handler in %s; if the mapping or the "
+                        + "annotation order has changed, update the pattern this test looks for",
+                        source)
+                .isTrue();
+        return matcher.group(1);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateNullBehaviourTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateNullBehaviourTest.java
@@ -433,6 +433,7 @@ class PartialUpdateNullBehaviourTest {
         @Mock private EmployeeMapper employeeMapper;
         @Mock private EmployeeHierarchyService employeeHierarchyService;
         @Mock private ShiftTimingRepository shiftTimingRepository;
+        @Mock private OrganizationSecurityService orgSecurity;
 
         @InjectMocks private EmployeeService service;
 
@@ -443,6 +444,13 @@ class PartialUpdateNullBehaviourTest {
             employee.setManager(new Employee());
             TenantContext.setCurrentOrgId(ORG_ID);
             try {
+                // This sweep is about what a null does to each field, not about who may send it,
+                // so it runs as a caller who may send every field. The two role names are stubbed
+                // exactly rather than through a matcher, so this cannot quietly answer true for
+                // whatever roles the field scope comes to name. What the scope refuses is
+                // EmployeePatchSelfScopeIT's subject.
+                when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin"))
+                        .thenReturn(true);
                 when(employeeRepository.findByIdAndOrganizationId(any(), any()))
                         .thenReturn(Optional.of(employee));
                 when(employeeRepository.save(any(Employee.class))).thenAnswer(i -> i.getArgument(0));

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeLookupTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeLookupTest.java
@@ -38,7 +38,7 @@ class EmployeeLookupTest {
     private EmployeeRepository employeeRepository;
 
     private EmployeeService service() {
-        return new EmployeeService(employeeRepository, null, null, null, null, null, null);
+        return new EmployeeService(employeeRepository, null, null, null, null, null, null, null);
     }
 
     private Pageable capturePageable() {

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeePatchSelfScopeIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeePatchSelfScopeIT.java
@@ -1,0 +1,401 @@
+package org.tornotron.echno_backend.employee;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapperImpl;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapperImpl;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.enums.EmployeeStatus;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapperImpl;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * What a person may change about themselves through {@code PATCH /employee/{id}}, against a real
+ * CockroachDB.
+ *
+ * <p>The guard on that endpoint, {@code isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin')},
+ * answers whether the caller may touch the record. It was never asked which field, and the field
+ * list the service accepts reaches pay, employment status, the organizational identifier and the
+ * reporting line. So the self clause, added so that a person could maintain their own contact
+ * details from the phone, also let them raise their own salary and name their own manager. See
+ * #735.
+ *
+ * <p><b>Why this is an integration test and not a web slice.</b> A slice over the controller
+ * replaces {@code @orgSecurity} with a mock, so it fixes the expression the annotation evaluates
+ * and nothing about what the expression means; it also replaces the service, so the field scope
+ * never runs at all. Both halves of this question live below the annotation. Here the real
+ * {@link OrganizationSecurityService} reads real authorities off a real token, and the real service
+ * writes to a real database, so a passing assertion is a statement about the running application
+ * rather than about a stub. Nothing here is stubbed to return true for any role: the self-only
+ * caller simply holds no role authority, which is the same thing the deployed system would have
+ * to be true of them.
+ *
+ * <p>Every refusal is checked twice: that it was refused, and that the column still holds what it
+ * held. A refusal that happens after the write is not a refusal.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({EmployeeService.class, EmployeeHierarchyService.class, OrganizationSecurityService.class,
+        UserContextService.class, EmployeeMapperImpl.class, AttachmentMapperImpl.class,
+        ShiftTimingMapperImpl.class})
+class EmployeePatchSelfScopeIT extends AbstractIntegrationTest {
+
+    private static final double ORIGINAL_SALARY = 42_000.0;
+
+    @Autowired
+    private EmployeeService employeeService;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @MockitoBean
+    private KeycloakGroupService keycloakGroupService;
+
+    @MockitoBean
+    private FileStorageService fileStorageService;
+
+    private Long organizationId;
+    private Long subjectId;
+    private Long colleagueId;
+    private String subjectKeycloakId;
+    private String adminKeycloakId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        SecurityContextHolder.clearContext();
+
+        Organization organization = persistOrganization("Field Scope Org");
+        em.flush();
+        organizationId = organization.getId();
+
+        Employee subject = persistEmployee(organization, "Ravi Worker", "kc-ravi-worker");
+        Employee colleague = persistEmployee(organization, "Priya Colleague", "kc-priya-colleague");
+        persistEmployee(organization, "Sam Personnel", "kc-sam-personnel");
+        em.flush();
+
+        subjectId = subject.getId();
+        colleagueId = colleague.getId();
+        subjectKeycloakId = "kc-ravi-worker";
+        adminKeycloakId = "kc-sam-personnel";
+
+        TenantContext.setCurrentOrgId(organizationId);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+        TenantContext.clear();
+    }
+
+    @Test
+    @DisplayName("A person editing their own record cannot raise their own salary")
+    void selfCaller_isRefusedSalary() {
+        authenticateAsSelfOnly();
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("salary", 250_000.0), subjectId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("salary");
+
+        assertThat(reloadSubject().getSalary()).isEqualTo(ORIGINAL_SALARY);
+    }
+
+    @Test
+    @DisplayName("A person editing their own record cannot name their own manager")
+    void selfCaller_isRefusedManagerId() {
+        authenticateAsSelfOnly();
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("managerId", colleagueId), subjectId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("managerId");
+
+        assertThat(reloadSubject().getManager()).isNull();
+    }
+
+    @Test
+    @DisplayName("A person editing their own record cannot change their own employment status")
+    void selfCaller_isRefusedStatus() {
+        authenticateAsSelfOnly();
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("status", EmployeeStatus.inactive.name()), subjectId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("status");
+
+        assertThat(reloadSubject().getStatus()).isEqualTo(EmployeeStatus.active);
+    }
+
+    @Test
+    @DisplayName("A person editing their own record cannot rewrite their organizational identifier")
+    void selfCaller_isRefusedEmployeeId() {
+        authenticateAsSelfOnly();
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("employeeId", "ECH-9999"), subjectId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("employeeId");
+
+        assertThat(reloadSubject().getEmployeeId()).isEqualTo("ECH-0001");
+    }
+
+    @Test
+    @DisplayName("A person editing their own record cannot promote themselves or move department")
+    void selfCaller_isRefusedDesignationAndDepartment() {
+        authenticateAsSelfOnly();
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("designation", "Chief Engineer"), subjectId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("designation");
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("department", "Finance"), subjectId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("department");
+
+        Employee reloaded = reloadSubject();
+        assertThat(reloaded.getDesignation()).isEqualTo("Site Engineer");
+        assertThat(reloaded.getDepartment()).isEqualTo("Execution");
+    }
+
+    @Test
+    @DisplayName("A person editing their own record cannot backdate their own joining date")
+    void selfCaller_isRefusedJoiningDate() {
+        authenticateAsSelfOnly();
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("joiningDate", "2015-01-01T00:00:00"), subjectId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("joiningDate");
+
+        assertThat(reloadSubject().getJoiningDate())
+                .isEqualTo(LocalDateTime.of(2024, 6, 1, 0, 0));
+    }
+
+    @Test
+    @DisplayName("A refusal names every field the caller may not set, not only the first")
+    void selfCaller_isToldAboutEveryRefusedField() {
+        authenticateAsSelfOnly();
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("phoneNumber", "+91 90000 00000");
+        updates.put("salary", 250_000.0);
+        updates.put("managerId", colleagueId);
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(updates, subjectId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("managerId")
+                .hasMessageContaining("salary");
+
+        // The whole update is refused, so the field the caller was entitled to change does not
+        // land either. A partial application would let the refused fields be probed for one at a
+        // time while the permitted ones quietly took effect.
+        Employee reloaded = reloadSubject();
+        assertThat(reloaded.getPhoneNumber()).isEqualTo("0000000000");
+        assertThat(reloaded.getSalary()).isEqualTo(ORIGINAL_SALARY);
+    }
+
+    @Test
+    @DisplayName("Self-service still works: contact details, name and date of birth")
+    void selfCaller_stillMaintainsTheirOwnContactDetails() {
+        authenticateAsSelfOnly();
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("phoneNumber", "+91 90000 11111");
+        updates.put("emailAddress", "ravi.worker@echno.test");
+        updates.put("employeeName", "Ravi Worker Jr");
+        updates.put("dateOfBirth", "1991-02-03T00:00:00");
+
+        assertThatCode(() -> employeeService.partialUpdateAnEmployee(updates, subjectId))
+                .doesNotThrowAnyException();
+
+        Employee reloaded = reloadSubject();
+        assertThat(reloaded.getPhoneNumber()).isEqualTo("+91 90000 11111");
+        assertThat(reloaded.getEmailAddress()).isEqualTo("ravi.worker@echno.test");
+        assertThat(reloaded.getEmployeeName()).isEqualTo("Ravi Worker Jr");
+        assertThat(reloaded.getDateOfBirth()).isEqualTo(LocalDateTime.of(1991, 2, 3, 0, 0));
+    }
+
+    @Test
+    @DisplayName("hr-admin still sets pay and the reporting line")
+    void personnelRole_stillSetsTheAdministrativeFields() {
+        authenticateAsPersonnel("hr-admin");
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("salary", 55_000.0);
+        updates.put("managerId", colleagueId);
+        updates.put("designation", "Senior Site Engineer");
+
+        assertThatCode(() -> employeeService.partialUpdateAnEmployee(updates, subjectId))
+                .doesNotThrowAnyException();
+
+        Employee reloaded = reloadSubject();
+        assertThat(reloaded.getSalary()).isEqualTo(55_000.0);
+        assertThat(reloaded.getManager()).isNotNull();
+        assertThat(reloaded.getManager().getId()).isEqualTo(colleagueId);
+        assertThat(reloaded.getDesignation()).isEqualTo("Senior Site Engineer");
+    }
+
+    @Test
+    @DisplayName("system-admin still sets pay, so the split is on the role and not on the person")
+    void systemAdmin_stillSetsPay() {
+        authenticateAsPersonnel("system-admin");
+
+        assertThatCode(() -> employeeService.partialUpdateAnEmployee(
+                updates("salary", 61_000.0), subjectId))
+                .doesNotThrowAnyException();
+
+        assertThat(reloadSubject().getSalary()).isEqualTo(61_000.0);
+    }
+
+    @Test
+    @DisplayName("An hr-admin editing their own record is not refused their own pay")
+    void personnelRole_editingTheirOwnRecordIsNotRefused() {
+        authenticateAsPersonnel("hr-admin");
+
+        Long ownId = em.createQuery(
+                        "select e.id from Employee e where e.user.keycloakId = :kc", Long.class)
+                .setParameter("kc", adminKeycloakId)
+                .getSingleResult();
+
+        assertThatCode(() -> employeeService.partialUpdateAnEmployee(
+                updates("salary", 99_000.0), ownId))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("A role held in another organization does not unlock the fields here")
+    void roleInAnotherOrganization_doesNotUnlockTheFields() {
+        // The authority is org-scoped, so a role string minted for a different organization must
+        // not satisfy the check for this one. Written because the field scope reads the same
+        // authority format the guards do, and a check that dropped the organization id would pass
+        // every other test in this class.
+        authenticate(subjectKeycloakId,
+                List.of(new SimpleGrantedAuthority("ORG_" + (organizationId + 1) + "_ROLE_hr-admin")));
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("salary", 250_000.0), subjectId))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(reloadSubject().getSalary()).isEqualTo(ORIGINAL_SALARY);
+    }
+
+    @Test
+    @DisplayName("A neighbouring role that the PATCH never admitted does not unlock the fields")
+    void projectManagerRole_doesNotUnlockTheFields() {
+        // project-manager reads the directory and is not named on this PATCH. Isolating it proves
+        // the check tests the two roles it names rather than any role at all.
+        authenticateAsPersonnel("project-manager");
+
+        assertThatThrownBy(() -> employeeService.partialUpdateAnEmployee(
+                updates("salary", 250_000.0), subjectId))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(reloadSubject().getSalary()).isEqualTo(ORIGINAL_SALARY);
+    }
+
+    private Map<String, Object> updates(String key, Object value) {
+        Map<String, Object> updates = new HashMap<>();
+        updates.put(key, value);
+        return updates;
+    }
+
+    private Employee reloadSubject() {
+        em.flush();
+        em.clear();
+        return em.find(Employee.class, subjectId);
+    }
+
+    private void authenticateAsSelfOnly() {
+        // Membership and nothing else. This is the caller the self clause on the guard exists for.
+        authenticate(subjectKeycloakId,
+                List.of(new SimpleGrantedAuthority("ORG_MEMBER_" + organizationId)));
+    }
+
+    private void authenticateAsPersonnel(String role) {
+        authenticate(adminKeycloakId, List.of(
+                new SimpleGrantedAuthority("ORG_MEMBER_" + organizationId),
+                new SimpleGrantedAuthority("ORG_" + organizationId + "_ROLE_" + role)));
+    }
+
+    private void authenticate(String keycloakId, List<GrantedAuthority> authorities) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject(keycloakId)
+                .claim("sub", keycloakId)
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+        SecurityContextHolder.getContext()
+                .setAuthentication(new JwtAuthenticationToken(jwt, authorities, keycloakId));
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization organization = new Organization();
+        organization.setOrganizationName(name);
+        organization.setOrganizationAddress(name + " address");
+        organization.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        organization.setOrganizationPhone("0000000000");
+        em.persist(organization);
+        return organization;
+    }
+
+    private Employee persistEmployee(Organization organization, String name, String keycloakId) {
+        User user = new User();
+        user.setKeycloakId(keycloakId);
+        user.setName(name);
+        em.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(organization);
+        employee.setUser(user);
+        employee.setEmployeeName(name);
+        employee.setEmployeeId("ECH-0001");
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(name.toLowerCase().replace(" ", ".") + "@emp.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        employee.setJoiningDate(LocalDateTime.of(2024, 6, 1, 0, 0));
+        employee.setDesignation("Site Engineer");
+        employee.setDepartment("Execution");
+        employee.setSalary(ORIGINAL_SALARY);
+        employee.setStatus(EmployeeStatus.active);
+        employee.setOrgRoles(new HashSet<>());
+        em.persist(employee);
+        return employee;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeShiftUnificationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeShiftUnificationIT.java
@@ -41,7 +41,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({EmployeeService.class, EmployeeHierarchyService.class, EmployeeMapperImpl.class,
-        AttachmentMapperImpl.class, ShiftTimingMapperImpl.class})
+        AttachmentMapperImpl.class, ShiftTimingMapperImpl.class,
+        org.tornotron.echno_backend.common.service.OrganizationSecurityService.class,
+        org.tornotron.echno_backend.user.UserContextService.class})
 class EmployeeShiftUnificationIT extends AbstractIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
`PATCH /employee/{id}` and its `/web` twin are gated on
`isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin')`. The self clause is right for what it was
added for: maintaining your own contact details from the phone is ordinary, and it is what keeps
the endpoint level with the read beside it. What the guard was never asked is which field. The map
the service accepts reaches pay, employment status, the organizational identifier, the joining
date, the shift and the reporting line, so the self clause covers all of those too.

The answer is the field list rather than the guard. Removing the self clause would take away
self-service to solve a question about eight fields.

First commit is the tests, so the red is measured rather than assumed.

Refs #735