### PR TITLE
Tell the storekeeper when a material crosses its reorder level

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11327,7 +11327,8 @@
               "LEAVE_CANCELLED",
               "LEAVE_BALANCE_LOW",
               "LEAVE_REMINDER",
-              "APPROVAL_DELEGATED"
+              "APPROVAL_DELEGATED",
+              "MATERIAL_LOW_STOCK"
             ],
             "example": "LEAVE_PENDING_APPROVAL",
             "type": "string"

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -109,6 +109,31 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
     List<Employee> findByOrganizationIdAndOrgRole(Long orgId, OrgRole role);
 
     /**
+     * The holders of one organization role who are assigned to one project.
+     *
+     * <p>Org roles are held on the employee and are organization-wide, so "the storekeeper of
+     * project 12" is not a field anywhere: it is the intersection of the project's assignment
+     * list with the holders of the role. Nothing computed that intersection before this, and
+     * every caller that needs it needs the same one.
+     *
+     * <p>Both joins are association joins out of a root the {@code orgFilter} has already
+     * narrowed, so neither can widen the result past the tenant, and the organization predicate
+     * is written out anyway because a background caller runs with the filter established
+     * explicitly rather than by a request.
+     *
+     * @param orgId The organization the employee and the project both belong to.
+     * @param projectId The project they must be assigned to.
+     * @param role The organization role they must hold.
+     * @return The employees holding that role on that project, in no particular order. Empty
+     *         when nobody on the project holds it, which is a normal state and not an error.
+     */
+    @Query("SELECT DISTINCT e FROM Employee e JOIN e.orgRoles r JOIN e.projects p "
+            + "WHERE e.organization.id = :orgId AND p.id = :projectId AND r = :role")
+    List<Employee> findByProjectAndOrgRole(@Param("orgId") Long orgId,
+                                           @Param("projectId") Long projectId,
+                                           @Param("role") OrgRole role);
+
+    /**
      * Whether the employee holds one of the given roles <em>in the given organization</em>.
      *
      * <p>The organization predicate is written out rather than left to the {@code orgFilter}.

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationDraft.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationDraft.java
@@ -1,0 +1,36 @@
+package org.tornotron.echno_backend.leave;
+
+import org.tornotron.echno_backend.leave.enums.NotificationType;
+
+/**
+ * One notification, composed but not yet addressed.
+ *
+ * <p>Every sender on {@link NotificationService} before this one was a whole method per event,
+ * with the leave request it was about hard-wired into its signature. That is workable while every
+ * event is a leave event and stops being workable at the first one that is not: a caller outside
+ * the leave package cannot describe what it wants to say without a method being written for it
+ * inside a package it has nothing to do with.
+ *
+ * <p>Splitting the message from the recipient is the other half of it. A notification aimed at a
+ * role is a fan-out, because {@code Notification.recipient} is a single employee and there is no
+ * broadcast row, so the same draft has to be delivered several times over. Composing it once and
+ * addressing it N times is what {@link NotificationService#deliverToAll} does, and it keeps the
+ * wording of an event in one place rather than once per recipient.
+ *
+ * @param type What kind of event this is. Drives grouping and filtering in the inbox.
+ * @param title The one-line heading. At most 200 characters, which the column enforces.
+ * @param message The body. At most 1000 characters, which the column enforces.
+ * @param entityType What the notification is about, as a bare string: {@code "MATERIAL"},
+ *         {@code "LEAVE_REQUEST"}. Nullable, for a notification about nothing in particular.
+ * @param entityId The id of that thing, in the recipient's own organization. Nullable with
+ *         {@code entityType}.
+ * @param actionUrl Where the recipient should be sent to act on it. Nullable.
+ */
+public record NotificationDraft(
+        NotificationType type,
+        String title,
+        String message,
+        String entityType,
+        Long entityId,
+        String actionUrl) {
+}

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationService.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.leave.mapper.NotificationMapper;
 import org.tornotron.echno_backend.leave.enums.NotificationType;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,6 +39,63 @@ public class NotificationService {
         this.employeeRepository = employeeRepository;
         this.notificationMapper = notificationMapper;
         this.currentEmployeeService = currentEmployeeService;
+    }
+
+    /**
+     * Sends one composed notification to one employee.
+     *
+     * <p>The seam every non-leave sender goes through. The five methods below it are one method
+     * per leave event, each carrying a {@link LeaveRequest} in its signature, and there was no way
+     * for anything outside this package to raise a notification without a sixth being written for
+     * it here. This takes the message as data instead.
+     *
+     * <p>The organization is the recipient's own rather than anything the caller passes, which is
+     * what the five leave senders already do. A notification belongs to the tenant of the person
+     * reading it, and a caller that could set it independently could file a row into an
+     * organization the recipient cannot see, where it would be invisible to them and visible to
+     * everybody else.
+     *
+     * @param recipient Who is being told. Must be persisted and must have an organization.
+     * @param draft What they are being told.
+     * @return The saved notification.
+     */
+    @Transactional
+    public Notification deliver(Employee recipient, NotificationDraft draft) {
+        Notification notification = new Notification();
+        notification.setRecipient(recipient);
+        notification.setOrganization(recipient.getOrganization());
+        notification.setNotificationType(draft.type());
+        notification.setTitle(draft.title());
+        notification.setMessage(draft.message());
+        notification.setEntityType(draft.entityType());
+        notification.setEntityId(draft.entityId());
+        notification.setActionUrl(draft.actionUrl());
+        notification.setIsRead(false);
+        return notificationRepository.save(notification);
+    }
+
+    /**
+     * Sends the same composed notification to several employees, one row each.
+     *
+     * <p>A role-targeted notification is a fan-out and cannot be anything else here:
+     * {@code Notification.recipient} is a single employee foreign key, so there is no row that
+     * addresses a role and no row that addresses everybody. Saying so in one method keeps callers
+     * from each inventing their own loop, and keeps the wording of an event written once.
+     *
+     * <p>An empty recipient list saves nothing and is not an error. Deciding whether having
+     * nobody to tell is worth reporting belongs to the caller, which is the only party that knows
+     * what the silence means.
+     *
+     * @param recipients Who is being told. May be empty.
+     * @param draft What they are being told.
+     * @return The saved notifications, in the order the recipients were given.
+     */
+    @Transactional
+    public List<Notification> deliverToAll(Collection<Employee> recipients, NotificationDraft draft) {
+        if (recipients == null || recipients.isEmpty()) {
+            return List.of();
+        }
+        return recipients.stream().map(recipient -> deliver(recipient, draft)).toList();
     }
 
     @Transactional

--- a/src/main/java/org/tornotron/echno_backend/leave/enums/NotificationType.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/enums/NotificationType.java
@@ -8,5 +8,15 @@ public enum NotificationType {
     LEAVE_CANCELLED,
     LEAVE_BALANCE_LOW,
     LEAVE_REMINDER,
-    APPROVAL_DELEGATED
+    APPROVAL_DELEGATED,
+
+    /**
+     * A material has reached its reorder level on a project, and somebody who can act on it is
+     * being told once.
+     *
+     * <p>The first constant here that is not about leave. The enum is named for the subsystem
+     * rather than for leave, the column is {@code VARCHAR(50)}, and nothing reads the constants
+     * as a closed leave-shaped set, so this costs a line rather than a migration.
+     */
+    MATERIAL_LOW_STOCK
 }

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.material.Material;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * The reorder-level comparison, at each of the three scopes stock is held at.
  *
@@ -183,4 +186,70 @@ public interface LowStockRepository extends Repository<Material, Long> {
                                                     @Param("projectId") Long projectId,
                                                     @Param("storageLocationId") Long storageLocationId,
                                                     Pageable pageable);
+
+    /**
+     * Every project that holds a stock balance, in every organization.
+     *
+     * <p>The candidate list for the reorder sweep. It reads across tenants on purpose and returns
+     * two ids and nothing else: the pass establishes a tenant from the organization id before it
+     * reads anything belonging to that tenant, so the only thing crossing the boundary here is
+     * the pair of numbers saying where to look next.
+     *
+     * <p>Projects rather than organizations, because the project is the scope the sweep reports
+     * at. The organization total is the wrong question for this: on staging {@code TNT Steel}
+     * reads healthy at 60 against a level of 30 while holding 1, 18, 1, 7 and 1 unit at five
+     * separate sites, and a sweep on the organization total would find nothing wrong with any of
+     * them.
+     *
+     * <p>A project that has never held stock is not a candidate. Nothing can have crossed a
+     * threshold there, because there is no balance to cross it with, and the project-scope
+     * comparison would report the entire catalogue as absent from it.
+     *
+     * <p>Ordering is by organization then project, which is stable rather than rotating. A pass
+     * capped below the size of the estate would therefore always read the same prefix and never
+     * reach the tail. That is a real limit and the cap is set well above the current estate
+     * rather than worked around; if the estate outgrows it, the fix is to order on when each
+     * project's stock last moved, so the projects that can have crossed anything come first.
+     *
+     * @param pageable How much of the list to read. Pass it unsorted: the query orders itself.
+     * @return Distinct organization and project pairs, ordered.
+     */
+    @Query("""
+            SELECT DISTINCT new org.tornotron.echno_backend.material.lowstock.StockedProject(
+                       cs.organization.id, cs.project.id)
+            FROM CurrentStock cs
+            WHERE cs.organization IS NOT NULL AND cs.project IS NOT NULL
+            ORDER BY cs.organization.id ASC, cs.project.id ASC
+            """)
+    List<StockedProject> findProjectsHoldingStock(Pageable pageable);
+
+    /**
+     * The reorder level and project total for named materials on one project.
+     *
+     * <p>Asked about materials that were reported low earlier and are no longer in the low-stock
+     * answer, to decide whether they have recovered. The low-stock query cannot answer it, since
+     * the rows in question are the ones it has stopped returning.
+     *
+     * <p>The root is {@code Material} rather than {@code CurrentStock}, and the quantity is a
+     * correlated subquery rather than a join, so that a material whose stock rows on the project
+     * have all gone still comes back, with nothing on hand and its level intact. Rooting on the
+     * stock rows would drop it, and dropping it is indistinguishable from it having recovered.
+     *
+     * @param organizationId The tenant to read within.
+     * @param projectId The project to total at.
+     * @param materialIds The materials to report on. Never empty when called.
+     * @return One row per material that still exists in the catalogue, in no particular order.
+     */
+    @Query("""
+            SELECT new org.tornotron.echno_backend.material.lowstock.ProjectMaterialStock(
+                       m.id, m.reorderLevel,
+                       COALESCE((SELECT SUM(cs.currentQuantity) FROM CurrentStock cs
+                                 WHERE cs.material = m AND cs.project.id = :projectId
+                                   AND cs.organization.id = :organizationId), 0.0))
+            FROM Material m
+            WHERE m.organization.id = :organizationId AND m.id IN :materialIds
+            """)
+    List<ProjectMaterialStock> findProjectStockForMaterials(@Param("organizationId") Long organizationId,
+                                                            @Param("projectId") Long projectId,
+                                                            @Param("materialIds") Collection<Long> materialIds);
 }

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockSweep.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockSweep.java
@@ -1,0 +1,480 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.common.multitenancy.WithoutTenant;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.NotificationDraft;
+import org.tornotron.echno_backend.leave.NotificationService;
+import org.tornotron.echno_backend.leave.enums.NotificationType;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Tells whoever can act on it that a material has crossed its reorder level on a project.
+ *
+ * <h2>What it does, and the one thing it deliberately does not</h2>
+ *
+ * <p>It notifies. It does not raise a purchase order, an indent, or any other procurement
+ * document, and this is the decision rather than an omission. Reorder levels are set and the
+ * comparison against them is built ({@code GET /api/v1/materials/low-stock}, #652); what was
+ * missing is that the answer only existed while somebody was looking at it. A job that raised
+ * paperwork instead would be creating documents that carry approval workflows and money, nightly,
+ * on nobody's instruction. Telling somebody is reversible by ignoring it. Raising an indent is
+ * not.
+ *
+ * <h2>Who is told</h2>
+ *
+ * <p>The storekeepers assigned to the project, and only if there are none, the project managers
+ * assigned to it. {@code OrgRole.STORE_KEEPER} exists as of #650 and is exactly the person who
+ * books the goods receipt that answers this, which is the whole point of choosing a recipient: the
+ * notification goes to somebody who can do something about it in the same application.
+ *
+ * <p>Before that role existed the only available recipient was an organization administrator, and
+ * an administrator getting last night's shortfalls from twelve sites they do not run is the
+ * definition of the alert that gets muted in a week. So an administrator is <em>not</em> a
+ * fallback here. A project with nobody assigned in either role is counted and logged, and no
+ * notification is sent and no latch is written, so the first crossing still reaches whoever is
+ * eventually assigned rather than having been silently spent on nobody.
+ *
+ * <p>Org roles are read from the {@code Employee} row, where Keycloak's groups are mirrored, and
+ * not from Keycloak. The admin client can list a user's groups but has no reverse lookup from a
+ * subgroup to its members, so "who holds this role" is a question only the database can answer.
+ *
+ * <h2>Project scope, not organization and not location</h2>
+ *
+ * <p>The organization total is the wrong question and hides the answer: on staging {@code TNT
+ * Steel} totals 60 against a level of 30 while holding 1, 18, 1, 7 and 1 unit at five separate
+ * sites, so an organization-scope sweep would find nothing wrong at any of them. Storage-location
+ * scope is the noisiest reading, one event per shelf, and it has no recipient of its own, since
+ * the person who would be told about a location is the storekeeper on its project. The project is
+ * where the shortfall is real and where somebody is responsible for it.
+ *
+ * <h2>What counts as low, and what an unset level means</h2>
+ *
+ * <p>The comparison is not restated here. It is {@code LowStockRepository#findLowStockForProject},
+ * the same read the endpoint answers from, so the job and the endpoint cannot disagree about what
+ * is low. What that means, in full:
+ *
+ * <ul>
+ *   <li><b>At or below, not below.</b> A reorder level is the level at which you reorder, so
+ *       sitting exactly on it is the moment to act.</li>
+ *   <li><b>A null level is never reported, at any scope.</b> Nobody has said what low means for
+ *       that material, and a job that guessed would be inventing a threshold and then waking
+ *       somebody up about it. This is the case most easily conflated with the next one and it is
+ *       a different state entirely.</li>
+ *   <li><b>A level of zero is a set level.</b> Somebody drew the line at nothing on hand, which is
+ *       a decision and reads as "tell me when it is gone". It is reported once the material holds
+ *       nothing, and never before.</li>
+ *   <li><b>Only materials the project actually carries.</b> Project scope inner-joins the stock
+ *       rows, so the catalogue is not reported as absent from every project that has never held
+ *       it.</li>
+ * </ul>
+ *
+ * <h2>Crossing, not being below</h2>
+ *
+ * <p>A material is reported when it crosses its level, once, and not again while it stays down.
+ * Being below is a standing fact and the endpoint answers it on demand; re-sending it nightly is
+ * how the whole category gets muted, and then the one crossing that mattered is lost with the
+ * rest. {@link MaterialReorderAlert} holds the latch that makes this possible, keyed on the
+ * material and the project together, and its unique constraint is also what stops two replicas
+ * both sending.
+ *
+ * <p>Two things end a latch, and one of them is the answer to a material that hovers.
+ *
+ * <ul>
+ *   <li><b>Recovery, with a margin.</b> The latch clears once the project holds more than the
+ *       level plus {@code rearmMargin} of it, not the moment it ticks one unit above. Without the
+ *       margin a material oscillating on the boundary would be re-reported every pass, which is
+ *       the nightly re-raise the latch exists to prevent, reached by another route.</li>
+ *   <li><b>The level moving.</b> A material reported at a level of 30 and now measured against 100
+ *       is below a different line than the one anybody was told about. That is a new event. The
+ *       alternative is that raising a level latches a material permanently at the moment it
+ *       becomes badly short.</li>
+ * </ul>
+ *
+ * <p>A material that stays down for a month is therefore reported once. That is intended. The
+ * notification says something changed; the standing list of what is short is the endpoint's job
+ * and it is one click away.
+ *
+ * <h2>Tenants</h2>
+ *
+ * <p>The pass is {@link WithoutTenant} because it belongs to no organization, and everything it
+ * reads at that level is a pair of ids. Every read and write that touches a tenant's rows happens
+ * inside {@link TenantScopedJobRunner#runForTenant}, which refuses a null organization id. That is
+ * not belt and braces: both isolation mechanisms fail <em>open</em> on a missing organization id
+ * and {@code UnscopedAccessGuard} defaults to warning rather than denying, so a scheduled job that
+ * forgot its scope would read every tenant's rows and look perfectly healthy doing it.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "inventory.reorder-sweep.enabled", havingValue = "true")
+public class LowStockSweep {
+
+    private final LowStockRepository lowStockRepository;
+    private final MaterialReorderAlertRepository alertRepository;
+    private final EmployeeRepository employeeRepository;
+    private final OrganizationRepository organizationRepository;
+    private final ProjectRepository projectRepository;
+    private final MaterialRepository materialRepository;
+    private final NotificationService notificationService;
+    private final TenantScopedJobRunner tenantScopedJobRunner;
+    private final LowStockSweepProperties properties;
+
+    /**
+     * One pass.
+     *
+     * <p>Nothing here throws. Spring stops rescheduling a {@code @Scheduled} method that throws,
+     * so a single bad night would silently end the schedule, and a sweep that quietly stopped
+     * sweeping is a worse failure than the one it exists to fix.
+     */
+    @Scheduled(cron = "${inventory.reorder-sweep.cron:0 30 3 * * *}",
+            zone = "${inventory.reorder-sweep.zone:UTC}")
+    @WithoutTenant("The reorder sweep belongs to no organization: it exists to find which "
+            + "organizations have projects holding stock, reads two ids and nothing else at that "
+            + "level, and establishes a tenant per project before reading or writing anything "
+            + "belonging to one")
+    public void sweep() {
+        try {
+            runPass();
+        } catch (Exception e) {
+            log.error("Low stock sweep pass failed: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * The pass itself. Package-private so a test can run it and assert on what it did without
+     * waiting on a cron.
+     */
+    void runPass() {
+        LocalDateTime passStartedAt = LocalDateTime.now();
+
+        List<StockedProject> candidates = lowStockRepository.findProjectsHoldingStock(
+                PageRequest.of(0, Math.max(1, properties.getProjectScanLimit())));
+        if (candidates.isEmpty()) {
+            log.debug("Low stock sweep found no project holding stock; nothing to compare");
+            return;
+        }
+
+        int cap = Math.max(0, properties.getMaxNotificationsPerRun());
+        int raised = 0;
+        int stillLow = 0;
+        int recovered = 0;
+        int unaddressed = 0;
+        boolean cappedOut = false;
+
+        for (StockedProject candidate : candidates) {
+            if (!withinBudget(cap, raised, passStartedAt)) {
+                cappedOut = true;
+                break;
+            }
+            try {
+                ProjectOutcome outcome = tenantScopedJobRunner.callForTenant(
+                        candidate.organizationId(), () -> sweepProject(candidate));
+                raised += outcome.raised();
+                stillLow += outcome.stillLow();
+                recovered += outcome.recovered();
+                unaddressed += outcome.unaddressed();
+            } catch (Exception e) {
+                // One project's night must not cost every other project theirs.
+                log.error("Low stock sweep could not sweep project {} in organization {}: {}",
+                        candidate.projectId(), candidate.organizationId(), e.getMessage(), e);
+            }
+        }
+
+        if (cappedOut) {
+            log.info("Low stock sweep stopped at its per-run cap of {} material(s); the rest are "
+                    + "picked up by the next pass", cap);
+        }
+        log.info("Low stock sweep looked at {} project(s): reported {} newly at or below level, "
+                        + "{} already reported and still down, {} recovered, {} with nobody to tell",
+                candidates.size(), raised, stillLow, recovered, unaddressed);
+    }
+
+    /** What one project's pass did. */
+    private record ProjectOutcome(int raised, int stillLow, int recovered, int unaddressed) {
+    }
+
+    /**
+     * One project, under its own tenant.
+     *
+     * <p>The two halves are the low list and the latch list, and the second half is about the
+     * latches the first half did not match: a material that was reported and has since dropped out
+     * of the low answer is the one that might have recovered.
+     */
+    private ProjectOutcome sweepProject(StockedProject candidate) {
+        Long orgId = candidate.organizationId();
+        Long projectId = candidate.projectId();
+
+        List<LowStockRow> low = lowStockRepository.findLowStockForProject(orgId, projectId,
+                PageRequest.of(0, Math.max(1, properties.getMaterialsPerProject()))).getContent();
+
+        Map<Long, MaterialReorderAlert> latched = new LinkedHashMap<>();
+        for (MaterialReorderAlert alert : alertRepository
+                .findByOrganization_IdAndProject_Id(orgId, projectId)) {
+            latched.put(alert.getMaterial().getId(), alert);
+        }
+
+        int raised = 0;
+        int stillLow = 0;
+        int unaddressed = 0;
+        List<Employee> recipients = null;
+
+        for (LowStockRow row : low) {
+            MaterialReorderAlert existing = latched.remove(row.materialId());
+            if (existing != null && sameLevel(existing.getNotifiedLevel(), row.reorderLevel())) {
+                // Already reported against this level, and still down. Nothing has changed, so
+                // there is nothing to say.
+                stillLow++;
+                continue;
+            }
+
+            if (recipients == null) {
+                recipients = recipientsFor(orgId, projectId);
+            }
+            if (recipients.isEmpty()) {
+                // No latch is written. The crossing has not been reported, so it must still be
+                // reportable once somebody is assigned to the project.
+                unaddressed++;
+                continue;
+            }
+
+            if (raise(orgId, projectId, row, recipients, existing)) {
+                raised++;
+            }
+        }
+
+        int recovered = clearRecovered(orgId, projectId, latched);
+        return new ProjectOutcome(raised, stillLow, recovered, unaddressed);
+    }
+
+    /**
+     * Sends one material's notification and latches it.
+     *
+     * <p>The latch is written after the notifications rather than before, so a failure to save it
+     * cannot leave a material latched that nobody was told about. The other order of the same
+     * failure, notifications sent and no latch, costs a repeat on the next pass, which is the
+     * cheaper of the two mistakes.
+     *
+     * @return Whether anything was sent. A losing race is not a failure and is not counted.
+     */
+    private boolean raise(Long orgId, Long projectId, LowStockRow row,
+                          List<Employee> recipients, MaterialReorderAlert existing) {
+        Optional<Project> project = projectRepository.findById(projectId);
+        String projectName = project.map(Project::getProjectName).orElse("project " + projectId);
+
+        NotificationDraft draft = new NotificationDraft(
+                NotificationType.MATERIAL_LOW_STOCK,
+                title(row),
+                message(row, projectName),
+                "MATERIAL",
+                row.materialId(),
+                "/materials/" + row.materialId());
+
+        try {
+            notificationService.deliverToAll(recipients, draft);
+            latch(orgId, projectId, row, recipients.size(), existing);
+        } catch (DataIntegrityViolationException e) {
+            // Another replica latched the same material in the same second. Its notifications
+            // went out; ours may have too, and one duplicate is the documented cost of not
+            // running a leader election for a nightly job.
+            log.debug("Low stock sweep lost the latch race for material {} on project {}: {}",
+                    row.materialId(), projectId, e.getMessage());
+            return false;
+        }
+        log.info("Low stock sweep reported material {} on project {} in organization {} to {} "
+                + "recipient(s)", row.materialId(), projectId, orgId, recipients.size());
+        return true;
+    }
+
+    /** Writes or refreshes the latch for one material on one project. */
+    private void latch(Long orgId, Long projectId, LowStockRow row, int recipientCount,
+                       MaterialReorderAlert existing) {
+        MaterialReorderAlert alert = existing != null ? existing : new MaterialReorderAlert();
+        if (existing == null) {
+            Organization organization = organizationRepository.getReferenceById(orgId);
+            Project project = projectRepository.getReferenceById(projectId);
+            Material material = materialRepository.getReferenceById(row.materialId());
+            alert.setOrganization(organization);
+            alert.setProject(project);
+            alert.setMaterial(material);
+        }
+        alert.setNotifiedLevel(row.reorderLevel());
+        alert.setNotifiedQuantity(row.currentStock() == null ? 0.0 : row.currentStock());
+        alert.setRecipientCount(recipientCount);
+        alert.setNotifiedAt(LocalDateTime.now());
+        alertRepository.saveAndFlush(alert);
+    }
+
+    /**
+     * Deletes the latches whose material has recovered, and returns how many.
+     *
+     * <p>Every latch handed here is for a material the project's low-stock answer no longer
+     * contains, which is one of three things: it has climbed above its level, its level has been
+     * cleared, or the material has been removed from the catalogue. The first is the only one that
+     * needs a margin.
+     *
+     * <p>A material still at or below the rearm line keeps its latch. That includes a material
+     * whose stock rows on the project are all gone, which reads as nothing on hand: it holds
+     * nothing there, so it has not recovered, and re-reporting it would say nothing new.
+     */
+    private int clearRecovered(Long orgId, Long projectId, Map<Long, MaterialReorderAlert> latched) {
+        if (latched.isEmpty()) {
+            return 0;
+        }
+
+        Map<Long, ProjectMaterialStock> now = new HashMap<>();
+        for (ProjectMaterialStock stock : lowStockRepository
+                .findProjectStockForMaterials(orgId, projectId, latched.keySet())) {
+            now.put(stock.materialId(), stock);
+        }
+
+        List<MaterialReorderAlert> clear = new ArrayList<>();
+        for (Map.Entry<Long, MaterialReorderAlert> entry : latched.entrySet()) {
+            ProjectMaterialStock stock = now.get(entry.getKey());
+            if (stock == null) {
+                // The material is gone from the catalogue. There is nothing left to report on.
+                clear.add(entry.getValue());
+                continue;
+            }
+            if (stock.reorderLevel() == null) {
+                // The level has been cleared. Nobody is saying what low means for this material
+                // any more, so there is no line for it to be below.
+                clear.add(entry.getValue());
+                continue;
+            }
+            if (hasRearmed(stock.currentStock(), stock.reorderLevel())) {
+                clear.add(entry.getValue());
+            }
+        }
+
+        if (!clear.isEmpty()) {
+            alertRepository.deleteAll(clear);
+        }
+        return clear.size();
+    }
+
+    /**
+     * Whether stock has come back far enough above the level for a later dip to count as a new
+     * crossing.
+     *
+     * <p>Strictly above level plus the margin. A level of zero rearms at anything above nothing,
+     * which needs no special case: the margin is a fraction of the level and a fraction of zero is
+     * zero.
+     */
+    private boolean hasRearmed(Double quantity, Double level) {
+        double onHand = quantity == null ? 0.0 : quantity;
+        double margin = Math.max(0.0, properties.getRearmMargin());
+        return onHand > level * (1.0 + margin);
+    }
+
+    /**
+     * Whether the level a material was reported against is the level in force now.
+     *
+     * <p>Compared as doubles because that is what both are, with the null case answered rather
+     * than assumed: a latch always carries a level, and a row in the low answer always carries
+     * one, so a null on either side is a state neither is supposed to reach and is treated as a
+     * change rather than as equality.
+     */
+    private boolean sameLevel(Double latchedLevel, Double currentLevel) {
+        if (latchedLevel == null || currentLevel == null) {
+            return false;
+        }
+        return latchedLevel.compareTo(currentLevel) == 0;
+    }
+
+    /**
+     * Who to tell about a shortfall on one project.
+     *
+     * <p>Storekeepers first, project managers only if the project has none. An organization
+     * administrator is deliberately not the third rung: see the class comment.
+     */
+    private List<Employee> recipientsFor(Long orgId, Long projectId) {
+        List<Employee> keepers = employeeRepository.findByProjectAndOrgRole(
+                orgId, projectId, OrgRole.STORE_KEEPER);
+        if (!keepers.isEmpty()) {
+            return keepers;
+        }
+        List<Employee> managers = employeeRepository.findByProjectAndOrgRole(
+                orgId, projectId, OrgRole.PROJECT_MANAGER);
+        if (managers.isEmpty()) {
+            log.info("Low stock sweep found nobody to tell about project {} in organization {}: "
+                    + "no storekeeper and no project manager is assigned to it", projectId, orgId);
+        }
+        return managers;
+    }
+
+    /**
+     * Whether this pass may still report, counting what every replica has reported rather than
+     * only what this one has.
+     */
+    private boolean withinBudget(int cap, int raisedHere, LocalDateTime passStartedAt) {
+        if (raisedHere >= cap) {
+            return false;
+        }
+        long raisedAnywhere = alertRepository.countByNotifiedAtGreaterThanEqual(passStartedAt);
+        return Math.max(raisedHere, raisedAnywhere) < cap;
+    }
+
+    /** The heading. Kept inside 200 characters, which is what the column holds. */
+    private String title(LowStockRow row) {
+        return truncate("Low stock: " + row.materialName(), 200);
+    }
+
+    /** The body. Kept inside 1000 characters, which is what the column holds. */
+    private String message(LowStockRow row, String projectName) {
+        StringBuilder text = new StringBuilder()
+                .append(row.materialName())
+                .append(" is down to ")
+                .append(number(row.currentStock()));
+        if (row.unit() != null && !row.unit().isBlank()) {
+            text.append(' ').append(row.unit());
+        }
+        text.append(" on ").append(projectName)
+                .append(", at or below its reorder level of ")
+                .append(number(row.reorderLevel()))
+                .append('.');
+        if (row.moq() != null && row.moq() > 0) {
+            text.append(" The minimum order quantity is ").append(number(row.moq())).append('.');
+        }
+        return truncate(text.toString(), 1000);
+    }
+
+    /**
+     * A quantity as a person would write it, so a whole number reads as {@code 60} rather than
+     * {@code 60.0}.
+     */
+    private String number(Double value) {
+        if (value == null) {
+            return "0";
+        }
+        return BigDecimal.valueOf(value).stripTrailingZeros().toPlainString();
+    }
+
+    /** Cuts text to what the column holds, rather than letting the insert fail on a long name. */
+    private String truncate(String text, int limit) {
+        return text.length() <= limit ? text : text.substring(0, limit - 1) + "…";
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockSweepProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockSweepProperties.java
@@ -1,0 +1,92 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * How the reorder sweep behaves. Bound from the {@code inventory.reorder-sweep.*} block in
+ * application.yml.
+ *
+ * <p>Off by default, in the shape {@code ComplianceSweepProperties} established. The mechanism is
+ * settled and the schedule is a decision somebody has to make with a real inbox in front of them,
+ * so turning it on is configuration rather than a build.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "inventory.reorder-sweep")
+public class LowStockSweepProperties {
+
+    /**
+     * Master switch. False, so the bean does not exist until somebody turns it on.
+     *
+     * <p>Turning it on costs no money, unlike the compliance sweep, but it does put notifications
+     * in people's inboxes, and an alert nobody asked for is muted once and then useless for ever.
+     */
+    private boolean enabled = false;
+
+    /**
+     * When a pass runs, as a Spring cron expression.
+     *
+     * <p>Half past three rather than two, which is when the compliance sweep runs. The two do not
+     * contend for anything expensive, since this one makes no model calls, but they share a
+     * database and a scheduler pool and there is no reason to put both on the same minute.
+     *
+     * <p>Before the working day rather than during it: what the storekeeper wants is the morning's
+     * list, and the crossings that matter happened yesterday.
+     */
+    private String cron = "0 30 3 * * *";
+
+    /**
+     * Time zone the cron is read in. UTC, so the schedule does not move with a host's zone and
+     * does not shift twice a year.
+     */
+    private String zone = "UTC";
+
+    /**
+     * How many stock-holding projects one pass looks at, across every tenant.
+     *
+     * <p>This bounds the scan. The candidate query has no organization filter by design, and an
+     * unbounded read of every project holding stock in the database is fine at today's handful and
+     * is not fine later. The ordering is stable rather than rotating, so this has to stay above
+     * the real number of such projects; see {@code LowStockRepository#findProjectsHoldingStock}.
+     */
+    private int projectScanLimit = 2000;
+
+    /**
+     * How many low materials one pass reports on per project.
+     *
+     * <p>A project genuinely short of two hundred things has a procurement problem rather than a
+     * notification problem, and telling one person about all two hundred in one night is how a
+     * category gets muted. Materials come back most depleted first, so a capped project still
+     * reports the worst of it, and the rest arrive on the passes after.
+     */
+    private int materialsPerProject = 25;
+
+    /**
+     * How many materials one pass may raise notifications for in total, across every tenant.
+     *
+     * <p>The second bound, on noise rather than on reads. It is counted from the latch table
+     * rather than in memory so that N replicas share one budget instead of having one each. That
+     * makes it a bound and not a lock: two replicas starting a pass in the same second can both
+     * send before either sees the other, so the real ceiling is this plus roughly one material
+     * per replica.
+     */
+    private int maxNotificationsPerRun = 200;
+
+    /**
+     * How far above its reorder level a material has to recover before it is worth reporting on
+     * again, as a fraction of that level.
+     *
+     * <p>This is the whole answer to a material that hovers. Clearing the latch the moment stock
+     * ticks one unit above the level would mean a material oscillating around the boundary is
+     * reported again on the next pass, and again the pass after, which is the nightly re-raise the
+     * latch exists to prevent, arrived at by a different route. At the default a material with a
+     * level of 30 has to reach above 33 before a later dip counts as a new crossing.
+     *
+     * <p>A level of zero needs no special case and gets none: zero times anything is zero, so a
+     * material whose owner asked to be told when it is gone rearms as soon as it holds anything
+     * at all, which is the right reading of what they asked for.
+     */
+    private double rearmMargin = 0.10;
+}

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/MaterialReorderAlert.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/MaterialReorderAlert.java
@@ -1,0 +1,115 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+
+import java.time.LocalDateTime;
+
+/**
+ * A record that one material on one project has already been reported as low, and has not
+ * recovered since.
+ *
+ * <h2>Why a row exists at all</h2>
+ *
+ * <p>What makes a low-stock notification worth sending is the material <em>crossing</em> its
+ * reorder level, not sitting below it. Being below it is a standing fact that
+ * {@code GET /api/v1/materials/low-stock} answers at any hour for free, and a nightly pass that
+ * re-sent it would tell the same person the same forty things every morning until they muted the
+ * category, at which point the one crossing that mattered is lost with the rest. Nothing in the
+ * notification subsystem could express that on its own: {@code Notification} has no idempotency
+ * key, {@code (entity_type, entity_id)} is indexed but not unique, and the key here is a pair
+ * (this material, on this project) that a single {@code entity_id} column cannot hold.
+ *
+ * <p>So the state is held here instead. A row means "already reported, and not recovered". The
+ * sweep writes one when it sends, leaves it alone while the material stays down, and deletes it
+ * once the material has recovered far enough to be worth reporting again. No row and low means
+ * this is news.
+ *
+ * <h2>The unique constraint is the idempotency key</h2>
+ *
+ * <p>{@code @Scheduled} elects no leader, so on N replicas the pass runs N times and two replicas
+ * can find the same material low in the same second. The uniqueness of
+ * {@code (organization_id, project_id, material_id)} is what makes the second one lose: the
+ * insert fails and that replica sends nothing, rather than both sending and the storekeeper
+ * getting the same notification twice.
+ *
+ * <h2>What the recorded level is for</h2>
+ *
+ * <p>{@code notifiedLevel} is the reorder level that was in force when the notification went out,
+ * and it is compared against the level in force now. A material that was reported at a level of
+ * 30 and is now measured against a level of 100 is below a different line than the one anybody
+ * was told about, and that is a new event rather than the same one continuing. Without the
+ * comparison, raising a level would put a material into a permanently-latched state where it is
+ * newly and badly short and nobody is ever told.
+ *
+ * <p>{@code notifiedQuantity} is what it held at that moment. Nothing reads it: it is there so
+ * that somebody looking at why a notification went out can see the number it went out for.
+ */
+@Entity
+@Data
+@NoArgsConstructor
+@Table(name = "material_reorder_alert",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_material_reorder_alert_scope",
+                columnNames = {"organization_id", "project_id", "material_id"}),
+        indexes = {
+                @Index(name = "idx_material_reorder_alert_scope",
+                        columnList = "organization_id, project_id"),
+                @Index(name = "idx_material_reorder_alert_notified_at",
+                        columnList = "notified_at")
+        })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+public class MaterialReorderAlert implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    /** The tenant this belongs to. */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
+
+    /** The project the shortfall was measured on. */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    /** The material that reached its level. */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "material_id", nullable = false)
+    private Material material;
+
+    /** The reorder level that was in force when the notification was sent. */
+    @Column(name = "notified_level", nullable = false)
+    private Double notifiedLevel;
+
+    /** What the project held at that moment. */
+    @Column(name = "notified_quantity", nullable = false)
+    private Double notifiedQuantity;
+
+    /** How many people were told. Zero is never written: nobody to tell means nothing is sent. */
+    @Column(name = "recipient_count", nullable = false)
+    private Integer recipientCount = 0;
+
+    /** When the notification went out. */
+    @Column(name = "notified_at", nullable = false)
+    private LocalDateTime notifiedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/MaterialReorderAlertRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/MaterialReorderAlertRepository.java
@@ -1,0 +1,41 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * The latch rows, read the two ways the sweep reads them.
+ */
+public interface MaterialReorderAlertRepository extends JpaRepository<MaterialReorderAlert, Long> {
+
+    /**
+     * Every material currently latched on one project.
+     *
+     * <p>Read whole rather than probed one material at a time: a pass already holds the project's
+     * low-stock list in memory and has to answer two questions against these rows, which of the
+     * low materials have already been reported and which of the reported ones are no longer low,
+     * and the second question is about the rows the first one did not match.
+     *
+     * @param organizationId The tenant. Written out rather than left to {@code orgFilter},
+     *         because the caller is a background pass that sets its own scope.
+     * @param projectId The project.
+     */
+    List<MaterialReorderAlert> findByOrganization_IdAndProject_Id(Long organizationId, Long projectId);
+
+    /**
+     * How many notifications have been raised anywhere since a moment.
+     *
+     * <p>The per-pass cap is counted from the table rather than from a local variable, for the
+     * reason {@code ComplianceRuleSweep} documents at length: {@code @Scheduled} elects no leader,
+     * so a cap held in memory on N replicas is N caps. This makes it one budget they share. It is
+     * a bound and not a lock, and the honest statement of what it buys is that the overshoot falls
+     * from a whole cap per replica to roughly what one replica can send between two counts.
+     *
+     * <p>It counts across tenants deliberately: the cap is on the noise one pass may generate in
+     * total, not per organization, because the thing being protected is the pass rather than any
+     * one tenant's inbox.
+     */
+    long countByNotifiedAtGreaterThanEqual(LocalDateTime since);
+}

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/ProjectMaterialStock.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/ProjectMaterialStock.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+/**
+ * What one material's position on one project is, for a material the sweep already knows about.
+ *
+ * <p>The counterpart to {@link LowStockRow}, and needed because that one cannot answer this
+ * question. The low-stock query returns what is low; deciding whether a material that was
+ * reported low has recovered needs the level and the quantity for a material the low-stock query
+ * has stopped returning, which is precisely the row it no longer produces.
+ *
+ * @param materialId The material.
+ * @param reorderLevel The material's own reorder level, or null if nobody has set one. Null is
+ *         not zero: it means no line has been drawn, so there is nothing to be below.
+ * @param currentStock What the project holds across all its storage locations. Zero, never null:
+ *         a material with no stock row on the project holds nothing there.
+ */
+public record ProjectMaterialStock(Long materialId, Double reorderLevel, Double currentStock) {
+}

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/StockedProject.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/StockedProject.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+/**
+ * One project that holds stock, and the organization it belongs to.
+ *
+ * <p>Two scalars rather than the entities, because the sweep that reads this runs across every
+ * tenant at once and must not load a tenant-scoped row while it is doing so. It reads the pair,
+ * establishes the tenant from the organization id, and only then reads anything belonging to it.
+ *
+ * @param organizationId The tenant the project belongs to.
+ * @param projectId The project.
+ */
+public record StockedProject(Long organizationId, Long projectId) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -129,6 +129,31 @@ compliance:
     max-projects-per-run: ${COMPLIANCE_SWEEP_MAX_PROJECTS_PER_RUN:25}
 
 
+# The nightly reorder sweep. It tells the storekeepers on a project, or its project
+# managers if it has none, that a material has crossed its reorder level there. It
+# notifies and raises no procurement document.
+#
+# Off by default: turning it on puts notifications in real inboxes, and an alert
+# nobody asked for is muted once and useless afterwards.
+#
+# Half past three rather than two, which is when the compliance sweep runs. They do
+# not contend for anything expensive but they share a database and a scheduler pool.
+#
+# rearm-margin is how far above its level a material has to recover before a later dip
+# counts as a new crossing, as a fraction of the level. It is what stops a material
+# hovering on the boundary being reported every night. A level of zero needs no special
+# case: a fraction of zero is zero, so it rearms at anything above nothing.
+inventory:
+  reorder-sweep:
+    enabled: ${INVENTORY_REORDER_SWEEP_ENABLED:false}
+    cron: ${INVENTORY_REORDER_SWEEP_CRON:0 30 3 * * *}
+    zone: ${INVENTORY_REORDER_SWEEP_ZONE:UTC}
+    project-scan-limit: ${INVENTORY_REORDER_SWEEP_PROJECT_SCAN_LIMIT:2000}
+    materials-per-project: ${INVENTORY_REORDER_SWEEP_MATERIALS_PER_PROJECT:25}
+    max-notifications-per-run: ${INVENTORY_REORDER_SWEEP_MAX_NOTIFICATIONS_PER_RUN:200}
+    rearm-margin: ${INVENTORY_REORDER_SWEEP_REARM_MARGIN:0.10}
+
+
 # Chart-of-accounts auto numbering. level-steps is the gap between sibling codes
 # at each depth (0 = roots); root-blocks is the first code per account type.
 finance:

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -412,4 +412,7 @@
     <!-- v4.0 - Issue comments: let an author correct their own comment, and say on the record that they did -->
     <include file="db/changelog/v4.0/092-issue-comment-edited-marker.xml"/>
 
+    <!-- v4.0 - Inventory: remember that a material was reported low, so the sweep reports a crossing rather than a standing fact -->
+    <include file="db/changelog/v4.0/093-material-reorder-alert.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/093-material-reorder-alert.xml
+++ b/src/main/resources/db/changelog/v4.0/093-material-reorder-alert.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <!--
+      Where the reorder sweep remembers that it has already reported a material on a project.
+
+      A row means "reported, and not recovered since". Without it the sweep can only ask whether a
+      material is below its level, which is a standing fact rather than an event, and it would
+      re-send the same list every night until the recipient muted the category.
+
+      The unique constraint is doing two jobs. It is the key of the state, one latch per material
+      per project, and it is also the idempotency key: @Scheduled elects no leader, so on N
+      replicas the pass runs N times, and this is what makes the second replica's insert fail
+      rather than the recipient get told twice.
+    -->
+    <changeSet id="093-create-material-reorder-alert" author="abhijith">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="material_reorder_alert"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="material_reorder_alert">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" primaryKeyName="pk_material_reorder_alert"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="project_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="material_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <!-- The level the notification went out against, so a later change to it reads as a
+                 new event rather than as the same one continuing. -->
+            <column name="notified_level" type="DOUBLE">
+                <constraints nullable="false"/>
+            </column>
+            <!-- What the project held at that moment. Nothing reads it; it is here so somebody
+                 asking why a notification went out can see the number it went out for. -->
+            <column name="notified_quantity" type="DOUBLE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="recipient_count" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="notified_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint tableName="material_reorder_alert"
+                             columnNames="organization_id, project_id, material_id"
+                             constraintName="uq_material_reorder_alert_scope"/>
+
+        <!-- The sweep reads every latch on one project at a time. -->
+        <createIndex tableName="material_reorder_alert"
+                     indexName="idx_material_reorder_alert_scope">
+            <column name="organization_id"/>
+            <column name="project_id"/>
+        </createIndex>
+
+        <!-- The per-run cap is counted from this column, across tenants, on every project. -->
+        <createIndex tableName="material_reorder_alert"
+                     indexName="idx_material_reorder_alert_notified_at">
+            <column name="notified_at"/>
+        </createIndex>
+
+        <!-- Cascading deletes rather than orphan latches. A latch has no meaning once the thing
+             it is about is gone, and it is state the application can rebuild on its next pass. -->
+        <addForeignKeyConstraint baseTableName="material_reorder_alert"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_material_reorder_alert_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+        <addForeignKeyConstraint baseTableName="material_reorder_alert"
+                                 baseColumnNames="project_id"
+                                 constraintName="fk_material_reorder_alert_project"
+                                 referencedTableName="project"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+        <addForeignKeyConstraint baseTableName="material_reorder_alert"
+                                 baseColumnNames="material_id"
+                                 constraintName="fk_material_reorder_alert_material"
+                                 referencedTableName="material"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <rollback>
+            <dropTable tableName="material_reorder_alert"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockSweepScheduleTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockSweepScheduleTest.java
@@ -1,0 +1,117 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.support.CronExpression;
+import org.tornotron.echno_backend.common.multitenancy.WithoutTenant;
+import org.tornotron.echno_backend.compliance.sweep.ComplianceRuleSweep;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Whether the sweep is ever triggered, and under what conditions.
+ *
+ * <p>Separate from {@link LowStockSweepTest} on purpose, and the separation is the point.
+ * Everything in that class calls {@code runPass()} by hand, which exercises the logic and says
+ * nothing at all about the schedule: a job whose {@code @Scheduled} was deleted, or whose cron
+ * expression does not parse, or whose bean never exists, would pass every one of those tests. The
+ * trigger is a declaration rather than behaviour, so this reads the declaration.
+ *
+ * <p>What it does not claim: nothing here waits for a cron to fire. It asserts that the trigger
+ * exists, that its default expression is one Spring can actually parse, that the bean is
+ * conditional and off, and that a failing pass cannot take the schedule down with it.
+ */
+class LowStockSweepScheduleTest {
+
+    private Method sweepMethod() throws NoSuchMethodException {
+        return LowStockSweep.class.getMethod("sweep");
+    }
+
+    @Test
+    @DisplayName("the pass is on a cron trigger, read from configuration")
+    void isScheduled() throws Exception {
+        Scheduled scheduled = sweepMethod().getAnnotation(Scheduled.class);
+
+        assertThat(scheduled).isNotNull();
+        assertThat(scheduled.cron()).isEqualTo("${inventory.reorder-sweep.cron:0 30 3 * * *}");
+        assertThat(scheduled.zone()).isEqualTo("${inventory.reorder-sweep.zone:UTC}");
+    }
+
+    @Test
+    @DisplayName("the default cron expression is one Spring can parse")
+    void defaultCronParses() {
+        // A property placeholder that resolves to nonsense fails at context refresh, months after
+        // the change that broke it, on whichever environment did not override the property.
+        assertThat(CronExpression.isValidExpression(defaultCron())).isTrue();
+    }
+
+    @Test
+    @DisplayName("the default window is not the compliance sweep's window")
+    void doesNotLandOnTheComplianceSweep() throws Exception {
+        // Both are nightly, both run against the same database on the same scheduler pool, and
+        // development is deployed to two stagings that already carry the compliance pass. There
+        // is no reason to put them on the same minute and no cost to not doing so.
+        Scheduled compliance = ComplianceRuleSweep.class.getMethod("sweep")
+                .getAnnotation(Scheduled.class);
+        String complianceCron = defaultOf(compliance.cron());
+
+        LocalDateTime from = LocalDateTime.of(2026, 1, 1, 0, 0);
+        LocalDateTime ours = CronExpression.parse(defaultCron()).next(from);
+        LocalDateTime theirs = CronExpression.parse(complianceCron).next(from);
+
+        assertThat(ours).isNotEqualTo(theirs);
+    }
+
+    @Test
+    @DisplayName("the bean does not exist unless somebody turns it on")
+    void isOffByDefault() {
+        ConditionalOnProperty conditional =
+                LowStockSweep.class.getAnnotation(ConditionalOnProperty.class);
+
+        assertThat(conditional).isNotNull();
+        assertThat(conditional.name()).containsExactly("inventory.reorder-sweep.enabled");
+        assertThat(conditional.havingValue()).isEqualTo("true");
+        // matchIfMissing defaults to false, so an environment that says nothing gets no bean.
+        assertThat(conditional.matchIfMissing()).isFalse();
+        assertThat(new LowStockSweepProperties().isEnabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("the pass declares that it belongs to no organization, and says why")
+    void declaresItsScope() throws Exception {
+        // Both tenant-isolation mechanisms fail open on a missing organization id and
+        // UnscopedAccessGuard warns rather than denies, so an undeclared scheduled job reads
+        // every tenant's rows and looks healthy doing it. The declaration is what makes the
+        // choice visible instead of accidental.
+        WithoutTenant withoutTenant = sweepMethod().getAnnotation(WithoutTenant.class);
+
+        assertThat(withoutTenant).isNotNull();
+        assertThat(withoutTenant.value()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("a failing pass does not stop the schedule")
+    void survivesAFailingPass() {
+        // Spring stops rescheduling a @Scheduled method that throws. A sweep that quietly stopped
+        // sweeping after one bad night is worse than the gap it was built to close, because
+        // nothing about the system looks any different afterwards.
+        LowStockSweep sweep = new LowStockSweep(null, null, null, null, null, null, null, null,
+                new LowStockSweepProperties());
+
+        sweep.sweep();
+    }
+
+    private String defaultCron() {
+        return defaultOf("${inventory.reorder-sweep.cron:0 30 3 * * *}");
+    }
+
+    /** The fallback out of a {@code ${property:default}} placeholder. */
+    private String defaultOf(String placeholder) {
+        return placeholder.substring(placeholder.indexOf(':') + 1, placeholder.length() - 1);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockSweepTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockSweepTest.java
@@ -1,0 +1,485 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.NotificationDraft;
+import org.tornotron.echno_backend.leave.NotificationService;
+import org.tornotron.echno_backend.leave.enums.NotificationType;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * What the reorder sweep decides, once it has a project's answer in front of it.
+ *
+ * <p>Everything here calls {@code runPass()} directly, so none of it says anything about whether
+ * the job is ever triggered. That is deliberately a separate question and it is asked in
+ * {@link LowStockSweepScheduleTest}, which reads the declaration rather than the logic. A test
+ * that calls a scheduled method and passes proves the method works and proves nothing whatsoever
+ * about the schedule.
+ *
+ * <p>Plain Mockito, no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LowStockSweepTest {
+
+    private static final Long ORG = 7L;
+    private static final Long PROJECT = 12L;
+    private static final Long MATERIAL = 55L;
+
+    @Mock private LowStockRepository lowStockRepository;
+    @Mock private MaterialReorderAlertRepository alertRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private NotificationService notificationService;
+
+    private LowStockSweepProperties properties;
+    private LowStockSweep sweep;
+
+    /** Every organization id the pass established a tenant for, in order. */
+    private final List<Long> scopedTo = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        properties = new LowStockSweepProperties();
+
+        // The real runner, not a stub. It is what refuses a null organization id, and stubbing it
+        // out would remove the only thing standing between a scheduled job and every tenant's
+        // rows. The list records what it was asked to scope to.
+        TenantScopedJobRunner runner = new TenantScopedJobRunner() {
+            @Override
+            public <T> T callForTenant(Long orgId, java.util.function.Supplier<T> work) {
+                scopedTo.add(orgId);
+                return super.callForTenant(orgId, work);
+            }
+        };
+
+        sweep = new LowStockSweep(lowStockRepository, alertRepository, employeeRepository,
+                organizationRepository, projectRepository, materialRepository, notificationService,
+                runner, properties);
+
+        when(lowStockRepository.findProjectsHoldingStock(any(Pageable.class)))
+                .thenReturn(List.of(new StockedProject(ORG, PROJECT)));
+        when(alertRepository.findByOrganization_IdAndProject_Id(ORG, PROJECT))
+                .thenReturn(List.of());
+        when(alertRepository.countByNotifiedAtGreaterThanEqual(any())).thenReturn(0L);
+        when(lowStockRepository.findLowStockForProject(eq(ORG), eq(PROJECT), any(Pageable.class)))
+                .thenReturn(emptyPage());
+        when(lowStockRepository.findProjectStockForMaterials(anyLong(), anyLong(), any()))
+                .thenReturn(List.of());
+        when(projectRepository.findById(PROJECT)).thenReturn(Optional.of(project("Marina Tower")));
+        when(projectRepository.getReferenceById(PROJECT)).thenReturn(project("Marina Tower"));
+        when(organizationRepository.getReferenceById(ORG)).thenReturn(new Organization());
+        when(materialRepository.getReferenceById(MATERIAL)).thenReturn(new Material());
+        when(alertRepository.saveAndFlush(any())).thenAnswer(i -> i.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("Who is told")
+    class Recipients {
+
+        @Test
+        @DisplayName("the storekeepers on the project, who are the people who can act on it")
+        void tellsTheProjectsStorekeepers() {
+            Employee keeper = employee(101L);
+            lowMaterial(30.0, 4.0);
+            when(employeeRepository.findByProjectAndOrgRole(ORG, PROJECT, OrgRole.STORE_KEEPER))
+                    .thenReturn(List.of(keeper));
+
+            sweep.runPass();
+
+            assertThat(deliveredTo()).containsExactly(keeper);
+        }
+
+        @Test
+        @DisplayName("the project managers only when the project has no storekeeper")
+        void fallsBackToProjectManagers() {
+            Employee manager = employee(202L);
+            lowMaterial(30.0, 4.0);
+            when(employeeRepository.findByProjectAndOrgRole(ORG, PROJECT, OrgRole.STORE_KEEPER))
+                    .thenReturn(List.of());
+            when(employeeRepository.findByProjectAndOrgRole(ORG, PROJECT, OrgRole.PROJECT_MANAGER))
+                    .thenReturn(List.of(manager));
+
+            sweep.runPass();
+
+            assertThat(deliveredTo()).containsExactly(manager);
+        }
+
+        @Test
+        @DisplayName("nobody, rather than an administrator, when the project has neither")
+        void neverFallsBackToAdministrators() {
+            lowMaterial(30.0, 4.0);
+            when(employeeRepository.findByProjectAndOrgRole(eq(ORG), eq(PROJECT), any()))
+                    .thenReturn(List.of());
+
+            sweep.runPass();
+
+            verifyNoInteractions(notificationService);
+            // An organization administrator is a recipient the sweep must never reach for. It is
+            // the person least able to act on a site they do not run and the one most likely to
+            // mute the whole category, which loses every later crossing with it.
+            verify(employeeRepository, never())
+                    .findByOrganizationIdAndOrgRole(anyLong(), eq(OrgRole.SYSTEM_ADMIN));
+            verify(employeeRepository, never())
+                    .findByOrganizationIdAndOrgRole(anyLong(), eq(OrgRole.ORG_MANAGER));
+        }
+
+        @Test
+        @DisplayName("a crossing with nobody to tell is not latched, so it survives to be told later")
+        void doesNotSpendTheCrossingOnNobody() {
+            lowMaterial(30.0, 4.0);
+            when(employeeRepository.findByProjectAndOrgRole(eq(ORG), eq(PROJECT), any()))
+                    .thenReturn(List.of());
+
+            sweep.runPass();
+
+            verify(alertRepository, never()).saveAndFlush(any());
+        }
+
+        @Test
+        @DisplayName("one notification row per recipient, because a role has no row of its own")
+        void fansOutOneRowPerRecipient() {
+            Employee first = employee(101L);
+            Employee second = employee(102L);
+            lowMaterial(30.0, 4.0);
+            when(employeeRepository.findByProjectAndOrgRole(ORG, PROJECT, OrgRole.STORE_KEEPER))
+                    .thenReturn(List.of(first, second));
+
+            sweep.runPass();
+
+            assertThat(deliveredTo()).containsExactly(first, second);
+            assertThat(latched().getRecipientCount()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Crossing, not being below")
+    class Suppression {
+
+        @Test
+        @DisplayName("a material found low with no latch is reported and latched")
+        void reportsTheFirstCrossing() {
+            lowMaterial(30.0, 4.0);
+            withStorekeeper();
+
+            sweep.runPass();
+
+            MaterialReorderAlert alert = latched();
+            assertThat(alert.getNotifiedLevel()).isEqualTo(30.0);
+            assertThat(alert.getNotifiedQuantity()).isEqualTo(4.0);
+            assertThat(alert.getNotifiedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("a material still below its same level is not reported again")
+        void staysQuietWhileTheMaterialStaysDown() {
+            lowMaterial(30.0, 2.0);
+            withStorekeeper();
+            when(alertRepository.findByOrganization_IdAndProject_Id(ORG, PROJECT))
+                    .thenReturn(List.of(latch(30.0, 4.0)));
+
+            sweep.runPass();
+
+            verifyNoInteractions(notificationService);
+            verify(alertRepository, never()).saveAndFlush(any());
+        }
+
+        @Test
+        @DisplayName("a material whose level has moved is a new event, not the same one continuing")
+        void reportsAgainWhenTheLevelChanges() {
+            // Reported at 30, and somebody has since raised the level to 100. The material is
+            // below a line nobody has been told about, and without this it would stay latched
+            // permanently at exactly the moment it became badly short.
+            lowMaterial(100.0, 40.0);
+            withStorekeeper();
+            when(alertRepository.findByOrganization_IdAndProject_Id(ORG, PROJECT))
+                    .thenReturn(List.of(latch(30.0, 4.0)));
+
+            sweep.runPass();
+
+            assertThat(deliveredTo()).hasSize(1);
+            assertThat(latched().getNotifiedLevel()).isEqualTo(100.0);
+        }
+
+        @Test
+        @DisplayName("a hovering material is not re-reported the moment it ticks above its level")
+        void doesNotRearmOnASingleUnit() {
+            // Level 30, latched, and stock has crept back to 31. That is inside the rearm margin,
+            // so the latch stands and tomorrow's dip below 30 says nothing new.
+            withStorekeeper();
+            when(alertRepository.findByOrganization_IdAndProject_Id(ORG, PROJECT))
+                    .thenReturn(List.of(latch(30.0, 4.0)));
+            when(lowStockRepository.findProjectStockForMaterials(eq(ORG), eq(PROJECT), any()))
+                    .thenReturn(List.of(new ProjectMaterialStock(MATERIAL, 30.0, 31.0)));
+
+            sweep.runPass();
+
+            verify(alertRepository, never()).deleteAll(any());
+        }
+
+        @Test
+        @DisplayName("a material that recovers past the margin is rearmed")
+        void rearmsOnRealRecovery() {
+            withStorekeeper();
+            when(alertRepository.findByOrganization_IdAndProject_Id(ORG, PROJECT))
+                    .thenReturn(List.of(latch(30.0, 4.0)));
+            when(lowStockRepository.findProjectStockForMaterials(eq(ORG), eq(PROJECT), any()))
+                    .thenReturn(List.of(new ProjectMaterialStock(MATERIAL, 30.0, 40.0)));
+
+            sweep.runPass();
+
+            assertThat(deleted()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("a level of zero rearms at anything on hand, with no special case for it")
+        void rearmsAZeroLevelAtAnythingAtAll() {
+            // The margin is a fraction of the level, and a fraction of zero is zero. Somebody who
+            // set the level to zero asked to be told when the material is gone, so one unit back
+            // on the shelf is a real recovery.
+            withStorekeeper();
+            when(alertRepository.findByOrganization_IdAndProject_Id(ORG, PROJECT))
+                    .thenReturn(List.of(latch(0.0, 0.0)));
+            when(lowStockRepository.findProjectStockForMaterials(eq(ORG), eq(PROJECT), any()))
+                    .thenReturn(List.of(new ProjectMaterialStock(MATERIAL, 0.0, 1.0)));
+
+            sweep.runPass();
+
+            assertThat(deleted()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("a latch whose level has been cleared is dropped, because no line is drawn any more")
+        void dropsTheLatchWhenTheLevelIsUnset() {
+            withStorekeeper();
+            when(alertRepository.findByOrganization_IdAndProject_Id(ORG, PROJECT))
+                    .thenReturn(List.of(latch(30.0, 4.0)));
+            when(lowStockRepository.findProjectStockForMaterials(eq(ORG), eq(PROJECT), any()))
+                    .thenReturn(List.of(new ProjectMaterialStock(MATERIAL, null, 0.0)));
+
+            sweep.runPass();
+
+            assertThat(deleted()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("a latch for a material that holds nothing on the project stands")
+        void keepsTheLatchWhenTheMaterialHasNothingThere() {
+            // Every stock row gone reads as nothing on hand rather than as recovery, and
+            // re-reporting a material that holds nothing would say nothing new.
+            withStorekeeper();
+            when(alertRepository.findByOrganization_IdAndProject_Id(ORG, PROJECT))
+                    .thenReturn(List.of(latch(30.0, 4.0)));
+            when(lowStockRepository.findProjectStockForMaterials(eq(ORG), eq(PROJECT), any()))
+                    .thenReturn(List.of(new ProjectMaterialStock(MATERIAL, 30.0, 0.0)));
+
+            sweep.runPass();
+
+            verify(alertRepository, never()).deleteAll(any());
+        }
+
+        @Test
+        @DisplayName("losing the latch race to another replica is not a failure")
+        void survivesALostLatchRace() {
+            lowMaterial(30.0, 4.0);
+            withStorekeeper();
+            when(alertRepository.saveAndFlush(any()))
+                    .thenThrow(new DataIntegrityViolationException("uq_material_reorder_alert_scope"));
+
+            sweep.runPass();
+            // The pass carries on rather than ending the night for every other project.
+        }
+    }
+
+    @Nested
+    @DisplayName("What it must not do")
+    class Boundaries {
+
+        @Test
+        @DisplayName("every read and write of a tenant's rows happens under that tenant")
+        void establishesTheTenantBeforeReadingAnything() {
+            lowMaterial(30.0, 4.0);
+            withStorekeeper();
+
+            sweep.runPass();
+
+            assertThat(scopedTo).containsExactly(ORG);
+            // And the context is put back, so an organization id cannot leak onto the pooled
+            // scheduler thread and silently scope whatever runs there next.
+            assertThat(TenantContext.getCurrentOrgId()).isNull();
+        }
+
+        @Test
+        @DisplayName("it notifies and raises no procurement document")
+        void raisesNoPaperwork() {
+            lowMaterial(30.0, 4.0);
+            withStorekeeper();
+
+            sweep.runPass();
+
+            NotificationDraft draft = draft();
+            assertThat(draft.type()).isEqualTo(NotificationType.MATERIAL_LOW_STOCK);
+            assertThat(draft.entityType()).isEqualTo("MATERIAL");
+            assertThat(draft.entityId()).isEqualTo(MATERIAL);
+            // The sweep holds no procurement repository at all, so there is nothing for it to
+            // raise. The constructor is the assertion; this records why.
+        }
+
+        @Test
+        @DisplayName("a project that fails does not cost the rest of the estate its night")
+        void carriesOnAfterAFailingProject() {
+            when(lowStockRepository.findProjectsHoldingStock(any(Pageable.class)))
+                    .thenReturn(List.of(new StockedProject(ORG, 999L), new StockedProject(ORG, PROJECT)));
+            when(lowStockRepository.findLowStockForProject(eq(ORG), eq(999L), any(Pageable.class)))
+                    .thenThrow(new IllegalStateException("bad project"));
+            lowMaterial(30.0, 4.0);
+            withStorekeeper();
+
+            sweep.runPass();
+
+            assertThat(deliveredTo()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("the per-run cap counts what every replica raised, not just this one")
+        void sharesTheCapAcrossReplicas() {
+            properties.setMaxNotificationsPerRun(5);
+            when(alertRepository.countByNotifiedAtGreaterThanEqual(any())).thenReturn(5L);
+            lowMaterial(30.0, 4.0);
+            withStorekeeper();
+
+            sweep.runPass();
+
+            verifyNoInteractions(notificationService);
+        }
+
+        @Test
+        @DisplayName("the message names the shortfall in the material's own unit")
+        void saysWhatIsShort() {
+            lowMaterial(30.0, 4.0);
+            withStorekeeper();
+
+            sweep.runPass();
+
+            assertThat(draft().title()).isEqualTo("Low stock: TNT Steel");
+            assertThat(draft().message())
+                    .contains("TNT Steel")
+                    .contains("4 kg")
+                    .contains("Marina Tower")
+                    .contains("30");
+        }
+    }
+
+    // ---- fixtures -------------------------------------------------------------------------
+
+    private void lowMaterial(Double level, Double onHand) {
+        when(lowStockRepository.findLowStockForProject(eq(ORG), eq(PROJECT), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(new LowStockRow(
+                        MATERIAL, "TNT-01", "TNT Steel", "kg", 100.0, level, onHand))));
+    }
+
+    private void withStorekeeper() {
+        when(employeeRepository.findByProjectAndOrgRole(ORG, PROJECT, OrgRole.STORE_KEEPER))
+                .thenReturn(List.of(employee(101L)));
+    }
+
+    private MaterialReorderAlert latch(Double level, Double quantity) {
+        MaterialReorderAlert alert = new MaterialReorderAlert();
+        alert.setId(1L);
+        Material material = new Material();
+        material.setId(MATERIAL);
+        alert.setMaterial(material);
+        alert.setNotifiedLevel(level);
+        alert.setNotifiedQuantity(quantity);
+        alert.setRecipientCount(1);
+        alert.setNotifiedAt(LocalDateTime.now().minusDays(3));
+        return alert;
+    }
+
+    private Employee employee(Long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        employee.setOrganization(new Organization());
+        return employee;
+    }
+
+    private Project project(String name) {
+        Project project = new Project();
+        project.setId(PROJECT);
+        project.setProjectName(name);
+        return project;
+    }
+
+    private Page<LowStockRow> emptyPage() {
+        return new PageImpl<>(List.of());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Employee> deliveredTo() {
+        ArgumentCaptor<Collection<Employee>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(notificationService).deliverToAll(captor.capture(), any());
+        return new ArrayList<>(captor.getValue());
+    }
+
+    private NotificationDraft draft() {
+        ArgumentCaptor<NotificationDraft> captor = ArgumentCaptor.forClass(NotificationDraft.class);
+        verify(notificationService).deliverToAll(any(), captor.capture());
+        return captor.getValue();
+    }
+
+    private MaterialReorderAlert latched() {
+        ArgumentCaptor<MaterialReorderAlert> captor =
+                ArgumentCaptor.forClass(MaterialReorderAlert.class);
+        verify(alertRepository).saveAndFlush(captor.capture());
+        return captor.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<MaterialReorderAlert> deleted() {
+        ArgumentCaptor<Iterable<MaterialReorderAlert>> captor =
+                ArgumentCaptor.forClass(Iterable.class);
+        verify(alertRepository).deleteAll(captor.capture());
+        List<MaterialReorderAlert> all = new ArrayList<>();
+        captor.getValue().forEach(all::add);
+        return all;
+    }
+}


### PR DESCRIPTION
Closes #667.

The query half of this was built (#652, PR #663) and nothing scheduled it, because the issue named three questions that had to be answered before a job could exist. Here are the answers and the job that follows from them.

## It notifies. It raises nothing.

No purchase order, no indent, no procurement document of any kind, and no approval workflow. That is the decision, not an omission. A nightly job that raised paperwork would be creating documents carrying approvals and money on nobody's instruction. Ignoring a notification is free; withdrawing an indent is not.

## Who is told

The storekeepers assigned to the project. If it has none, its project managers. Nobody otherwise.

`OrgRole.STORE_KEEPER` landed with #650, and it is exactly the person who books the goods receipt that answers a shortfall, which is the whole test for a recipient: can they act on it, in this application, today. An organization administrator is deliberately **not** the third rung. They cannot act on a site they do not run, and the issue names them correctly as the recipient most likely to mute the category, which loses every later crossing along with this one.

A project with nobody in either role is counted and logged, and no notification is sent **and no latch is written**, so the first crossing still reaches whoever is eventually assigned rather than having been silently spent on nobody.

Org roles are read from the `Employee` row where Keycloak's groups are mirrored. The admin client is user-id-in only with no reverse lookup from a subgroup to its members, so "who holds this role" is a question only the database can answer. `Project` has no manager field either, so the intersection of the project's assignment list with the role holders is a new query.

## Project scope, not organization and not location

The organization total hides precisely what this is for: on staging `TNT Steel` reads healthy at 60 against a level of 30 while holding 1, 18, 1, 7 and 1 unit at five separate sites. Location scope is one event per shelf and has no recipient of its own, because the person told about a location is the storekeeper on its project.

## What "low" means, including the unset case

Not restated by the job. It calls `LowStockRepository.findLowStockForProject`, the same read the endpoint answers from, so the two cannot drift apart. What that gives:

- **At or below**, not below. A reorder level is the level at which you reorder.
- **A null level is never reported, at any scope.** Nobody has said what low means for that material. A job that guessed would invent a threshold and then wake somebody about it.
- **A level of zero is a set level.** Somebody drew the line at nothing on hand. It reads as "tell me when it is gone" and is reported once the material holds nothing, never before. This is the state most easily conflated with the one above and it is a different state entirely.
- **Only materials the project carries.** Project scope inner-joins, so the catalogue is not reported as absent from every project that never held it.

## Repeat suppression: crossing, not being below

Being below is a standing fact and the endpoint answers it on demand. Re-sending it nightly is how the category gets muted. So `material_reorder_alert` latches (organization, project, material): a row means "reported, and not recovered since".

Two things end a latch, and the first is the answer to a material that hovers:

- **Recovery past a margin.** The latch clears once the project holds more than the level plus `rearm-margin` of it (10% by default), not the moment it ticks one unit above. Without the margin, a material oscillating on the boundary is re-reported every pass, which is the same nightly re-raise reached from the other side. A level of zero needs no special case: a fraction of zero is zero, so it rearms at anything on hand.
- **The level moving.** A material reported at 30 and now measured against 100 is below a different line than the one anybody was told about. Without this, raising a level latches a material permanently at the moment it becomes badly short.

A material that stays down for a month is reported once. That is intended: the notification says something changed, and the standing list of what is short is the endpoint's job.

The unique constraint on the latch is also the idempotency key. `@Scheduled` elects no leader, so on N replicas the pass runs N times, and the constraint is what makes the second replica's insert fail rather than the storekeeper be told twice. The notification subsystem has no idempotency key of its own: `(entity_type, entity_id)` is indexed but not unique, and the key here is a pair one id column cannot hold anyway.

## Safety

- **Off by default.** `inventory.reorder-sweep.enabled` is false and the bean is `@ConditionalOnProperty`, so nothing exists until somebody turns it on.
- **03:30 UTC, not 02:00.** `development` is deployed to both stagings and already carries the compliance re-assessment pass at 02:00. No reason to put both on the same minute.
- **Tenant scope.** The pass is `@WithoutTenant` with a reason and reads two ids at that level. Every read and write of a tenant's rows runs inside `TenantScopedJobRunner.runForTenant`. Both isolation mechanisms fail *open* on a missing organization id and `UnscopedAccessGuard` warns rather than denies, so a scheduled job that forgot its scope would read every tenant's rows and look healthy doing it.
- **Nothing throws out of the trigger.** Spring stops rescheduling a `@Scheduled` method that throws.
- **Bounded.** A scan cap on projects, a per-project cap on materials (most depleted first), and a per-run notification cap counted from the table rather than a local variable, so N replicas share one budget instead of having one each.

## The notification seam

`NotificationService` had five hardcoded senders, each with a `LeaveRequest` in its signature, so nothing outside that package could raise a notification without a sixth being written for it there. `NotificationDraft` splits the message from the recipient, which is also what role targeting needs: `Notification.recipient` is a single employee foreign key, so a role-targeted notification is a fan-out and the wording has to be composed once and delivered N times.

## Tests, and what each one actually proves

- **`LowStockSweepTest`** exercises the **logic**. It calls `runPass()` directly, so it says nothing about the schedule. It covers the recipient tiers including the never-fall-back-to-admin rule, the first crossing, the hovering material inside the margin, real recovery, a zero level rearming at one unit, a cleared level, a material holding nothing on the project, the level-moved re-notify, the lost latch race, the shared cap, and that the tenant context is established and restored. It uses the real `TenantScopedJobRunner`, subclassed only to record what it was scoped to, because stubbing it out would remove the one thing standing between the job and every tenant's rows.
- **`LowStockSweepScheduleTest`** exercises the **trigger declaration**. That the `@Scheduled` exists and reads from configuration, that the default cron parses, that its first firing does not coincide with the compliance sweep's, that `@ConditionalOnProperty` is off by default, that `@WithoutTenant` carries a reason, and that a failing pass does not throw out of `sweep()`. Nothing here waits for a cron to fire, and it does not claim to.

The tests are the commit before the implementation, so the red is on the record.

## Migration

`093-material-reorder-alert.xml`, one new table with a unique constraint, two indexes and cascading foreign keys. Nothing existing is altered.