### PR TITLE
Repair the issue guards and the mobile join route, and inventory what is left

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -57080,7 +57080,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -57214,7 +57214,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -57324,7 +57324,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -59503,7 +59503,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -34239,7 +34239,7 @@
                 }
               }
             },
-            "description": "Caller lacks the employee create or admin authority, or named an organization that is not the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or named an organization that is not it"
           },
           "404": {
             "content": {
@@ -57080,7 +57080,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue create or admin authority, or has no employee record in the current tenant, so the record would name nobody"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -57214,7 +57214,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue-comment read or admin authority"
+            "description": "Caller lacks the required role in the current tenant"
           },
           "404": {
             "content": {
@@ -57324,7 +57324,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue-comment create or admin authority, or has no employee record in the current tenant, so the record would name nobody"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -58142,7 +58142,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue-comment delete or admin authority"
+            "description": "Caller lacks the required role in the current tenant"
           },
           "404": {
             "content": {
@@ -59392,7 +59392,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue delete or admin authority"
+            "description": "Caller lacks the required role in the current tenant"
           },
           "404": {
             "content": {
@@ -59503,7 +59503,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue read or admin authority"
+            "description": "Caller lacks the required role in the current tenant"
           },
           "404": {
             "content": {
@@ -59644,7 +59644,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue update or admin authority"
+            "description": "Caller lacks the required role in the current tenant"
           },
           "404": {
             "content": {
@@ -108995,7 +108995,7 @@
       "name": "Inventory Transactions (Web)"
     },
     {
-      "description": "A comment left on an issue, carrying the comment text, its author and a timestamp. Endpoints cover creation, paginated listing and deletion, gated by the issue-comment authorities, with an admin authority that grants all operations.",
+      "description": "A comment left on an issue, carrying the comment text, its author and a timestamp. Endpoints cover creation, paginated listing and deletion, gated by tenant membership, with deletion restricted to a system admin or project manager.",
       "name": "Issue Comments"
     },
     {
@@ -109007,7 +109007,7 @@
       "name": "Issues"
     },
     {
-      "description": "A problem or defect raised against a task, optionally with attachments and comments. Endpoints cover reading a single issue, creating one with attachments, partial updates and deletion. Access is gated by the issue authorities, with an admin authority that grants all operations.",
+      "description": "A problem or defect raised against a task, optionally with attachments and comments. Endpoints cover reading a single issue, creating one with attachments, partial updates and deletion. Access is gated by tenant membership, with update and delete restricted to a system admin or project manager.",
       "name": "Issues"
     },
     {

--- a/docs/org-scoped-roles.md
+++ b/docs/org-scoped-roles.md
@@ -430,6 +430,16 @@ You can combine them in `@PreAuthorize` using `or` and `and`:
 
 This reads as: "Allow if the user is a system-admin of THIS org, OR has global employee:read permission AND is a member of this org, OR is a global employee admin."
 
+> **Layer 1 does not work in this realm, and new guards should not use it.** A bare
+> `resource:scope` authority such as `employee:read` is minted in exactly one place,
+> `JwtAuthConverter.extractPermissions`, which reads the `authorization` claim of an RPT.
+> The realm defines no authorization scopes: `ensureDefaultResource` registers a Default
+> Resource and never calls `setScopes`, and a permission carrying no scopes yields no
+> authority. So `hasAuthority('thing:action')` is satisfied by nobody. ORed with nothing
+> else it refuses every caller; ANDed onto a working check it refuses every caller too.
+> Guard on layer 2 or layer 3 instead. Issues #641, #684, #710, #716 and #734 are the
+> repairs; #734 carries the inventory of what is still standing.
+
 ---
 
 ## What Happens in the JWT Token

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
@@ -25,8 +25,8 @@ import java.util.List;
 @Tag(
         name = "Issue Comments",
         description = "A comment left on an issue, carrying the comment text, its author and a "
-                + "timestamp. Endpoints cover creation, paginated listing and deletion, gated by the "
-                + "issue-comment authorities, with an admin authority that grants all operations."
+                + "timestamp. Endpoints cover creation, paginated listing and deletion, gated by "
+                + "tenant membership, with deletion restricted to a system admin or project manager."
 )
 public class IssueCommentController {
 
@@ -37,7 +37,7 @@ public class IssueCommentController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAuthority('issue-comment:create') or hasAuthority('issue-comment:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Create an issue comment",
             description = "Adds a comment to the given issue."
@@ -45,7 +45,7 @@ public class IssueCommentController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Comment created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment create or admin authority, or has no employee record in the current tenant, so the record would name nobody"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueCommentSimpleDto> createIssueComment(@Valid @RequestBody IssueCommentCreationDto issueCommentCreationDto) {
@@ -54,7 +54,7 @@ public class IssueCommentController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAuthority('issue-comment:read') or hasAuthority('issue-comment:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "List issue comments",
             description = "Returns a single page of issue comments. The pageNo and pageSize parameters "
@@ -62,7 +62,7 @@ public class IssueCommentController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of comments returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment read or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@Valid @ParameterObject PageQuery pageQuery) {
         Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageQuery.getPageNo(),pageQuery.getPageSize());
@@ -70,14 +70,14 @@ public class IssueCommentController {
     }
 
     @DeleteMapping("{id}")
-    @PreAuthorize("hasAuthority('issue-comment:delete') or hasAuthority('issue-comment:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Delete an issue comment",
             description = "Deletes the comment with the given id."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Comment deleted"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No comment with the given id")
     })
     public ResponseEntity<ApiResponse> deleteAnIssueComment(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
@@ -45,7 +45,7 @@ public class IssueCommentController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Comment created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueCommentSimpleDto> createIssueComment(@Valid @RequestBody IssueCommentCreationDto issueCommentCreationDto) {
@@ -62,7 +62,7 @@ public class IssueCommentController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of comments returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
     public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@Valid @ParameterObject PageQuery pageQuery) {
         Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageQuery.getPageNo(),pageQuery.getPageSize());

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
@@ -61,13 +61,19 @@ public class EmployeeController {
      * Nothing about onboarding passes through here, so binding the guard to an organization
      * costs that flow nothing.
      *
-     * <p>{@code employee:create} and {@code employee:admin} are Keycloak resource permissions
-     * carried on the RPT, and {@code docs/org-scoped-roles.md} calls them global: they say what
-     * the holder may do and nothing at all about where. On a route that names an organization in
+     * <p>The organization check has to be here or nowhere. The route names an organization in
      * its path and then loads {@link org.tornotron.echno_backend.organization.Organization} by
-     * that id, "what" on its own is not an answer. The tenant root is the one entity neither
-     * ambient defence covers, so the id has to be checked here or not at all, which is what
+     * that id, and the tenant root is the one entity neither ambient defence covers, which is what
      * {@code isCurrentTenant} does.
+     *
+     * <p>Beside it stood {@code employee:create} or {@code employee:admin}, ANDed on. Those are
+     * bare {@code resource:scope} authorities, minted only by
+     * {@code JwtAuthConverter.extractPermissions} from the {@code authorization} claim of an RPT,
+     * and the realm defines no authorization scopes, so neither is ever granted and the whole
+     * expression refused every caller. That is #734. The half saying who may add somebody to an
+     * organization is now the one the web twin has always used: a system admin or an HR admin of
+     * the tenant the session is scoped to. Both halves are still needed, because being scoped to
+     * an organization is not the same as being entitled to enrol people into it.
      *
      * @param userId             The ID of the user joining.
      * @param orgId              The organization named by the caller, which must be the one their
@@ -77,7 +83,7 @@ public class EmployeeController {
      */
     @PostMapping("/joinOrganization/{userId}/{orgId}")
     @PreAuthorize("@orgSecurity.isCurrentTenant(#orgId)"
-            + " and (hasAuthority('employee:create') or hasAuthority('employee:admin'))")
+            + " and @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Add a user to an organization as an employee",
             description = "Creates an employee record that links the given user to the organization "
@@ -87,7 +93,7 @@ public class EmployeeController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Employee record created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The employment details failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee create or admin authority, or named an organization that is not the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or named an organization that is not it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user or organization with the given id")
     })
     public ResponseEntity<EmployeeDto> joinOrganization(@PathVariable Long userId, @PathVariable Long orgId, @Valid @RequestBody EmployeeJoinOrgDto employeeJoinOrgDto) {

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
@@ -63,7 +63,7 @@ public class IssueController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueDto> readAnIssue(@PathVariable Long id) {
@@ -82,7 +82,7 @@ public class IssueController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Issue created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so the record would name nobody")
     })
     public ResponseEntity<IssueSimpleDto> createIssue(
             @Parameter(schema = @Schema(implementation = IssueCreationDto.class))

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
@@ -31,8 +31,8 @@ import org.tornotron.echno_backend.issue.dto.IssueUpdateFieldsDto;
         name = "Issues",
         description = "A problem or defect raised against a task, optionally with attachments and "
                 + "comments. Endpoints cover reading a single issue, creating one with attachments, "
-                + "partial updates and deletion. Access is gated by the issue authorities, with an "
-                + "admin authority that grants all operations."
+                + "partial updates and deletion. Access is gated by tenant membership, with update "
+                + "and delete restricted to a system admin or project manager."
 )
 public class IssueController {
 
@@ -56,14 +56,14 @@ public class IssueController {
 
 
     @GetMapping("{id}")
-    @PreAuthorize("hasAuthority('issue:read') or hasAuthority('issue:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get an issue by id",
             description = "Returns a single issue including its comments and attachments."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueDto> readAnIssue(@PathVariable Long id) {
@@ -72,7 +72,7 @@ public class IssueController {
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PreAuthorize("hasAuthority('issue:create') or hasAuthority('issue:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Create an issue",
             description = "Creates an issue from a multipart request. The data part carries the issue "
@@ -82,7 +82,7 @@ public class IssueController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Issue created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue create or admin authority, or has no employee record in the current tenant, so the record would name nobody")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody")
     })
     public ResponseEntity<IssueSimpleDto> createIssue(
             @Parameter(schema = @Schema(implementation = IssueCreationDto.class))
@@ -94,7 +94,7 @@ public class IssueController {
     }
 
     @PatchMapping(value = "{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PreAuthorize("hasAuthority('issue:update') or hasAuthority('issue:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Partially update an issue",
             description = "Applies field updates from a multipart request. The data part carries the "
@@ -104,7 +104,7 @@ public class IssueController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueSimpleDto> partialUpdateAnIssue(
@@ -119,14 +119,14 @@ public class IssueController {
     }
 
     @DeleteMapping("{id}")
-    @PreAuthorize("hasAuthority('issue:delete') or hasAuthority('issue:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Delete an issue",
             description = "Deletes the issue with the given id."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue deleted"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<ApiResponse> deleteAnIssue(@PathVariable Long id) {

--- a/src/test/java/org/tornotron/echno_backend/IssueComment/IssueCommentMobileGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/IssueComment/IssueCommentMobileGuardTest.java
@@ -1,0 +1,182 @@
+package org.tornotron.echno_backend.IssueComment;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The mobile {@code IssueCommentController} was dead end to end: all three of its guards named an
+ * {@code issue-comment} authority, and {@code JwtAuthConverter.extractPermissions} mints a
+ * {@code resource:scope} authority only from the {@code authorization} claim of an RPT, which the
+ * realm never populates because it defines no authorization scopes. See #734.
+ *
+ * <p>Nothing was lost while it stayed dead, because the web twin carries working versions, which
+ * is exactly why it went unnoticed. It surfaced when #676 added an edit to the twin and
+ * deliberately did not add one here: a new endpoint on this controller would have arrived
+ * refusing every caller.
+ *
+ * <p>Repaired to the twin's answer rather than to the widest expression that makes the endpoints
+ * reachable. Leaving a comment on an issue, and reading the comments on one, is any member's;
+ * deleting somebody else's comment is a system admin's or a project manager's. The twin's edit
+ * endpoint, which is the author's own, has no counterpart here and none is added: adding a route
+ * is a contract change, and this repair deliberately changes no route.
+ *
+ * <p>Roles are stubbed as the exact list the guard names. A stub answering true to
+ * {@code any(String[].class)} would keep passing if the delete quietly admitted every member.
+ */
+@WebMvcTest(IssueCommentController.class)
+@Import(IssueCommentMobileGuardTest.TestSecurityConfig.class)
+class IssueCommentMobileGuardTest {
+
+    private static final long COMMENT = 11L;
+
+    /** The pair the web twin's delete names. */
+    private static final String[] DELETE_ROLES = {"system-admin", "project-manager"};
+
+    /**
+     * Valid against {@code IssueCommentCreationDto}. Body validation runs while arguments are
+     * bound, which is before the method-security interceptor, so an invalid body would answer 400
+     * and say nothing at all about the guard.
+     */
+    private static final String VALID_BODY = """
+            {"comment":"Rebar spacing checked on the east face","issueId":42}
+            """;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IssueCommentService issueCommentService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    private void callerIsAnOutsider() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+    }
+
+    private void callerIsAPlainMember() {
+        callerIsAnOutsider();
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+    }
+
+    private void callerIsAProjectManager() {
+        callerIsAPlainMember();
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(DELETE_ROLES)).thenReturn(true);
+    }
+
+    @Test
+    void create_asAMemberOfTheTenant_isAllowed() throws Exception {
+        callerIsAPlainMember();
+
+        mockMvc.perform(post("/api/v1/issues/comments")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void create_asSomebodyOutsideTheTenant_isForbidden() throws Exception {
+        callerIsAnOutsider();
+
+        mockMvc.perform(post("/api/v1/issues/comments")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueCommentService);
+    }
+
+    @Test
+    void list_asAMemberOfTheTenant_isAllowed() throws Exception {
+        callerIsAPlainMember();
+
+        mockMvc.perform(get("/api/v1/issues/comments").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void list_asSomebodyOutsideTheTenant_isForbidden() throws Exception {
+        callerIsAnOutsider();
+
+        mockMvc.perform(get("/api/v1/issues/comments").with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueCommentService);
+    }
+
+    @Test
+    void delete_asAProjectManager_isAllowed() throws Exception {
+        callerIsAProjectManager();
+
+        mockMvc.perform(delete("/api/v1/issues/comments/{id}", COMMENT).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void delete_asAPlainMember_isForbidden() throws Exception {
+        callerIsAPlainMember();
+
+        mockMvc.perform(delete("/api/v1/issues/comments/{id}", COMMENT).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueCommentService);
+    }
+
+    /** The repaired guards keep no branch on the authority the realm cannot issue. */
+    @Test
+    void theOldAuthorityAloneOpensNothing() throws Exception {
+        callerIsAnOutsider();
+
+        mockMvc.perform(get("/api/v1/issues/comments")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("issue-comment:admin"))))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueCommentService);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/IssueComment/IssueCommentMobileGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/IssueComment/IssueCommentMobileGuardTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -18,6 +19,7 @@ import org.tornotron.echno_backend.common.configuration.RPTCache;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -121,9 +123,15 @@ class IssueCommentMobileGuardTest {
         verifyNoInteractions(issueCommentService);
     }
 
+    /**
+     * The listing calls {@code getContent()} on what the service returns, so the empty page has to
+     * be stubbed. An unstubbed mock answers null and the request would fail on that rather than on
+     * the guard, which is the assertion this test is making.
+     */
     @Test
     void list_asAMemberOfTheTenant_isAllowed() throws Exception {
         callerIsAPlainMember();
+        when(issueCommentService.getAllIssueComments(anyInt(), anyInt())).thenReturn(Page.empty());
 
         mockMvc.perform(get("/api/v1/issues/comments").with(jwt()))
                 .andExpect(status().isOk());

--- a/src/test/java/org/tornotron/echno_backend/architecture/PhantomAuthorityCensusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PhantomAuthorityCensusTest.java
@@ -65,9 +65,14 @@ class PhantomAuthorityCensusTest {
     /**
      * A bare {@code resource:scope} authority. The colon is what distinguishes it from a realm
      * role, which carries no scope and is granted by an ordinary role claim.
+     *
+     * <p>Both halves are deliberately anything-but-a-quote-or-colon rather than a character class.
+     * {@code extractPermissions} concatenates the resource name and the scope straight out of the
+     * token without validating either, so a guard naming {@code employee:read_all} would be just
+     * as unsatisfiable and a tighter pattern would walk past it.
      */
     private static final Pattern PHANTOM_AUTHORITY =
-            Pattern.compile("hasAuthority\\('[A-Za-z][A-Za-z0-9-]*:[A-Za-z][A-Za-z0-9-]*'\\)");
+            Pattern.compile("hasAuthority\\('[^':]+:[^':]+'\\)");
 
     private static final List<Class<? extends Annotation>> MAPPINGS = List.of(
             RequestMapping.class, GetMapping.class, PostMapping.class,

--- a/src/test/java/org/tornotron/echno_backend/architecture/PhantomAuthorityCensusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PhantomAuthorityCensusTest.java
@@ -1,0 +1,196 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A ratchet over the endpoints still guarded by an authority the realm cannot issue, so the
+ * number can only come down and a new one cannot arrive unnoticed.
+ *
+ * <h2>What is being counted</h2>
+ *
+ * <p>{@code JwtAuthConverter.extractPermissions} is the only place a {@code resource:scope}
+ * authority is minted, and it reads the {@code authorization} claim of an RPT. The realm defines
+ * no authorization scopes: {@code ensureDefaultResource} registers a Default Resource and never
+ * calls {@code setScopes}, and a permission with no scopes yields no authority. So a guard of the
+ * form {@code hasAuthority('thing:action')} is never satisfied. ORed with nothing else it refuses
+ * every caller; ANDed onto a working check it refuses every caller too. Established by #641,
+ * #684, #710 and #716, and inventoried in #734.
+ *
+ * <p>The raw grep in #734 reported 168 lines containing {@code hasAuthority(}, deliberately as an
+ * upper bound. That figure counts commented-out annotations, non-guard uses of the same string in
+ * {@code TenantFilter} and {@code OrganizationSecurityService}, and whole modules already
+ * repaired. Reading the annotations instead, on {@code development} at the time of writing, the
+ * live figure was 136 guards on 17 controllers. This test counts the same way, so a
+ * {@code hasAuthority} left in a comment or in prose does not move it.
+ *
+ * <h2>Why the remainder is left standing</h2>
+ *
+ * <p>Every entry below is a mobile controller whose {@code /web} twin carries the working
+ * version, so nothing a user does today is blocked by one. Repairing them is not one decision
+ * but three, taken per module: a dead read whose twin is alive is usually a surface that should
+ * work, a dead write may still be required (the mobile leave endpoints were repaired for exactly
+ * that reason), and an endpoint with no caller anywhere is a removal candidate, which is a change
+ * to a published contract rather than a repair to a guard. This map is what that decision has to
+ * be taken against.
+ *
+ * <p>Removing an entry means the controller was repaired or removed. Adding one, or raising a
+ * number, means a guard nobody can satisfy has just been written, and the fix is the guard rather
+ * than this file.
+ */
+class PhantomAuthorityCensusTest {
+
+    /**
+     * A bare {@code resource:scope} authority. The colon is what distinguishes it from a realm
+     * role, which carries no scope and is granted by an ordinary role claim.
+     */
+    private static final Pattern PHANTOM_AUTHORITY =
+            Pattern.compile("hasAuthority\\('[A-Za-z][A-Za-z0-9-]*:[A-Za-z][A-Za-z0-9-]*'\\)");
+
+    private static final List<Class<? extends Annotation>> MAPPINGS = List.of(
+            RequestMapping.class, GetMapping.class, PostMapping.class,
+            PutMapping.class, PatchMapping.class, DeleteMapping.class);
+
+    /**
+     * Controller simple name to the number of its request-mapped methods still guarded by an
+     * authority the realm cannot issue. Ordered, so a failure reads as a diff.
+     */
+    private static final Map<String, Integer> EXPECTED = new TreeMap<>(Map.ofEntries(
+            Map.entry("CategoryController", 4),
+            Map.entry("EmployeeController", 1),
+            Map.entry("GoodsReceivedNoteController", 7),
+            Map.entry("IndentController", 9),
+            Map.entry("IndentItemController", 10),
+            Map.entry("InventoryTransactionController", 13),
+            Map.entry("MaterialConsumptionController", 8),
+            Map.entry("MaterialController", 12),
+            Map.entry("OrganizationController", 4),
+            Map.entry("PayableController", 7),
+            Map.entry("ProjectController", 9),
+            Map.entry("SiteTransferController", 10),
+            Map.entry("StorageLocationController", 6),
+            Map.entry("TaskController", 5),
+            Map.entry("VendorController", 23)));
+
+    @Test
+    void theRemainingPhantomGuardsAreExactlyTheOnesRecorded() {
+        assertThat(census()).isEqualTo(EXPECTED);
+    }
+
+    /**
+     * The Issues module and the mobile join route were the coherent subset repaired first, so
+     * naming them keeps the boundary explicit: a phantom guard reappearing on one of these is a
+     * regression rather than a leftover.
+     */
+    @Test
+    void theRepairedControllersCarryNoPhantomGuardAtAll() {
+        assertThat(census()).doesNotContainKeys(
+                "IssueController", "IssueCommentController");
+    }
+
+    /** The single remaining employee guard is the create route, which is proposed for removal. */
+    @Test
+    void theOnlyEmployeeGuardLeftIsTheCreateRouteThatCannotSucceed() {
+        assertThat(phantomGuardedMethodNames("EmployeeController"))
+                .containsExactly("createEmployee");
+    }
+
+    /** Guards against the whole thing passing because the scan found nothing to look at. */
+    @Test
+    void theScanFoundTheControllers() {
+        assertThat(controllers()).hasSizeGreaterThan(60);
+    }
+
+    private static Map<String, Integer> census() {
+        Map<String, Integer> found = new TreeMap<>();
+        for (Class<?> controller : controllers()) {
+            int count = phantomGuardedMethodNames(controller).size();
+            if (count > 0) {
+                found.put(controller.getSimpleName(), count);
+            }
+        }
+        return found;
+    }
+
+    private static List<String> phantomGuardedMethodNames(String simpleName) {
+        for (Class<?> controller : controllers()) {
+            if (controller.getSimpleName().equals(simpleName)) {
+                return phantomGuardedMethodNames(controller);
+            }
+        }
+        throw new AssertionError("No controller named " + simpleName + " on the classpath");
+    }
+
+    private static List<String> phantomGuardedMethodNames(Class<?> controller) {
+        return java.util.Arrays.stream(controller.getDeclaredMethods())
+                .filter(method -> !method.isSynthetic() && !method.isBridge())
+                .filter(PhantomAuthorityCensusTest::isRequestMapped)
+                .filter(method -> isPhantomGuarded(method, controller))
+                .map(Method::getName)
+                .sorted()
+                .toList();
+    }
+
+    private static boolean isRequestMapped(Method method) {
+        for (Class<? extends Annotation> mapping : MAPPINGS) {
+            if (AnnotatedElementUtils.hasAnnotation(method, mapping)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isPhantomGuarded(Method method, Class<?> controller) {
+        PreAuthorize guard = AnnotatedElementUtils.findMergedAnnotation(method, PreAuthorize.class);
+        if (guard == null) {
+            guard = AnnotatedElementUtils.findMergedAnnotation(controller, PreAuthorize.class);
+        }
+        if (guard == null) {
+            return false;
+        }
+        Matcher matcher = PHANTOM_AUTHORITY.matcher(guard.value());
+        return matcher.find();
+    }
+
+    private static List<Class<?>> controllers() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(RestController.class));
+        Set<BeanDefinition> candidates = scanner.findCandidateComponents("org.tornotron.echno_backend");
+        return candidates.stream()
+                .map(BeanDefinition::getBeanClassName)
+                .sorted()
+                .map(PhantomAuthorityCensusTest::load)
+                .toList();
+    }
+
+    private static Class<?> load(String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError("Scanned a controller that will not load: " + className, e);
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeMobileJoinGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeMobileJoinGuardTest.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationSer
 import org.tornotron.echno_backend.common.configuration.RPTCache;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -49,10 +50,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * service does not stand in for a guard either, because {@code Employee} is filtered, so it
  * evaluates within the caller's own tenant and cannot see a row in another one.
  *
- * <p>The caller modelled here holds {@code employee:create} and is a member of
- * {@link #OWN_ORG}. {@code @orgSecurity} is mocked so the tenant branch is exercised without
- * building JWT group claims; the authority is real, granted on the token, because that half of
- * the expression is what has to keep working.
+ * <p>The authority half was the other half of the problem, and it is gone. {@code employee:create}
+ * and {@code employee:admin} are bare {@code resource:scope} authorities, minted only by
+ * {@code JwtAuthConverter.extractPermissions} from the {@code authorization} claim of an RPT, and
+ * the realm defines no authorization scopes, so neither is ever granted. ANDed onto a working
+ * tenant check it refused every caller, which is what #734 records. The half that says who may add
+ * somebody to an organization is now the web twin's: a system admin or an HR admin of the tenant
+ * the session is scoped to.
+ *
+ * <p>{@code @orgSecurity} is mocked so both branches are exercised without building JWT group
+ * claims, and the role list is stubbed exactly rather than through {@code any(String[].class)}, so
+ * a guard that widened to every member would fail here rather than pass.
  */
 @WebMvcTest(EmployeeController.class)
 @Import(EmployeeMobileJoinGuardTest.TestSecurityConfig.class)
@@ -84,16 +92,27 @@ class EmployeeMobileJoinGuardTest {
     @MockitoBean
     private RPTCache rptCache;
 
+    /** The pair the web twin's joinOrganization names. */
+    private static final String[] JOIN_ROLES = {"system-admin", "hr-admin"};
+
     @BeforeEach
     void callerIsEntitledToTheirOwnOrganizationOnly() {
         when(orgSecurity.isCurrentTenant(OWN_ORG)).thenReturn(true);
         when(orgSecurity.isCurrentTenant(FOREIGN_ORG)).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+    }
+
+    /** An HR admin of the tenant the session is scoped to. */
+    private void callerIsAnHrAdmin() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(JOIN_ROLES)).thenReturn(true);
     }
 
     @Test
     void join_intoAnotherOrganization_isForbiddenAndNeverReachesTheService() throws Exception {
+        callerIsAnHrAdmin();
+
         mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + FOREIGN_ORG)
-                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:create")))
+                        .with(jwt())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(VALID_BODY))
                 .andExpect(status().isForbidden());
@@ -104,9 +123,25 @@ class EmployeeMobileJoinGuardTest {
     }
 
     @Test
-    void join_holdingTheGlobalAdminAuthorityIntoAnotherOrganization_isAlsoForbidden() throws Exception {
-        mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + FOREIGN_ORG)
-                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:admin")))
+    void join_intoTheCallersOwnOrganization_isAllowed() throws Exception {
+        callerIsAnHrAdmin();
+
+        mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + OWN_ORG)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isCreated());
+    }
+
+    /**
+     * The role half of the expression still has to be satisfied on its own. Being scoped to the
+     * organization is not a substitute for holding the role, or every member of an organization
+     * could add employees to it.
+     */
+    @Test
+    void join_intoTheCallersOwnOrganizationWithoutTheRole_isForbidden() throws Exception {
+        mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + OWN_ORG)
+                        .with(jwt())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(VALID_BODY))
                 .andExpect(status().isForbidden());
@@ -114,24 +149,14 @@ class EmployeeMobileJoinGuardTest {
         verifyNoInteractions(employeeService);
     }
 
-    @Test
-    void join_intoTheCallersOwnOrganization_isStillAllowed() throws Exception {
-        mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + OWN_ORG)
-                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:create")))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(VALID_BODY))
-                .andExpect(status().isCreated());
-    }
-
     /**
-     * The authority half of the expression still has to be satisfied on its own. Being scoped to
-     * the organization is not a substitute for holding the permission, or every member of an
-     * organization could add employees to it.
+     * The authority the guard used to name is not kept as an alternative branch. It cannot be
+     * obtained in production, so a caller holding it in a test proves nothing about the endpoint.
      */
     @Test
-    void join_intoTheCallersOwnOrganizationWithoutTheAuthority_isForbidden() throws Exception {
+    void join_holdingOnlyTheOldAuthority_isForbidden() throws Exception {
         mockMvc.perform(post("/api/v1/employee/joinOrganization/" + USER_ID + "/" + OWN_ORG)
-                        .with(jwt())
+                        .with(jwt().authorities(new SimpleGrantedAuthority("employee:admin")))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(VALID_BODY))
                 .andExpect(status().isForbidden());

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueMobileGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueMobileGuardTest.java
@@ -1,0 +1,222 @@
+package org.tornotron.echno_backend.issue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The four guards on the mobile {@code IssueController}, which named an authority the realm
+ * cannot issue, and what each answers now.
+ *
+ * <p>{@code issue:read}, {@code issue:create}, {@code issue:update} and {@code issue:delete} are
+ * bare {@code resource:scope} authorities. {@code JwtAuthConverter} mints those in one place,
+ * {@code extractPermissions}, which reads the {@code authorization} claim of an RPT, and the realm
+ * defines no authorization scopes, so a permission with no scopes yields no
+ * {@code resource:scope} authority at all. Every endpoint on this controller therefore refused
+ * every caller from the day the annotation was written. Same mechanism as #641, #684, #710 and
+ * #716; see #734.
+ *
+ * <p>Raising a defect from the site, with a photograph, on the phone that is already in the
+ * hand is the workflow this controller exists for, so it is repaired rather than removed. The
+ * target is the web twin's answer, endpoint for endpoint: reading and raising an issue is open to
+ * any member of the tenant, and editing or deleting one belongs to a system admin or project
+ * manager. Nobody's effective reach changes, because the same member already does all four
+ * things through {@code /api/v1/issues/web}.
+ *
+ * <p>The role list is stubbed exactly rather than through {@code any(String[].class)}. A blanket
+ * stub answering true would pass whatever roles the guards named, so a delete that quietly
+ * admitted every member would look identical from here. The broad stub is kept, answering false,
+ * so an endpoint asking for a list no persona grants is refused rather than falling through to a
+ * Mockito default that happens to agree.
+ */
+@WebMvcTest(IssueController.class)
+@Import(IssueMobileGuardTest.TestSecurityConfig.class)
+class IssueMobileGuardTest {
+
+    private static final long ISSUE = 42L;
+
+    /** The pair the web twin's update and delete name. */
+    private static final String[] WRITE_ROLES = {"system-admin", "project-manager"};
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IssueService issueService;
+
+    @MockitoBean
+    private JsonPartBinder jsonPartBinder;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** No membership of the tenant and no role in it. */
+    private void callerIsAnOutsider() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+    }
+
+    /** An ordinary member of the tenant, holding no org role. */
+    private void callerIsAPlainMember() {
+        callerIsAnOutsider();
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+    }
+
+    /** A project manager: a member who also satisfies the write pair. */
+    private void callerIsAProjectManager() {
+        callerIsAPlainMember();
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(WRITE_ROLES)).thenReturn(true);
+    }
+
+    private static MockMultipartFile dataPart() {
+        return new MockMultipartFile(
+                "data", "data", MediaType.APPLICATION_JSON_VALUE, "{}".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void read_asAMemberOfTheTenant_isAllowed() throws Exception {
+        callerIsAPlainMember();
+
+        mockMvc.perform(get("/api/v1/issues/{id}", ISSUE).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void read_asSomebodyOutsideTheTenant_isForbidden() throws Exception {
+        callerIsAnOutsider();
+
+        mockMvc.perform(get("/api/v1/issues/{id}", ISSUE).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueService);
+    }
+
+    @Test
+    void create_asAMemberOfTheTenant_isAllowed() throws Exception {
+        callerIsAPlainMember();
+
+        mockMvc.perform(multipart("/api/v1/issues").file(dataPart()).with(jwt()))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void create_asSomebodyOutsideTheTenant_isForbidden() throws Exception {
+        callerIsAnOutsider();
+
+        mockMvc.perform(multipart("/api/v1/issues").file(dataPart()).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueService);
+    }
+
+    @Test
+    void update_asAProjectManager_isAllowed() throws Exception {
+        callerIsAProjectManager();
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/v1/issues/{id}", ISSUE)
+                        .file(dataPart())
+                        .with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * The difference between the two guards on this controller. A member raises and reads an
+     * issue; changing somebody else's, or removing it, is the pair's.
+     */
+    @Test
+    void update_asAPlainMember_isForbidden() throws Exception {
+        callerIsAPlainMember();
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/v1/issues/{id}", ISSUE)
+                        .file(dataPart())
+                        .with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueService);
+    }
+
+    @Test
+    void delete_asAProjectManager_isAllowed() throws Exception {
+        callerIsAProjectManager();
+
+        mockMvc.perform(delete("/api/v1/issues/{id}", ISSUE).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void delete_asAPlainMember_isForbidden() throws Exception {
+        callerIsAPlainMember();
+
+        mockMvc.perform(delete("/api/v1/issues/{id}", ISSUE).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueService);
+    }
+
+    /**
+     * The repaired guards do not keep the old authority as an alternative branch. Holding it
+     * would otherwise look like a working credential in a test and be unobtainable in production,
+     * which is how these guards went unnoticed for as long as they did.
+     */
+    @Test
+    void theOldAuthorityAloneOpensNothing() throws Exception {
+        callerIsAnOutsider();
+
+        mockMvc.perform(get("/api/v1/issues/{id}", ISSUE)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("issue:admin"))))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(delete("/api/v1/issues/{id}", ISSUE)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("issue:delete"))))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(issueService);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
`JwtAuthConverter.extractPermissions` mints a `resource:scope` authority only from the `authorization` claim of an RPT, and the realm defines no authorization scopes, so `hasAuthority('thing:action')` is satisfied by nobody. Established by #641, #684, #710 and #716, inventoried in #734.

## The true count

#734 reported 168 as an upper bound. Reading the annotations rather than grepping lines, on `development` at `d6cbff54`, the live figure was **136 guards on 17 controllers**. The 168 counted commented-out annotations, non-guard uses of the same string in `TenantFilter` and `OrganizationSecurityService`, and the whole leave module, which was repaired already. 313 is the raw occurrence count, because most guards name two authorities on one line.

Of the 136, 133 are phantom-only and refuse everybody outright. Two of the three mixed ones are dead as well: the mobile `joinOrganization` ANDs the phantom onto the tenant check, and `OrganizationController.readOrganization` has a phantom in both branches of its `or`. So **135 endpoints refuse every caller**, and one, `deleteOrganization`, survives on an `@orgSecurity.hasOrgRole` branch.

## What this repairs

The two surfaces #734 names, plus the sibling controller of one of them, taken as the Issues module:

| endpoint | now |
| --- | --- |
| `GET /api/v1/issues/{id}`, `POST /api/v1/issues` | `isMemberOfCurrentTenant()` |
| `PATCH /api/v1/issues/{id}`, `DELETE /api/v1/issues/{id}` | `system-admin, project-manager` |
| `POST /api/v1/issues/comments`, `GET /api/v1/issues/comments` | `isMemberOfCurrentTenant()` |
| `DELETE /api/v1/issues/comments/{id}` | `system-admin, project-manager` |
| `POST /api/v1/employee/joinOrganization/{userId}/{orgId}` | `isCurrentTenant(#orgId)` and `system-admin, hr-admin` |

Every target is the `/web` twin's answer, endpoint for endpoint, so **nobody's effective reach changes**: the same caller already does each of these things through the twin. Raising a defect from the site with a photograph is the workflow the mobile issue controller exists for, which is why it is repaired rather than proposed for removal.

No route is added. The twin's author-only comment edit has no counterpart here and none is introduced, because adding a route is a contract change rather than a guard repair.

**`EmployeeController.createEmployee` keeps its refusal.** It has no caller, cannot succeed against a non-null `user` column, and resolves its tenant from `organizationName` in the body, so repairing its guard alone would turn an unreachable route into a cross-tenant write. It is proposed for removal under #675 and #716 and is deliberately not repaired by analogy with the guards beside it.

## What is left, and why it is a decision rather than a task

128 guards on 15 controllers, all mobile twins of controllers whose `/web` side works, so nothing a user does today is blocked by one. `PhantomAuthorityCensusTest` records them exactly, by scanning every `@RestController` and reading the annotations, so the number can only come down and a new phantom guard fails the build. Removing an entry means that controller was repaired or removed.

The remainder is not one decision. A dead read whose twin is alive is usually a mobile surface that should work; a dead write may still be required, as the mobile leave endpoints turned out to be; and an endpoint with no caller anywhere is a removal candidate, which is a change to a published contract. The Resources cluster in particular (Material, Vendor, GRN, Indent, IndentItem, SiteTransfer, MaterialConsumption, InventoryTransaction, StorageLocation: 98 of the 128) has just had its `/web` role model settled by #727 and #730, and its mobile twins are also candidates for the twin collapse, so repairing them now would be deciding the collapse by accident.

## Tests

The tests are the first commit, ahead of the fix, but the red is **reasoned rather than measured**: `pull-request.yml` runs on `pull_request` only and the PR was opened after all three commits were pushed, so no CI run exists at `ed80ca04`. The reasoning is deterministic rather than a guess. Every allowed-case assertion sends `.with(jwt())` carrying no authority at all, against a pre-fix guard that requires one, so each asserts 200 or 201 where the old code answers 403; and `PhantomAuthorityCensusTest` expects no entry for two controllers that carried four and three phantom guards before this branch. `EmployeeMobileJoinGuardTest` needed rewriting for a reason worth naming: its passing case granted `employee:create` on the token directly, so it went green against an endpoint that refused every real caller. That is the shape of vacuous test this whole family hides behind. Every role list is stubbed as its exact varargs, with the `any(String[].class)` stub kept answering false, so a guard that widened to every member fails rather than falls through to a Mockito default.

The slice tests exercise a mock of `@orgSecurity`, so `PhantomAuthorityCensusTest` reads the real annotations as well.

`docs/org-scoped-roles.md` taught the layer-1 idiom without saying it cannot be satisfied, which is how these guards kept being written. It now says so.

Refs #734


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Authorization**
  - Updated issue and issue-comment access to use tenant membership and role-based permissions.
  - Tenant members can view and create issues and comments.
  - Issue updates/deletions and comment deletions are restricted to system administrators or project managers.
  - Employee organization joining is restricted to system administrators or HR administrators in the current tenant.

- **Documentation**
  - Updated API descriptions and authorization guidance to reflect tenant-role access controls.

- **Tests**
  - Added coverage for tenant membership and role-based authorization across issue, comment, and employee workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->