### PR TITLE
Say which finance response fields can be null

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15,9 +15,12 @@
             "type": "string"
           },
           "description": {
-            "description": "Optional description of the account.",
+            "description": "Optional description of the account. Null where none was given.",
             "example": "Petty cash and bank balances",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Unique account id.",
@@ -96,9 +99,12 @@
             "type": "string"
           },
           "description": {
-            "description": "Optional description of the account.",
+            "description": "Optional description of the account. Null where none was given.",
             "example": "Petty cash and bank balances",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Unique account id.",
@@ -135,53 +141,74 @@
         "description": "A postal address, used for customer billing.",
         "properties": {
           "city": {
-            "description": "City.",
+            "description": "City. Null where the customer's address does not carry it.",
             "example": "Chennai",
             "maxLength": 100,
             "minLength": 0,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "country": {
-            "description": "ISO 3166-1 alpha-2 country code.",
+            "description": "ISO 3166-1 alpha-2 country code. Null where the customer's address does not carry it.",
             "example": "IN",
             "maxLength": 2,
             "minLength": 0,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "line1": {
-            "description": "First address line.",
+            "description": "First address line. Null where the customer's address does not carry it.",
             "example": 12,
             "maxLength": 200,
             "minLength": 0,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "line2": {
-            "description": "Second address line.",
+            "description": "Second address line. Null where the customer's address does not carry it.",
             "example": "Suite 400",
             "maxLength": 200,
             "minLength": 0,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "postalCode": {
-            "description": "Postal or PIN code.",
+            "description": "Postal or PIN code. Null where the customer's address does not carry it.",
             "example": 600001,
             "maxLength": 20,
             "minLength": 0,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "state": {
-            "description": "State or province.",
+            "description": "State or province. Null where the customer's address does not carry it.",
             "example": "Tamil Nadu",
             "maxLength": 100,
             "minLength": 0,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "stateCode": {
-            "description": "GST state code.",
+            "description": "GST state code. Null where the customer's address does not carry it.",
             "example": 33,
             "maxLength": 2,
             "minLength": 0,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -3093,9 +3120,12 @@
             "type": "string"
           },
           "ifscCode": {
-            "description": "IFSC code of the branch.",
+            "description": "IFSC code of the branch. Null on an account held abroad, where the SWIFT code stands in.",
             "example": "HDFC0001234",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "isDefault": {
             "description": "Whether this is the default account for new transactions.",
@@ -3119,9 +3149,12 @@
             "type": "string"
           },
           "swiftCode": {
-            "description": "SWIFT code, for international transfers.",
+            "description": "SWIFT code, for international transfers. Null on a domestic account, where the IFSC code stands in.",
             "example": "HDFCINBB",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -3208,16 +3241,22 @@
         "description": "A construction invoice with its computed totals, lifecycle status and line items.",
         "properties": {
           "approvedAt": {
-            "description": "Timestamp the invoice was approved.",
+            "description": "Timestamp the invoice was approved. Null until the invoice is approved.",
             "example": "2026-08-03T11:40:00Z",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "approvedBy": {
-            "description": "User id that approved the invoice.",
+            "description": "User id that approved the invoice. Null until the invoice is approved.",
             "example": 2,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "approvedByName": {
             "description": "Name of the user that approved the invoice, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never approved.",
@@ -3253,15 +3292,21 @@
             "type": "string"
           },
           "goodsReceiptId": {
-            "description": "Matched goods receipt, if any.",
+            "description": "Matched goods receipt, if any. Null where none is matched.",
             "example": 231,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "gstNumber": {
-            "description": "Vendor GST registration number.",
+            "description": "Vendor GST registration number. Null where none was recorded.",
             "example": "29ABCDE1234F1Z5",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Unique invoice id.",
@@ -3281,10 +3326,13 @@
             "type": "string"
           },
           "journalEntryId": {
-            "description": "Ledger journal entry posted when the invoice was approved.",
+            "description": "Ledger journal entry posted when the invoice was approved. Null until the invoice is approved and posted to the ledger.",
             "example": "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "lines": {
             "description": "Invoice line items.",
@@ -3294,9 +3342,12 @@
             "type": "array"
           },
           "notes": {
-            "description": "Internal notes.",
+            "description": "Internal notes. Null where none were recorded.",
             "example": "Second progress claim for tower B",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "paidAmount": {
             "description": "Amount paid so far.",
@@ -3304,21 +3355,30 @@
             "type": "number"
           },
           "paymentDate": {
-            "description": "Date the invoice was fully paid, once settled.",
+            "description": "Date the invoice was fully paid, once settled. Null until the invoice is settled in full.",
             "example": "2026-08-28",
             "format": "date",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "paymentMethod": {
-            "description": "Settlement method.",
+            "description": "Settlement method. Null where none was recorded.",
             "example": "BANK_TRANSFER",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "paymentRecordedBy": {
-            "description": "User id that recorded the most recent payment.",
+            "description": "User id that recorded the most recent payment. Null until a payment is recorded against the invoice.",
             "example": 5,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "paymentRecordedByName": {
             "description": "Name of the user that recorded the most recent payment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when no payment has been recorded.",
@@ -3341,9 +3401,12 @@
             "type": "string"
           },
           "paymentTerms": {
-            "description": "Free-text payment terms.",
+            "description": "Free-text payment terms. Null where none were recorded.",
             "example": "Net 30",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectId": {
             "description": "Project the invoice is billed against.",
@@ -3352,15 +3415,21 @@
             "type": "integer"
           },
           "purchaseOrderId": {
-            "description": "Matched purchase order, if any.",
+            "description": "Matched purchase order, if any. Null where none is matched.",
             "example": 108,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "reversalJournalEntryId": {
-            "description": "Reversal journal entry, present when the invoice was cancelled after posting.",
+            "description": "Reversal journal entry, present when the invoice was cancelled after posting. Null on an invoice that was never cancelled after posting.",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "Lifecycle status of the invoice.",
@@ -3379,16 +3448,22 @@
             "type": "string"
           },
           "submittedAt": {
-            "description": "Timestamp the invoice was submitted.",
+            "description": "Timestamp the invoice was submitted. Null until the invoice is submitted for approval.",
             "example": "2026-08-02T09:15:00Z",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "submittedBy": {
-            "description": "User id that submitted the invoice for approval.",
+            "description": "User id that submitted the invoice for approval. Null until the invoice is submitted for approval.",
             "example": 5,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "submittedByName": {
             "description": "Name of the user that submitted the invoice, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never submitted.",
@@ -3409,13 +3484,19 @@
             "type": "number"
           },
           "taxType": {
-            "description": "Tax treatment applied to the invoice.",
+            "description": "Tax treatment applied to the invoice. Null where none was recorded.",
             "example": "CGST_SGST",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "termsAndConditions": {
-            "description": "Terms and conditions printed on the invoice.",
-            "type": "string"
+            "description": "Terms and conditions printed on the invoice. Null where none were recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "totalAmount": {
             "description": "Invoice grand total after tax and discount.",
@@ -3434,10 +3515,13 @@
             "type": "string"
           },
           "vendorId": {
-            "description": "Vendor being invoiced, if any.",
+            "description": "Vendor being invoiced, if any. Null on an invoice raised against no vendor, such as a sales or service invoice.",
             "example": 17,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -3446,21 +3530,30 @@
         "description": "A single line on a construction invoice with its computed tax, discount and totals.",
         "properties": {
           "assetId": {
-            "description": "Asset the line relates to, if any.",
+            "description": "Asset the line relates to, if any. Null where none is set.",
             "example": 88,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "costCategoryId": {
-            "description": "Budget head (cost category) this line is charged against, if any.",
+            "description": "Budget head (cost category) this line is charged against, if any. Null where the line carries no budget head.",
             "example": "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "costCategoryName": {
-            "description": "Name of the budget head this line is charged against, if any.",
+            "description": "Name of the budget head this line is charged against, if any. Null where the line carries no budget head.",
             "example": "Materials",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "description": {
             "description": "What the line is billing for.",
@@ -3484,10 +3577,13 @@
             "type": "string"
           },
           "inventoryItemId": {
-            "description": "Inventory item the line draws from, if any.",
+            "description": "Inventory item the line draws from, if any. Null where none is set.",
             "example": 512,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "quantity": {
             "description": "Quantity billed.",
@@ -3500,10 +3596,13 @@
             "type": "number"
           },
           "taskId": {
-            "description": "Task the line is charged against, if any.",
+            "description": "Task the line is charged against, if any. Null where none is set.",
             "example": 1204,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "taxAmount": {
             "description": "Tax charged on the line.",
@@ -3613,9 +3712,12 @@
         "description": "A construction payment voucher recording money paid out to a vendor, subcontractor, labour or employee on a project, with its method, payee and verification details.",
         "properties": {
           "accountNumber": {
-            "description": "Bank account number used for the payment.",
+            "description": "Bank account number used for the payment. Null on a payment that was not drawn on a bank.",
             "example": 50100123456789,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "amount": {
             "description": "Amount paid.",
@@ -3623,14 +3725,20 @@
             "type": "number"
           },
           "bankName": {
-            "description": "Bank the payment was drawn on.",
+            "description": "Bank the payment was drawn on. Null on a payment that was not drawn on a bank.",
             "example": "HDFC Bank",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "cancellationReason": {
             "description": "Why the voucher was voided, recorded by the cancel action. Null on a voucher that has not been cancelled.",
             "example": "Duplicate of CPMT-000118, raised twice for the same invoice",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "currency": {
             "description": "Currency code.",
@@ -3638,15 +3746,21 @@
             "type": "string"
           },
           "description": {
-            "description": "Description of what the payment covers.",
+            "description": "Description of what the payment covers. Null where none was recorded.",
             "example": "Payment for cement supply, batch 2",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "employeeId": {
-            "description": "Employee being paid, when the payee is an employee.",
+            "description": "Employee being paid, when the payee is an employee. Null on any other payee type.",
             "example": 5,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "id": {
             "description": "Unique payment voucher id.",
@@ -3655,21 +3769,30 @@
             "type": "string"
           },
           "ifscCode": {
-            "description": "IFSC code of the paying bank branch.",
+            "description": "IFSC code of the paying bank branch. Null on a payment that was not drawn on a bank.",
             "example": "HDFC0001234",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "invoiceId": {
-            "description": "Construction invoice this payment settles, if any.",
+            "description": "Construction invoice this payment settles, if any. Null where none is matched.",
             "example": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "labourId": {
-            "description": "Labour record being paid, when the payee is labour.",
+            "description": "Labour record being paid, when the payee is labour. Null on any other payee type.",
             "example": 61,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "method": {
             "description": "Method used to settle the payment.",
@@ -3688,22 +3811,31 @@
             "type": "string"
           },
           "notes": {
-            "description": "Internal notes.",
+            "description": "Internal notes. Null where none were recorded.",
             "example": "Approved by site engineer",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "payeeDetails": {
-            "description": "Free-text payee details.",
+            "description": "Free-text payee details. Null where none were recorded.",
             "example": "Contact: Ravi, GST 29ABCDE1234F1Z5",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "payeeName": {
-            "description": "Name of the party being paid.",
+            "description": "Name of the party being paid. Null where none was recorded.",
             "example": "Sundar Building Materials",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "payeeType": {
-            "description": "Category of party being paid.",
+            "description": "Category of party being paid. Null on a voucher that records no payee category; the column is nullable and nothing writes a default.",
             "enum": [
               "EMPLOYEE",
               "VENDOR",
@@ -3719,7 +3851,10 @@
               "OTHER"
             ],
             "example": "VENDOR",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "paymentDate": {
             "description": "Date the payment was made.",
@@ -3739,10 +3874,13 @@
             "type": "integer"
           },
           "purchaseOrderId": {
-            "description": "Purchase order the payment relates to, if any.",
+            "description": "Purchase order the payment relates to, if any. Null where none is matched.",
             "example": 108,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "raisedBy": {
             "description": "User id that raised the voucher, taken from the session that created it. Null on vouchers raised before the voucher recorded this.",
@@ -3762,9 +3900,12 @@
             ]
           },
           "referenceNumber": {
-            "description": "Cheque or reference number for the payment.",
+            "description": "Cheque or reference number for the payment. Null on a payment settled without one, such as one made in cash.",
             "example": "CHQ-000123",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "Lifecycle status of the voucher.",
@@ -3780,15 +3921,21 @@
             "type": "string"
           },
           "subContractId": {
-            "description": "Subcontract the payment relates to, when the payee is a subcontractor.",
+            "description": "Subcontract the payment relates to, when the payee is a subcontractor. Null on any other payee type.",
             "example": 23,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "transactionId": {
-            "description": "Bank or gateway transaction id.",
+            "description": "Bank or gateway transaction id. Null on a payment settled without one, such as one made in cash.",
             "example": "TXN20260805123456",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "type": {
             "description": "Kind of payment.",
@@ -3804,22 +3951,31 @@
             "type": "string"
           },
           "vendorId": {
-            "description": "Vendor being paid, when the payee is a vendor.",
+            "description": "Vendor being paid, when the payee is a vendor. Null on any other payee type.",
             "example": 17,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "verifiedAt": {
-            "description": "Timestamp the voucher was verified.",
+            "description": "Timestamp the voucher was verified. Null until the voucher is verified.",
             "example": "2026-08-06T10:20:00Z",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "verifiedBy": {
-            "description": "User id that verified the voucher, taken from the session that verified it.",
+            "description": "User id that verified the voucher, taken from the session that verified it. Null until the voucher is verified.",
             "example": 2,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "verifiedByName": {
             "description": "Name of the user that verified the voucher, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the voucher was never verified.",
@@ -3890,9 +4046,12 @@
             "type": "boolean"
           },
           "code": {
-            "description": "Optional short code for the head.",
+            "description": "Optional short code for the head. Null where none was given.",
             "example": "MAT",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "expenseAccountCode": {
             "description": "Code of the mapped expense account, or null.",
@@ -4738,8 +4897,15 @@
             "type": "boolean"
           },
           "billingAddress": {
-            "$ref": "#/components/schemas/AddressDto",
-            "description": "Billing address."
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AddressDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Billing address. Null where no part of the address is set: every address column on the customer is nullable, and Hibernate leaves an embedded value null when all of its columns are."
           },
           "code": {
             "description": "Customer code, unique within the tenant.",
@@ -4747,19 +4913,28 @@
             "type": "string"
           },
           "creditLimit": {
-            "description": "Credit limit extended to the customer.",
+            "description": "Credit limit extended to the customer. Null where no credit limit was agreed; a zero there would mean a limit of zero.",
             "example": 500000.0,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "email": {
-            "description": "Contact email address.",
+            "description": "Contact email address. Null where none was recorded.",
             "example": "accounts@assethomes.example",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "gstin": {
-            "description": "GST identification number.",
+            "description": "GST identification number. Null where the customer is not registered, or the number was not recorded.",
             "example": "29ABCDE1234F1Z5",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Unique customer id.",
@@ -4773,20 +4948,29 @@
             "type": "string"
           },
           "pan": {
-            "description": "Permanent account number.",
+            "description": "Permanent account number. Null where none was recorded.",
             "example": "ABCDE1234F",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "paymentTermsDays": {
-            "description": "Default payment terms in days.",
+            "description": "Default payment terms in days. Null where no default terms were agreed.",
             "example": 30,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "phone": {
-            "description": "Contact phone number.",
+            "description": "Contact phone number. Null where none was recorded.",
             "example": "+91 98765 43210",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -7405,10 +7589,13 @@
             "type": "string"
           },
           "journalEntryId": {
-            "description": "Ledger journal entry posted when the invoice was issued.",
+            "description": "Ledger journal entry posted when the invoice was issued. Null until the invoice is issued and posted to the ledger.",
             "example": "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "lines": {
             "description": "Invoice line items.",
@@ -7418,14 +7605,20 @@
             "type": "array"
           },
           "notes": {
-            "description": "Internal notes.",
+            "description": "Internal notes. Null where none were recorded.",
             "example": "First milestone billing",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "reversalJournalEntryId": {
-            "description": "Reversal journal entry, present when the invoice was cancelled after issue.",
+            "description": "Reversal journal entry, present when the invoice was cancelled after issue. Null on an invoice that was never cancelled after issue.",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "Lifecycle status of the invoice.",
@@ -7974,9 +8167,12 @@
             "type": "string"
           },
           "createdBy": {
-            "description": "User that created the entry.",
+            "description": "User that created the entry. Null where the auditing stamp was not recorded; the column is nullable.",
             "example": "abin",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "description": {
             "description": "Description of the entry.",
@@ -8008,32 +8204,47 @@
             "type": "array"
           },
           "reference": {
-            "description": "Free-text reference, such as a document number.",
+            "description": "Free-text reference, such as a document number. Null where none was recorded.",
             "example": "CINV-2026-0042",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "reversedByEntryId": {
-            "description": "Id of the entry that reversed this entry, present once it has been reversed.",
+            "description": "Id of the entry that reversed this entry, present once it has been reversed. Null until the entry is reversed.",
             "example": "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "reversesEntryId": {
-            "description": "Id of the entry this entry reverses, present when it is itself a reversal.",
+            "description": "Id of the entry this entry reverses, present when it is itself a reversal. Null on an entry that reverses nothing.",
             "example": "1c2f3d44-5a6e-4b7b-8f9a-0c1d2e3f4a5b",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "sourceId": {
-            "description": "Id of the source document that generated the entry, if any.",
+            "description": "Id of the source document that generated the entry, if any. Null on an entry posted by hand rather than from a document.",
             "example": "7a1e9b2f-1c44-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "sourceType": {
-            "description": "Type of the source document that generated the entry, if any.",
+            "description": "Type of the source document that generated the entry, if any. Null on an entry posted by hand rather than from a document.",
             "example": "CONSTRUCTION_INVOICE",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "Status of the entry.",
@@ -8090,9 +8301,12 @@
             "type": "integer"
           },
           "narration": {
-            "description": "Optional narration for the line.",
+            "description": "Optional narration for the line. Null where none was recorded.",
             "example": "Payment received from customer",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -13512,9 +13726,12 @@
             "type": "string"
           },
           "externalReference": {
-            "description": "External reference for the payment, such as a UTR or cheque number.",
+            "description": "External reference for the payment, such as a UTR or cheque number. Null where none was recorded.",
             "example": "UTR2026081012345",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Unique payment id.",
@@ -13523,15 +13740,21 @@
             "type": "string"
           },
           "journalEntryId": {
-            "description": "Ledger journal entry posted for the receipt.",
+            "description": "Ledger journal entry posted for the receipt. Null until the receipt is posted to the ledger.",
             "example": "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "notes": {
-            "description": "Internal notes.",
+            "description": "Internal notes. Null where none were recorded.",
             "example": "Part payment against August invoices",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "paymentDate": {
             "description": "Date the payment was received.",

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/dtos/CompanyBankAccountDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/dtos/CompanyBankAccountDto.java
@@ -14,9 +14,11 @@ public record CompanyBankAccountDto(
         String accountNumber,
         @Schema(description = "Name on the account.", example = "Fereydon Pvt Ltd")
         String accountHolderName,
-        @Schema(description = "IFSC code of the branch.", example = "HDFC0001234")
+        @Schema(description = "IFSC code of the branch. Null on an account held abroad, where the SWIFT code "
+                + "stands in.", example = "HDFC0001234", nullable = true)
         String ifscCode,
-        @Schema(description = "SWIFT code, for international transfers.", example = "HDFCINBB")
+        @Schema(description = "SWIFT code, for international transfers. Null on a domestic account, where the "
+                + "IFSC code stands in.", example = "HDFCINBB", nullable = true)
         String swiftCode,
         @Schema(description = "Whether this is the default account for new transactions.", example = "true")
         boolean isDefault,

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/CostCategoryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/CostCategoryDto.java
@@ -13,7 +13,8 @@ public record CostCategoryDto(
         @Schema(description = "Cost category name, unique within the tenant.", example = "Materials")
         String name,
 
-        @Schema(description = "Optional short code for the head.", example = "MAT")
+        @Schema(description = "Optional short code for the head. Null where none was given.",
+                example = "MAT", nullable = true)
         String code,
 
         @Schema(description = "Ledger expense account this head maps to, or null.",

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
@@ -31,13 +31,16 @@ public record ConstructionInvoiceDto(
         @Schema(description = "Project the invoice is billed against.", example = "42")
         Long projectId,
 
-        @Schema(description = "Vendor being invoiced, if any.", example = "17")
+        @Schema(description = "Vendor being invoiced, if any. Null on an invoice raised against no vendor, such "
+                + "as a sales or service invoice.", example = "17", nullable = true)
         Long vendorId,
 
-        @Schema(description = "Matched purchase order, if any.", example = "108")
+        @Schema(description = "Matched purchase order, if any. Null where none is matched.",
+                example = "108", nullable = true)
         Long purchaseOrderId,
 
-        @Schema(description = "Matched goods receipt, if any.", example = "231")
+        @Schema(description = "Matched goods receipt, if any. Null where none is matched.",
+                example = "231", nullable = true)
         Long goodsReceiptId,
 
         @Schema(description = "Date the invoice was issued.", example = "2026-08-01")
@@ -46,7 +49,8 @@ public record ConstructionInvoiceDto(
         @Schema(description = "Date payment is due.", example = "2026-08-31")
         LocalDate dueDate,
 
-        @Schema(description = "Date the invoice was fully paid, once settled.", example = "2026-08-28")
+        @Schema(description = "Date the invoice was fully paid, once settled. Null until the invoice is settled "
+                + "in full.", example = "2026-08-28", nullable = true)
         LocalDate paymentDate,
 
         @Schema(description = "Sum of line amounts before tax and discount.", example = "67500.00")
@@ -67,25 +71,32 @@ public record ConstructionInvoiceDto(
         @Schema(description = "Outstanding balance still due.", example = "36275.00")
         BigDecimal balanceAmount,
 
-        @Schema(description = "Free-text payment terms.", example = "Net 30")
+        @Schema(description = "Free-text payment terms. Null where none were recorded.",
+                example = "Net 30", nullable = true)
         String paymentTerms,
 
-        @Schema(description = "Settlement method.", example = "BANK_TRANSFER")
+        @Schema(description = "Settlement method. Null where none was recorded.",
+                example = "BANK_TRANSFER", nullable = true)
         String paymentMethod,
 
-        @Schema(description = "Vendor GST registration number.", example = "29ABCDE1234F1Z5")
+        @Schema(description = "Vendor GST registration number. Null where none was recorded.",
+                example = "29ABCDE1234F1Z5", nullable = true)
         String gstNumber,
 
-        @Schema(description = "Tax treatment applied to the invoice.", example = "CGST_SGST")
+        @Schema(description = "Tax treatment applied to the invoice. Null where none was recorded.",
+                example = "CGST_SGST", nullable = true)
         String taxType,
 
-        @Schema(description = "Internal notes.", example = "Second progress claim for tower B")
+        @Schema(description = "Internal notes. Null where none were recorded.",
+                example = "Second progress claim for tower B", nullable = true)
         String notes,
 
-        @Schema(description = "Terms and conditions printed on the invoice.")
+        @Schema(description = "Terms and conditions printed on the invoice. Null where none were recorded.",
+                nullable = true)
         String termsAndConditions,
 
-        @Schema(description = "User id that submitted the invoice for approval.", example = "5")
+        @Schema(description = "User id that submitted the invoice for approval. Null until the invoice is "
+                + "submitted for approval.", example = "5", nullable = true)
         Long submittedBy,
 
         @Schema(description = "Name of the user that submitted the invoice, or their email where the "
@@ -94,10 +105,12 @@ public record ConstructionInvoiceDto(
                 example = "Anand Rajashekar", nullable = true)
         String submittedByName,
 
-        @Schema(description = "Timestamp the invoice was submitted.", example = "2026-08-02T09:15:00Z")
+        @Schema(description = "Timestamp the invoice was submitted. Null until the invoice is submitted for "
+                + "approval.", example = "2026-08-02T09:15:00Z", nullable = true)
         Instant submittedAt,
 
-        @Schema(description = "User id that approved the invoice.", example = "2")
+        @Schema(description = "User id that approved the invoice. Null until the invoice is approved.",
+                example = "2", nullable = true)
         Long approvedBy,
 
         @Schema(description = "Name of the user that approved the invoice, or their email where the "
@@ -106,10 +119,12 @@ public record ConstructionInvoiceDto(
                 example = "Aneesh Johny", nullable = true)
         String approvedByName,
 
-        @Schema(description = "Timestamp the invoice was approved.", example = "2026-08-03T11:40:00Z")
+        @Schema(description = "Timestamp the invoice was approved. Null until the invoice is approved.",
+                example = "2026-08-03T11:40:00Z", nullable = true)
         Instant approvedAt,
 
-        @Schema(description = "User id that recorded the most recent payment.", example = "5")
+        @Schema(description = "User id that recorded the most recent payment. Null until a payment is recorded "
+                + "against the invoice.", example = "5", nullable = true)
         Long paymentRecordedBy,
 
         @Schema(description = "Name of the user that recorded the most recent payment, or their email "
@@ -118,11 +133,13 @@ public record ConstructionInvoiceDto(
                 example = "Anand Rajashekar", nullable = true)
         String paymentRecordedByName,
 
-        @Schema(description = "Ledger journal entry posted when the invoice was approved.",
-                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        @Schema(description = "Ledger journal entry posted when the invoice was approved. Null until the "
+                + "invoice is approved and posted to the ledger.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID journalEntryId,
 
-        @Schema(description = "Reversal journal entry, present when the invoice was cancelled after posting.")
+        @Schema(description = "Reversal journal entry, present when the invoice was cancelled after posting. "
+                + "Null on an invoice that was never cancelled after posting.", nullable = true)
         UUID reversalJournalEntryId,
 
         @Schema(description = "AR invoice raised for this invoice on approval. Present on a sales or "

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineDto.java
@@ -40,20 +40,23 @@ public record ConstructionInvoiceLineDto(
         @Schema(description = "Line total after tax and discount.", example = "79100.00")
         BigDecimal total,
 
-        @Schema(description = "Inventory item the line draws from, if any.", example = "512")
+        @Schema(description = "Inventory item the line draws from, if any. Null where none is set.",
+                example = "512", nullable = true)
         Long inventoryItemId,
 
-        @Schema(description = "Asset the line relates to, if any.", example = "88")
+        @Schema(description = "Asset the line relates to, if any. Null where none is set.",
+                example = "88", nullable = true)
         Long assetId,
 
-        @Schema(description = "Task the line is charged against, if any.", example = "1204")
+        @Schema(description = "Task the line is charged against, if any. Null where none is set.",
+                example = "1204", nullable = true)
         Long taskId,
 
-        @Schema(description = "Budget head (cost category) this line is charged against, if any.",
-                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        @Schema(description = "Budget head (cost category) this line is charged against, if any. Null where the "
+                + "line carries no budget head.", example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID costCategoryId,
 
-        @Schema(description = "Name of the budget head this line is charged against, if any.",
-                example = "Materials")
+        @Schema(description = "Name of the budget head this line is charged against, if any. Null where the "
+                + "line carries no budget head.", example = "Materials", nullable = true)
         String costCategoryName
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
@@ -29,35 +29,43 @@ public record ConstructionPaymentDto(
         @Schema(description = "Method used to settle the payment.", example = "BANK_TRANSFER")
         ConstructionPaymentMethod method,
 
-        @Schema(description = "Category of party being paid.", example = "VENDOR")
+        @Schema(description = "Category of party being paid. Null on a voucher that records no payee category; "
+                + "the column is nullable and nothing writes a default.", example = "VENDOR", nullable = true)
         ConstructionPayeeType payeeType,
 
         @Schema(description = "Project the payment is charged to.", example = "42")
         Long projectId,
 
-        @Schema(description = "Construction invoice this payment settles, if any.",
-                example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+        @Schema(description = "Construction invoice this payment settles, if any. Null where none is matched.",
+                example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301", nullable = true)
         UUID invoiceId,
 
-        @Schema(description = "Purchase order the payment relates to, if any.", example = "108")
+        @Schema(description = "Purchase order the payment relates to, if any. Null where none is matched.",
+                example = "108", nullable = true)
         Long purchaseOrderId,
 
-        @Schema(description = "Vendor being paid, when the payee is a vendor.", example = "17")
+        @Schema(description = "Vendor being paid, when the payee is a vendor. Null on any other payee type.",
+                example = "17", nullable = true)
         Long vendorId,
 
-        @Schema(description = "Employee being paid, when the payee is an employee.", example = "5")
+        @Schema(description = "Employee being paid, when the payee is an employee. Null on any other payee "
+                + "type.", example = "5", nullable = true)
         Long employeeId,
 
-        @Schema(description = "Subcontract the payment relates to, when the payee is a subcontractor.", example = "23")
+        @Schema(description = "Subcontract the payment relates to, when the payee is a subcontractor. Null on "
+                + "any other payee type.", example = "23", nullable = true)
         Long subContractId,
 
-        @Schema(description = "Labour record being paid, when the payee is labour.", example = "61")
+        @Schema(description = "Labour record being paid, when the payee is labour. Null on any other payee "
+                + "type.", example = "61", nullable = true)
         Long labourId,
 
-        @Schema(description = "Name of the party being paid.", example = "Sundar Building Materials")
+        @Schema(description = "Name of the party being paid. Null where none was recorded.",
+                example = "Sundar Building Materials", nullable = true)
         String payeeName,
 
-        @Schema(description = "Free-text payee details.", example = "Contact: Ravi, GST 29ABCDE1234F1Z5")
+        @Schema(description = "Free-text payee details. Null where none were recorded.",
+                example = "Contact: Ravi, GST 29ABCDE1234F1Z5", nullable = true)
         String payeeDetails,
 
         @Schema(description = "Amount paid.", example = "40000.00")
@@ -69,19 +77,24 @@ public record ConstructionPaymentDto(
         @Schema(description = "Date the payment was made.", example = "2026-08-05")
         LocalDate paymentDate,
 
-        @Schema(description = "Bank or gateway transaction id.", example = "TXN20260805123456")
+        @Schema(description = "Bank or gateway transaction id. Null on a payment settled without one, such as "
+                + "one made in cash.", example = "TXN20260805123456", nullable = true)
         String transactionId,
 
-        @Schema(description = "Cheque or reference number for the payment.", example = "CHQ-000123")
+        @Schema(description = "Cheque or reference number for the payment. Null on a payment settled without "
+                + "one, such as one made in cash.", example = "CHQ-000123", nullable = true)
         String referenceNumber,
 
-        @Schema(description = "Bank the payment was drawn on.", example = "HDFC Bank")
+        @Schema(description = "Bank the payment was drawn on. Null on a payment that was not drawn on a bank.",
+                example = "HDFC Bank", nullable = true)
         String bankName,
 
-        @Schema(description = "Bank account number used for the payment.", example = "50100123456789")
+        @Schema(description = "Bank account number used for the payment. Null on a payment that was not drawn "
+                + "on a bank.", example = "50100123456789", nullable = true)
         String accountNumber,
 
-        @Schema(description = "IFSC code of the paying bank branch.", example = "HDFC0001234")
+        @Schema(description = "IFSC code of the paying bank branch. Null on a payment that was not drawn on a "
+                + "bank.", example = "HDFC0001234", nullable = true)
         String ifscCode,
 
         @Schema(description = "User id that raised the voucher, taken from the session that created "
@@ -93,8 +106,8 @@ public record ConstructionPaymentDto(
                 example = "Hrishi", nullable = true)
         String raisedByName,
 
-        @Schema(description = "User id that verified the voucher, taken from the session that "
-                + "verified it.", example = "2")
+        @Schema(description = "User id that verified the voucher, taken from the session that verified it. Null "
+                + "until the voucher is verified.", example = "2", nullable = true)
         Long verifiedBy,
 
         @Schema(description = "Name of the user that verified the voucher, or their email where the "
@@ -103,17 +116,20 @@ public record ConstructionPaymentDto(
                 example = "Aneesh Johny", nullable = true)
         String verifiedByName,
 
-        @Schema(description = "Timestamp the voucher was verified.", example = "2026-08-06T10:20:00Z")
+        @Schema(description = "Timestamp the voucher was verified. Null until the voucher is verified.",
+                example = "2026-08-06T10:20:00Z", nullable = true)
         Instant verifiedAt,
 
-        @Schema(description = "Why the voucher was voided, recorded by the cancel action. Null on a "
-                + "voucher that has not been cancelled.",
-                example = "Duplicate of CPMT-000118, raised twice for the same invoice")
+        @Schema(description = "Why the voucher was voided, recorded by the cancel action. Null on a voucher "
+                + "that has not been cancelled.",
+                example = "Duplicate of CPMT-000118, raised twice for the same invoice", nullable = true)
         String cancellationReason,
 
-        @Schema(description = "Description of what the payment covers.", example = "Payment for cement supply, batch 2")
+        @Schema(description = "Description of what the payment covers. Null where none was recorded.",
+                example = "Payment for cement supply, batch 2", nullable = true)
         String description,
 
-        @Schema(description = "Internal notes.", example = "Approved by site engineer")
+        @Schema(description = "Internal notes. Null where none were recorded.",
+                example = "Approved by site engineer", nullable = true)
         String notes
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/InvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/InvoiceDto.java
@@ -46,14 +46,17 @@ public record InvoiceDto(
         @Schema(description = "Outstanding balance still due.", example = "39000.00")
         BigDecimal balanceDue,
 
-        @Schema(description = "Ledger journal entry posted when the invoice was issued.",
-                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        @Schema(description = "Ledger journal entry posted when the invoice was issued. Null until the invoice "
+                + "is issued and posted to the ledger.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID journalEntryId,
 
-        @Schema(description = "Reversal journal entry, present when the invoice was cancelled after issue.")
+        @Schema(description = "Reversal journal entry, present when the invoice was cancelled after issue. Null "
+                + "on an invoice that was never cancelled after issue.", nullable = true)
         UUID reversalJournalEntryId,
 
-        @Schema(description = "Internal notes.", example = "First milestone billing")
+        @Schema(description = "Internal notes. Null where none were recorded.",
+                example = "First milestone billing", nullable = true)
         String notes,
 
         @Schema(description = "Invoice line items.")

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountDto.java
@@ -26,7 +26,8 @@ public record AccountDto(
         @Schema(description = "Whether the account is active and available for posting.", example = "true")
         boolean active,
 
-        @Schema(description = "Optional description of the account.", example = "Petty cash and bank balances")
+        @Schema(description = "Optional description of the account. Null where none was given.",
+                example = "Petty cash and bank balances", nullable = true)
         String description
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountTreeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountTreeDto.java
@@ -23,7 +23,8 @@ public record AccountTreeDto(
         @Schema(description = "Whether the account is active and available for posting.", example = "true")
         boolean active,
 
-        @Schema(description = "Optional description of the account.", example = "Petty cash and bank balances")
+        @Schema(description = "Optional description of the account. Null where none was given.",
+                example = "Petty cash and bank balances", nullable = true)
         String description,
 
         @Schema(description = "Whether entries can be posted directly to this account. Only leaf accounts "

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AddressDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AddressDto.java
@@ -12,31 +12,38 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AddressDto {
 
-    @Schema(description = "First address line.", example = "12 Marina Boulevard")
+    @Schema(description = "First address line. Null where the customer's address does not carry it.",
+            example = "12 Marina Boulevard", nullable = true)
     @Size(max = 200,message = "Address line 1 cannot exceed 200 characters")
     private String line1;
 
-    @Schema(description = "Second address line.", example = "Suite 400")
+    @Schema(description = "Second address line. Null where the customer's address does not carry it.",
+            example = "Suite 400", nullable = true)
     @Size(max = 200,message = "Address line 2 cannot exceed 200 characters")
     private String line2;
 
-    @Schema(description = "City.", example = "Chennai")
+    @Schema(description = "City. Null where the customer's address does not carry it.",
+            example = "Chennai", nullable = true)
     @Size(max = 100,message = "City cannot exceed 100 characters")
     private String city;
 
-    @Schema(description = "State or province.", example = "Tamil Nadu")
+    @Schema(description = "State or province. Null where the customer's address does not carry it.",
+            example = "Tamil Nadu", nullable = true)
     @Size(max = 100,message = "State cannot exceed 100 characters")
     private String state;
 
-    @Schema(description = "GST state code.", example = "33")
+    @Schema(description = "GST state code. Null where the customer's address does not carry it.",
+            example = "33", nullable = true)
     @Size(max = 2,message = "State code cannot exceed 2 characters")
     private String stateCode;
 
-    @Schema(description = "Postal or PIN code.", example = "600001")
+    @Schema(description = "Postal or PIN code. Null where the customer's address does not carry it.",
+            example = "600001", nullable = true)
     @Size(max = 20,message = "Postal code cannot exceed 20 characters")
     private String postalCode;
 
-    @Schema(description = "ISO 3166-1 alpha-2 country code.", example = "IN")
+    @Schema(description = "ISO 3166-1 alpha-2 country code. Null where the customer's address does not carry "
+            + "it.", example = "IN", nullable = true)
     @Size(max = 2,message = "Country code cannot exceed 2 characters")
     private String country;
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CustomerDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CustomerDto.java
@@ -17,25 +17,33 @@ public record CustomerDto(
         @Schema(description = "Customer name.", example = "Asset Homes Pvt Ltd")
         String name,
 
-        @Schema(description = "GST identification number.", example = "29ABCDE1234F1Z5")
+        @Schema(description = "GST identification number. Null where the customer is not registered, or the "
+                + "number was not recorded.", example = "29ABCDE1234F1Z5", nullable = true)
         String gstin,
 
-        @Schema(description = "Permanent account number.", example = "ABCDE1234F")
+        @Schema(description = "Permanent account number. Null where none was recorded.",
+                example = "ABCDE1234F", nullable = true)
         String pan,
 
-        @Schema(description = "Contact email address.", example = "accounts@assethomes.example")
+        @Schema(description = "Contact email address. Null where none was recorded.",
+                example = "accounts@assethomes.example", nullable = true)
         String email,
 
-        @Schema(description = "Contact phone number.", example = "+91 98765 43210")
+        @Schema(description = "Contact phone number. Null where none was recorded.",
+                example = "+91 98765 43210", nullable = true)
         String phone,
 
-        @Schema(description = "Billing address.")
+        @Schema(description = "Billing address. Null where no part of the address is set: every address column "
+                + "on the customer is nullable, and Hibernate leaves an embedded value null when all of its "
+                + "columns are.", nullable = true)
         AddressDto billingAddress,
 
-        @Schema(description = "Credit limit extended to the customer.", example = "500000.00")
+        @Schema(description = "Credit limit extended to the customer. Null where no credit limit was agreed; a "
+                + "zero there would mean a limit of zero.", example = "500000.00", nullable = true)
         BigDecimal creditLimit,
 
-        @Schema(description = "Default payment terms in days.", example = "30")
+        @Schema(description = "Default payment terms in days. Null where no default terms were agreed.",
+                example = "30", nullable = true)
         Integer paymentTermsDays,
 
         @Schema(description = "Whether the customer is active.", example = "true")

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/JournalEntryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/JournalEntryDto.java
@@ -22,26 +22,30 @@ public record JournalEntryDto(
         @Schema(description = "Description of the entry.", example = "Vendor bill CINV-2026-0042 posted")
         String description,
 
-        @Schema(description = "Free-text reference, such as a document number.", example = "CINV-2026-0042")
+        @Schema(description = "Free-text reference, such as a document number. Null where none was recorded.",
+                example = "CINV-2026-0042", nullable = true)
         String reference,
 
         @Schema(description = "Status of the entry.", example = "POSTED")
         JournalStatus status,
 
-        @Schema(description = "Id of the entry that reversed this entry, present once it has been reversed.",
-                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        @Schema(description = "Id of the entry that reversed this entry, present once it has been reversed. "
+                + "Null until the entry is reversed.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID reversedByEntryId,
 
-        @Schema(description = "Id of the entry this entry reverses, present when it is itself a reversal.",
-                example = "1c2f3d44-5a6e-4b7b-8f9a-0c1d2e3f4a5b")
+        @Schema(description = "Id of the entry this entry reverses, present when it is itself a reversal. Null "
+                + "on an entry that reverses nothing.",
+                example = "1c2f3d44-5a6e-4b7b-8f9a-0c1d2e3f4a5b", nullable = true)
         UUID reversesEntryId,
 
-        @Schema(description = "Type of the source document that generated the entry, if any.",
-                example = "CONSTRUCTION_INVOICE")
+        @Schema(description = "Type of the source document that generated the entry, if any. Null on an entry "
+                + "posted by hand rather than from a document.", example = "CONSTRUCTION_INVOICE", nullable = true)
         String sourceType,
 
-        @Schema(description = "Id of the source document that generated the entry, if any.",
-                example = "7a1e9b2f-1c44-4e2b-9f0a-2c8d5e6f7a10")
+        @Schema(description = "Id of the source document that generated the entry, if any. Null on an entry "
+                + "posted by hand rather than from a document.",
+                example = "7a1e9b2f-1c44-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID sourceId,
 
         @Schema(description = "Debit and credit lines that make up the entry.")
@@ -50,7 +54,8 @@ public record JournalEntryDto(
         @Schema(description = "Timestamp the entry was created.", example = "2026-08-01T09:15:00Z")
         Instant createdAt,
 
-        @Schema(description = "User that created the entry.", example = "abin")
+        @Schema(description = "User that created the entry. Null where the auditing stamp was not recorded; the "
+                + "column is nullable.", example = "abin", nullable = true)
         String createdBy
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/JournalEntryLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/JournalEntryLineDto.java
@@ -25,7 +25,8 @@ public record JournalEntryLineDto(
         @Schema(description = "Credit amount on this line. Zero when the line is a debit.", example = "0.00")
         BigDecimal credit,
 
-        @Schema(description = "Optional narration for the line.", example = "Payment received from customer")
+        @Schema(description = "Optional narration for the line. Null where none was recorded.",
+                example = "Payment received from customer", nullable = true)
         String narration,
 
         @Schema(description = "Order of the line within the entry, starting at zero.", example = "0")

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/dtos/PaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/dtos/PaymentDto.java
@@ -38,15 +38,16 @@ public record PaymentDto(
         @Schema(description = "Receiving bank account number.", example = "50100123456789")
         String bankAccountNumber,
 
-        @Schema(description = "External reference for the payment, such as a UTR or cheque number.",
-                example = "UTR2026081012345")
+        @Schema(description = "External reference for the payment, such as a UTR or cheque number. Null where "
+                + "none was recorded.", example = "UTR2026081012345", nullable = true)
         String externalReference,
 
-        @Schema(description = "Ledger journal entry posted for the receipt.",
-                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        @Schema(description = "Ledger journal entry posted for the receipt. Null until the receipt is posted to "
+                + "the ledger.", example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID journalEntryId,
 
-        @Schema(description = "Internal notes.", example = "Part payment against August invoices")
+        @Schema(description = "Internal notes. Null where none were recorded.",
+                example = "Part payment against August invoices", nullable = true)
         String notes,
 
         @Schema(description = "How the payment amount was allocated across invoices.")

--- a/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
@@ -379,7 +379,7 @@ final class ReviewedResponseSchemas {
                                 "geofenceRadiusMeters", "geofenceExceptionReason", "recordedById",
                                 "remarks", "regularizationReason"),
                         Set.of("id", "eventType", "eventTimestamp", "projectId", "projectName",
-                                "isRegularized", "attachments"))),
+                                "isRegularized", "attachments")),
                 new ReviewedSchema(
                         AccountDto.class,
                         Set.of("description", "parentId"),

--- a/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
@@ -2,6 +2,25 @@ package org.tornotron.echno_backend.architecture;
 
 import org.tornotron.echno_backend.attendance.dto.AttendanceResponseDto;
 import org.tornotron.echno_backend.attendance.dto.ClockEventDto;
+import org.tornotron.echno_backend.finance.bank.dtos.CompanyBankAccountDto;
+import org.tornotron.echno_backend.finance.budget.dtos.BudgetAllocationDto;
+import org.tornotron.echno_backend.finance.budget.dtos.CostCategoryDto;
+import org.tornotron.echno_backend.finance.budget.dtos.ProjectCostControlDto;
+import org.tornotron.echno_backend.finance.budget.dtos.ProjectCostControlLineDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
+import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
+import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceLineDto;
+import org.tornotron.echno_backend.finance.ledger.dtos.AccountDto;
+import org.tornotron.echno_backend.finance.ledger.dtos.AccountTreeDto;
+import org.tornotron.echno_backend.finance.ledger.dtos.AddressDto;
+import org.tornotron.echno_backend.finance.ledger.dtos.CustomerDto;
+import org.tornotron.echno_backend.finance.ledger.dtos.JournalEntryDto;
+import org.tornotron.echno_backend.finance.ledger.dtos.JournalEntryLineDto;
+import org.tornotron.echno_backend.finance.payment.dtos.PaymentDto;
+import org.tornotron.echno_backend.finance.posting.dtos.PostingAccountMappingDto;
+import org.tornotron.echno_backend.finance.settings.dtos.FinanceSettingsDto;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
 import org.tornotron.echno_backend.payable.dto.PayableDto;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderDto;
@@ -219,6 +238,57 @@ final class ReviewedResponseSchemas {
      * foreign key at all, so a value there may name a row that no longer exists, which the
      * descriptions say.
      *
+     * <p><b>Finance.</b> The largest untouched block, and the one where a wrong answer is most
+     * expensive: the chart of accounts, the ledger, customer invoicing and receipts, construction
+     * invoices and payment vouchers, budget heads and the project cost-control view. Twenty
+     * schemas, 218 properties, 85 of them nullable.
+     *
+     * <ul>
+     *   <li>The entities agree with the changelog throughout, so there is no finding here of the
+     *       kind the procurement chain produced. Every straight-through property was read off the
+     *       Liquibase column, and no {@code @Column} or {@code @JoinColumn} in the module
+     *       contradicts one.
+     *   <li>The money on a construction invoice is non-null where the money on a purchase order
+     *       was not, which reads as an inconsistency and is not one. {@code subtotal},
+     *       {@code taxAmount}, {@code discountAmount}, {@code totalAmount}, {@code paidAmount}
+     *       and {@code balanceAmount} sit on {@code NOT NULL} columns, so the constraint carries
+     *       the claim and the code that writes them does not have to.
+     *   <li>{@code InvoiceDto.balanceDue} is the computed-with-no-column case, the third instance
+     *       of the {@code VendorSummaryDto} and {@code PayableDto.amountDue} shape:
+     *       {@code Invoice.balanceDue()} subtracts one {@code NOT NULL} column from another, so
+     *       nothing in it can produce a null.
+     *   <li>{@code ProjectCostControlDto} and its lines are computed end to end and read no
+     *       column directly. Every figure passes through {@code MoneyUtils.normalize}, which
+     *       turns a null into zero; the head name falls back to {@code (unknown)} and the totals
+     *       row is labelled. Only {@code costCategoryId} admits null, and only on that totals
+     *       row, which is what its null means.
+     *   <li>{@code PostingAccountMappingDto} is non-null throughout because
+     *       {@code PostingAccountResolver.resolveWithSource} either returns an account or throws
+     *       {@code AccountNotFoundException}. A role with no mapping falls back to the configured
+     *       default code, and a default code that resolves to nothing is an error rather than a
+     *       null account.
+     *   <li>{@code CustomerDto.billingAddress} is nullable for a reason that is neither a column
+     *       nor a mapper. {@code Address} is an {@code @Embedded} value whose seven columns are
+     *       all nullable, and Hibernate leaves the embedded object null when every one of them
+     *       is, whatever the field initialiser on {@code Customer} says. Its own seven properties
+     *       are then nullable for the ordinary reason, which makes {@code AddressDto} the one
+     *       schema here with nothing at all in its non-null half.
+     *   <li>A flattened name is null exactly when its foreign key is, as in procurement.
+     *       {@code ledgerAccountCode}, {@code ledgerAccountName}, {@code customerName},
+     *       {@code accountCode} and {@code accountName} on a journal line, {@code bankName} and
+     *       {@code bankAccountNumber} on a payment, and {@code revenueAccountCode} all reach a
+     *       {@code NOT NULL} column through a {@code NOT NULL} join, so every one of them is
+     *       non-null. {@code costCategoryName} on a construction invoice line is the mirror
+     *       image: its join column is nullable, so the name is too.
+     *   <li>{@code ConstructionPaymentDto} admits null on 22 of its 31 properties, which is the
+     *       schema's shape rather than an omission. One voucher names a payee of one kind out of
+     *       five and carries a column for each of them, records bank details only where a bank
+     *       was used, and stamps a verifier only once verified.
+     *   <li>{@code JournalEntryDto.createdBy} is nullable where {@code createdAt} on the same
+     *       schema is not. The two auditing columns disagree in the changelog:
+     *       {@code created_at} is {@code NOT NULL} and {@code created_by} is not.
+     * </ul>
+     *
      * @return The reviewed schemas.
      */
     static List<ReviewedSchema> schemas() {
@@ -309,6 +379,116 @@ final class ReviewedResponseSchemas {
                                 "geofenceRadiusMeters", "geofenceExceptionReason", "recordedById",
                                 "remarks", "regularizationReason"),
                         Set.of("id", "eventType", "eventTimestamp", "projectId", "projectName",
-                                "isRegularized", "attachments")));
+                                "isRegularized", "attachments"))),
+                new ReviewedSchema(
+                        AccountDto.class,
+                        Set.of("description", "parentId"),
+                        Set.of("id", "code", "name", "type", "active")),
+                new ReviewedSchema(
+                        AccountTreeDto.class,
+                        Set.of("description"),
+                        Set.of("id", "code", "name", "type", "active", "postable", "children")),
+                new ReviewedSchema(
+                        AddressDto.class,
+                        Set.of("city", "country", "line1", "line2", "postalCode", "state",
+                                "stateCode"),
+                        Set.of()),
+                new ReviewedSchema(
+                        CustomerDto.class,
+                        Set.of("billingAddress", "creditLimit", "email", "gstin", "pan",
+                                "paymentTermsDays", "phone"),
+                        Set.of("id", "code", "name", "active")),
+                new ReviewedSchema(
+                        JournalEntryDto.class,
+                        Set.of("createdBy", "reference", "reversedByEntryId", "reversesEntryId",
+                                "sourceId", "sourceType"),
+                        Set.of("id", "entryNumber", "entryDate", "description", "status", "lines",
+                                "createdAt")),
+                new ReviewedSchema(
+                        JournalEntryLineDto.class,
+                        Set.of("narration"),
+                        Set.of("id", "accountId", "accountCode", "accountName", "debit", "credit",
+                                "lineOrder")),
+                new ReviewedSchema(
+                        InvoiceDto.class,
+                        Set.of("journalEntryId", "notes", "reversalJournalEntryId"),
+                        Set.of("id", "invoiceNumber", "customerId", "customerName", "invoiceDate",
+                                "dueDate", "status", "subtotal", "taxTotal", "total", "amountPaid",
+                                "balanceDue", "lines")),
+                new ReviewedSchema(
+                        InvoiceLineDto.class,
+                        Set.of(),
+                        Set.of("id", "description", "quantity", "unitPrice", "lineSubtotal",
+                                "taxRate", "taxAmount", "lineTotal", "revenueAccountId",
+                                "revenueAccountCode")),
+                new ReviewedSchema(
+                        PaymentDto.class,
+                        Set.of("externalReference", "journalEntryId", "notes"),
+                        Set.of("id", "paymentNumber", "customerId", "customerName", "paymentDate",
+                                "amount", "companyBankAccountId", "bankName", "bankAccountNumber",
+                                "allocations")),
+                new ReviewedSchema(
+                        PaymentDto.AllocationDto.class,
+                        Set.of(),
+                        Set.of("id", "invoiceId", "invoiceNumber", "allocatedAmount")),
+                new ReviewedSchema(
+                        CompanyBankAccountDto.class,
+                        Set.of("ifscCode", "swiftCode"),
+                        Set.of("id", "bankName", "accountNumber", "accountHolderName", "isDefault",
+                                "active", "ledgerAccountId", "ledgerAccountCode", "ledgerAccountName")),
+                new ReviewedSchema(
+                        ConstructionInvoiceDto.class,
+                        Set.of("approvedAt", "approvedBy", "approvedByName", "arInvoiceId",
+                                "goodsReceiptId", "gstNumber", "journalEntryId", "notes",
+                                "paymentDate", "paymentMethod", "paymentRecordedBy",
+                                "paymentRecordedByName", "paymentTerms", "purchaseOrderId",
+                                "reversalJournalEntryId", "submittedAt", "submittedBy",
+                                "submittedByName", "taxType", "termsAndConditions", "vendorId"),
+                        Set.of("id", "invoiceNumber", "type", "status", "paymentStatus",
+                                "projectId", "issueDate", "dueDate", "subtotal", "taxAmount",
+                                "discountAmount", "totalAmount", "paidAmount", "balanceAmount",
+                                "lines")),
+                new ReviewedSchema(
+                        ConstructionInvoiceLineDto.class,
+                        Set.of("assetId", "costCategoryId", "costCategoryName", "inventoryItemId",
+                                "taskId"),
+                        Set.of("id", "description", "quantity", "unit", "unitPrice", "taxRate",
+                                "taxAmount", "discountRate", "discountAmount", "subtotal", "total")),
+                new ReviewedSchema(
+                        ConstructionPaymentDto.class,
+                        Set.of("accountNumber", "bankName", "cancellationReason", "description",
+                                "employeeId", "ifscCode", "invoiceId", "labourId", "notes",
+                                "payeeDetails", "payeeName", "payeeType", "purchaseOrderId",
+                                "raisedBy", "raisedByName", "referenceNumber", "subContractId",
+                                "transactionId", "vendorId", "verifiedAt", "verifiedBy",
+                                "verifiedByName"),
+                        Set.of("id", "paymentNumber", "type", "status", "method", "projectId",
+                                "amount", "currency", "paymentDate")),
+                new ReviewedSchema(
+                        CostCategoryDto.class,
+                        Set.of("code", "expenseAccountCode", "expenseAccountId"),
+                        Set.of("id", "name", "active")),
+                new ReviewedSchema(
+                        BudgetAllocationDto.class,
+                        Set.of(),
+                        Set.of("id", "projectId", "costCategoryId", "costCategoryName",
+                                "allocatedAmount")),
+                new ReviewedSchema(
+                        ProjectCostControlDto.class,
+                        Set.of(),
+                        Set.of("projectId", "categories", "totals")),
+                new ReviewedSchema(
+                        ProjectCostControlLineDto.class,
+                        Set.of("costCategoryId"),
+                        Set.of("costCategoryName", "allocated", "committed", "spent", "remaining",
+                                "overBudget")),
+                new ReviewedSchema(
+                        PostingAccountMappingDto.class,
+                        Set.of(),
+                        Set.of("role", "source", "accountId", "accountCode", "accountName")),
+                new ReviewedSchema(
+                        FinanceSettingsDto.class,
+                        Set.of("approvalThreshold"),
+                        Set.of()));
     }
 }


### PR DESCRIPTION
The response side of #645, fifth module: **finance**. Same shape as the vendor pass (#678) and the procurement, receipts and attendance pass (#725). What is left is specified at the bottom rather than implied.

## What this pass did

Twenty schemas, 218 properties, 85 nullable. Picked on the criterion that chose the last three: this is the largest untouched block and it is money, so a client writing `?? 0` on an unmarked field turns "no figure was agreed" into a figure someone will act on.

| schema | nullable | of |
|---|---|---|
| `ConstructionInvoiceDto` | 21 | 36 |
| `ConstructionPaymentDto` | 22 | 31 |
| `ConstructionInvoiceLineDto` | 5 | 16 |
| `InvoiceDto` | 3 | 16 |
| `InvoiceLineDto` | 0 | 10 |
| `PaymentDto` | 3 | 13 |
| `AllocationDto` | 0 | 4 |
| `JournalEntryDto` | 6 | 13 |
| `JournalEntryLineDto` | 1 | 8 |
| `AccountDto` | 2 | 7 |
| `AccountTreeDto` | 1 | 8 |
| `CustomerDto` | 7 | 11 |
| `AddressDto` | 7 | 7 |
| `CompanyBankAccountDto` | 2 | 11 |
| `CostCategoryDto` | 3 | 6 |
| `BudgetAllocationDto` | 0 | 5 |
| `ProjectCostControlDto` | 0 | 3 |
| `ProjectCostControlLineDto` | 1 | 7 |
| `PostingAccountMappingDto` | 0 | 5 |
| `FinanceSettingsDto` | 1 | 1 |

`ReviewedResponseSchemas` records both halves and `ResponseNullabilityRatchetTest` holds the table, the annotation and the published document to each other, so a property added to any of these fails the build until someone classifies it.

## The warning the last pass left did not fire here

The procurement pass found three entities declaring `@JoinColumn(name = "project_id", nullable = false)` over a nullable column, which `ddl-auto: validate` cannot catch. Finance has no such disagreement: every `@Column` and `@JoinColumn` in the module matches its changeset, checked rather than assumed. Nothing filed as a defect from this pass.

## Where an answer did not come from a column

The line the earlier passes drew holds: a computed value with no column is non-null, and a nullable column stays nullable even where the application writes it on every path.

- **`InvoiceDto.balanceDue`** is the third instance of the `VendorSummaryDto` / `PayableDto.amountDue` shape. `Invoice.balanceDue()` subtracts one `NOT NULL` column from another and has no column of its own, so nothing in it can produce a null.
- **`ProjectCostControlDto` and its lines** are computed end to end. Every figure passes through `MoneyUtils.normalize`, which turns a null into zero; the head name falls back to `(unknown)`, and the totals row is labelled. Only `costCategoryId` admits null, and only on that totals row, which is what its null means.
- **`PostingAccountMappingDto`** is non-null throughout because `PostingAccountResolver.resolveWithSource` either returns an account or throws. A role with no mapping falls back to the configured default code, and a default code that resolves to nothing is an error rather than a null account.
- **`CustomerDto.billingAddress`** is nullable for a reason that is neither a column nor a mapper. `Address` is an `@Embedded` value whose seven columns are all nullable, and Hibernate leaves the embedded object null when every one of them is, whatever the `= new Address()` initialiser on `Customer` says. That makes `AddressDto` the one schema here with nothing at all in its non-null half.

## Two things that look inconsistent and are not

**Construction invoice money is non-null where purchase order money was not.** `subtotal`, `taxAmount`, `discountAmount`, `totalAmount`, `paidAmount` and `balanceAmount` sit on `NOT NULL` columns, so the constraint carries the claim; `PurchaseOrderDto.totalAmount` had a nullable column behind the same computation.

**`JournalEntryDto.createdBy` is nullable where `createdAt` on the same schema is not.** The two auditing columns disagree in the changelog: `created_at` is `NOT NULL` and `created_by` is not.

## Document diff

Audited semantically rather than by line count: **73 properties changed, 0 added, 0 removed**, `paths` byte-identical, and nothing outside the thirteen schemas that gained an annotation. The other twelve nullable properties were already marked and already published as unions. Non-null properties keep the descriptions they had, so the diff is the real change rather than a rewrite.

## Remaining

- **About 1587 response-only properties across 134 schemas**, of which roughly 435 are Spring's own `Page*` wrappers and are not ours to annotate. The reviewed set is now 34 schemas and 409 properties. The largest untouched blocks are `leave` (129), `inspection` (119), the rest of `attendance` (86) and `asset` (72).
- **The bean-bound request properties**, about 1000, unchanged in priority from the #670 comment.
- **The `echno-core` response-side check** now has 34 schemas to check against, which is past the two or three modules the vendor comment said would make it worth filing.

Refs #645