### PR TITLE
Classify the leave and inspection response schemas for nullability

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9122,7 +9122,6 @@
           },
           "delegatedFromName": {
             "description": "Name of the approver this action was delegated from. Always null on this response: the mapper leaves the field unset and nothing else fills it in, so resolve the name from delegatedFromId.",
-            "example": "Suresh Pillai",
             "type": [
               "string",
               "null"
@@ -10362,7 +10361,6 @@
           },
           "createdByName": {
             "description": "Name of the employee who created the transaction. Always null on this response: the mapper leaves the field unset and nothing else fills it in, so resolve the name from createdById.",
-            "example": "Anand Rajan",
             "type": [
               "string",
               "null"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2575,7 +2575,11 @@
             "type": "string"
           },
           "description": {
-            "type": "string"
+            "description": "What the template covers. Null where none was recorded, including on a template adopted from a starter checklist that carried none.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "format": "uuid",
@@ -2626,7 +2630,11 @@
         "description": "A check point within a checklist template, as returned by the API.",
         "properties": {
           "acceptanceCriterion": {
-            "type": "string"
+            "description": "What makes the check point pass. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "category": {
             "type": "string"
@@ -2635,7 +2643,11 @@
             "type": "string"
           },
           "expectedValue": {
-            "type": "string"
+            "description": "Target value the check point is measured against. Null on qualitative check points.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "format": "uuid",
@@ -2649,13 +2661,25 @@
             "type": "boolean"
           },
           "priority": {
-            "type": "string"
+            "description": "Priority of the check point. The service substitutes \"medium\" wherever a payload or a starter checklist omits it, but the column permits null, so a row loaded outside the application can carry none.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "specification": {
-            "type": "string"
+            "description": "Reference specification for the check point. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "tolerance": {
-            "type": "string"
+            "description": "Permitted band around the expected value. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -4979,8 +5003,12 @@
         "description": "A mark drawn over one defect photo. Coordinates are fractions of the image width and height, so the mark holds its place at any rendered size.",
         "properties": {
           "createdById": {
+            "description": "Employee who drew the mark, resolved from the signed-in user's employee record in the current organization. Null where that user has no employee record.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "id": {
             "format": "uuid",
@@ -4991,7 +5019,11 @@
             "type": "string"
           },
           "label": {
-            "type": "string"
+            "description": "Caption printed against the mark. Null where the mark was drawn without one.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "lineOrder": {
             "format": "int32",
@@ -6773,10 +6805,18 @@
         "description": "A checklist item within an inspection, as returned by the API.",
         "properties": {
           "acceptanceCriterion": {
-            "type": "string"
+            "description": "What makes the check point pass, copied from the checklist template when the inspection was created. Null where the template carried none.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "bimElementGuid": {
-            "type": "string"
+            "description": "IFC GlobalId of the BIM element the check point was carried out against. Copied from the payload, which no client fills in until the BIM viewer lands, so it is null on every row today.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "category": {
             "type": "string"
@@ -6785,17 +6825,29 @@
             "type": "string"
           },
           "deviation": {
-            "type": "number"
+            "description": "Measured value minus the expected one, computed server-side on every save. Null wherever the two do not both parse as a number in the same unit, which is the normal case for a qualitative check point.",
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "expectedValue": {
-            "type": "string"
+            "description": "Value expected per specification. Null on check points with no numeric target.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "format": "uuid",
             "type": "string"
           },
           "measurement": {
-            "type": "string"
+            "description": "Measured value recorded on site. Null until a measurement is taken, and on qualitative check points that carry none.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "photos": {
             "items": {
@@ -6807,13 +6859,25 @@
             "type": "boolean"
           },
           "priority": {
-            "type": "string"
+            "description": "Priority of the check point. The service substitutes \"medium\" wherever a payload omits it, but the column permits null, so a row loaded outside the application can carry none.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "remarks": {
-            "type": "string"
+            "description": "Free-text remarks recorded against the check point. Null where none were recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "specification": {
-            "type": "string"
+            "description": "Reference specification for the check point. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "enum": [
@@ -6825,7 +6889,11 @@
             "type": "string"
           },
           "tolerance": {
-            "type": "string"
+            "description": "Permitted band around the expected value, copied from the checklist template. Null where the template carried none.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -6940,7 +7008,11 @@
         "description": "A defect identified during an inspection, as returned by the API.",
         "properties": {
           "category": {
-            "type": "string"
+            "description": "Grouping the defect belongs to. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "correctiveAction": {
             "type": "string"
@@ -6953,7 +7025,11 @@
             "type": "string"
           },
           "location": {
-            "type": "string"
+            "description": "Where on site the defect was found. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "photos": {
             "items": {
@@ -6962,32 +7038,52 @@
             "type": "array"
           },
           "resolvedDate": {
+            "description": "Date the defect was resolved. Null until it is.",
             "format": "date",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "responsibleParty": {
-            "type": "string"
+            "description": "Who is accountable for putting the defect right. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "severity": {
+            "description": "How serious the defect is. Null where none was recorded: the migration that promoted the free-text column to the enum cleared blank values to null rather than guessing a severity.",
             "enum": [
               "critical",
               "major",
               "minor"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
+            "description": "Where the defect stands. The service substitutes OPEN wherever a payload omits it, but the column permits null, so a row loaded outside the application can carry none.",
             "enum": [
               "open",
               "in-progress",
               "resolved",
               "verified"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "targetDate": {
+            "description": "Date the corrective action is due. Null where none was agreed.",
             "format": "date",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -7083,18 +7179,34 @@
         "description": "An inspection as returned by the API, including its checklist items, defects and summary counts.",
         "properties": {
           "actualEndTime": {
+            "description": "When the inspection actually finished. Null until it is carried out.",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "actualStartTime": {
+            "description": "When the inspection actually started. Null until it is carried out.",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "aiRationale": {
-            "type": "string"
+            "description": "The model's reasoning for suggesting this compliance inspection. Written only by the compliance generation service, so null on every manually created inspection.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "areaInspected": {
-            "type": "string"
+            "description": "Specific area inspected within the location. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "attendees": {
             "items": {
@@ -7118,22 +7230,38 @@
             "type": "array"
           },
           "clientRepresentative": {
-            "type": "string"
+            "description": "Name of the client's representative present at the inspection. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "compliancePhase": {
+            "description": "Project phase the compliance rule applies to. Written only by the compliance generation service, so null on every manually created inspection.",
             "enum": [
               "pre-construction",
               "ongoing",
               "post-construction"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "complianceRuleRef": {
-            "type": "string"
+            "description": "Code of the compliance rule that produced this inspection. Written only by the compliance generation service, so null on every manually created inspection.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "contractorId": {
+            "description": "Contractor whose work is being inspected. Null where the inspection is not against a contractor's work.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "createdAt": {
             "format": "date-time",
@@ -7150,11 +7278,19 @@
             "type": "integer"
           },
           "drawingReference": {
-            "type": "string"
+            "description": "Drawing the inspection was carried out against. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "duration": {
+            "description": "Duration of the inspection in minutes, stored as sent on the payload and never derived from the start and end times. Null where the payload carried none.",
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "failedCheckPoints": {
             "format": "int32",
@@ -7168,11 +7304,19 @@
             "type": "string"
           },
           "inspectorId": {
+            "description": "Employee performing the inspection. Every payload the API accepts requires one, but AI-generated compliance inspections are written by the generation service without an inspector, so those carry none until a project manager assigns one.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "location": {
-            "type": "string"
+            "description": "Site or building location of the inspection. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "origin": {
             "enum": [
@@ -7186,36 +7330,60 @@
             "type": "integer"
           },
           "projectId": {
+            "description": "Project the inspection is against. The column permits null and the create payload does not require the field, so an inspection can be recorded without a project.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "resolutionOptions": {
-            "type": "string"
+            "description": "Newline-separated ways of satisfying the compliance rule, taken from the model's suggestion and falling back to the rule's own. Written only by the compliance generation service, so null on every manually created inspection, and null again where the rule itself lists none.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "result": {
+            "description": "Overall outcome of the inspection. Null until the inspection is concluded and a result is recorded against it.",
             "enum": [
               "passed",
               "failed",
               "passed-with-remarks",
               "pending"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "riskLevel": {
+            "description": "Risk the compliance rule carries, taken from the model's suggestion and falling back to the rule's own default. Written only by the compliance generation service, so null on every manually created inspection, and null again where the rule itself carries no default.",
             "enum": [
               "low",
               "medium",
               "high",
               "critical"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "scheduledDate": {
+            "description": "Date the inspection is scheduled for. Every payload the API accepts requires one, but AI-generated compliance inspections are written by the generation service without a schedule, so those carry none until a project manager fills it in.",
             "format": "date",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "scheduledTime": {
-            "type": "string"
+            "description": "Scheduled time of day. Null where only a date was given.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "enum": [
@@ -7231,7 +7399,11 @@
             "type": "string"
           },
           "temperature": {
-            "type": "string"
+            "description": "Ambient temperature at the time of the inspection. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "title": {
             "type": "string"
@@ -7241,6 +7413,7 @@
             "type": "integer"
           },
           "trade": {
+            "description": "QA/QC stage or trade the inspection covers. Null on safety and compliance inspections, which carry no trade, and null on a QA/QC inspection whose payload omitted it.",
             "enum": [
               "pre-construction-documentation",
               "shuttering-formwork",
@@ -7259,7 +7432,10 @@
               "dimensional-check",
               "progress-check"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "type": {
             "enum": [
@@ -7280,7 +7456,11 @@
             "type": "string"
           },
           "weatherConditions": {
-            "type": "string"
+            "description": "Weather at the time of the inspection. Null where none was recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -8884,10 +9064,13 @@
             "type": "string"
           },
           "actionAt": {
-            "description": "Time the action was taken.",
+            "description": "Time the action was taken. Null while the approval is still pending, since the column is written only when the approver acts.",
             "example": "2026-08-31T10:05:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "approvalLevel": {
             "description": "Approval level this action was taken at.",
@@ -8896,9 +9079,12 @@
             "type": "integer"
           },
           "approverDesignation": {
-            "description": "Job title of the employee who took the action.",
+            "description": "Job title of the employee who took the action. Null where the employee record carries no designation, which the employee table permits.",
             "example": "Site Manager",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "approverId": {
             "description": "Id of the employee who took the action.",
@@ -8912,9 +9098,12 @@
             "type": "string"
           },
           "comments": {
-            "description": "Comments on the action.",
+            "description": "Comments on the action. Null where the approver recorded none, and on the pending rows written when the approval chain is built, which carry no comment yet.",
             "example": "Approved, please plan handover before you leave",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "createdAt": {
             "description": "Time this approval record was created.",
@@ -8923,15 +9112,21 @@
             "type": "string"
           },
           "delegatedFromId": {
-            "description": "Id of the approver this action was delegated from, if any.",
+            "description": "Id of the approver this action was delegated from. Null unless the action reached this approver by delegation.",
             "example": 3,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "delegatedFromName": {
-            "description": "Name of the approver this action was delegated from, if any.",
+            "description": "Name of the approver this action was delegated from. Always null on this response: the mapper leaves the field unset and nothing else fills it in, so resolve the name from delegatedFromId.",
             "example": "Suresh Pillai",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Id of the approval record.",
@@ -9014,16 +9209,22 @@
             "type": "number"
           },
           "carryForwardExpiryDate": {
-            "description": "Date the carried-forward days expire, if the policy sets one.",
+            "description": "Date the carried-forward days expire. Null where the policy sets no carry-forward expiry, and where nothing was carried forward.",
             "example": "2026-03-31",
             "format": "date",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "carryForwardFromPrevious": {
-            "description": "Days carried forward from the previous year.",
+            "description": "Days carried forward from the previous year. Written as zero on every balance the application creates, but the column permits null, so a row loaded outside the application can carry none.",
             "example": 1.5,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "employeeId": {
             "description": "Id of the employee this balance belongs to.",
@@ -9043,10 +9244,13 @@
             "type": "integer"
           },
           "lastCalculatedAt": {
-            "description": "Time this balance was last recalculated.",
+            "description": "Time this balance was last recalculated. Null until the accrual service first runs against the balance, and on the transient zero balance returned for a year before the employee joined.",
             "example": "2026-08-20T02:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "leavePolicy": {
             "$ref": "#/components/schemas/LeavePolicySimpleDto",
@@ -9141,9 +9345,12 @@
             "type": "string"
           },
           "department": {
-            "description": "Department of the employee on leave.",
+            "description": "Department of the employee on leave. Copied from the employee record when the entry is written, and null where that record carries no department.",
             "example": "Civil",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "employeeId": {
             "description": "Id of the employee on leave.",
@@ -9375,21 +9582,30 @@
         "description": "A leave policy with its quota, accrual and eligibility rules.",
         "properties": {
           "accrualRatePerMonth": {
-            "description": "Days accrued per completed month, for policies that accrue monthly.",
+            "description": "Days accrued per completed month. Null for policies that grant the full quota upfront instead of accruing monthly.",
             "example": 1.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "advanceNoticeDays": {
-            "description": "Minimum number of days' notice required before the leave starts.",
+            "description": "Minimum number of days' notice required before the leave starts. Defaults to 0 on a create payload that omits the field; a null sent explicitly is stored as null, because the column permits it.",
             "example": 2,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "allowHalfDay": {
-            "description": "Whether requests under this policy can be for half a day.",
+            "description": "Whether requests under this policy can be for half a day. Defaults to true when the create payload omits the field, and is null where the payload set it to null, which the column allows.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "annualQuota": {
             "description": "Total days granted per year under this policy.",
@@ -9398,27 +9614,39 @@
             "type": "number"
           },
           "applicableGenders": {
-            "description": "Genders this policy applies to.",
+            "description": "Genders this policy applies to. Defaults to ALL for a create payload that omits the field. The column is nullable, so a policy created with an explicit null carries none.",
             "example": "ALL",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "attachmentRequiredAfterDays": {
-            "description": "Number of consecutive days after which an attachment becomes required.",
+            "description": "Number of consecutive days after which an attachment becomes required. Null where the policy sets no such threshold.",
             "example": 3,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "carryForwardExpiryMonths": {
-            "description": "Number of months into the next year before carried-forward days expire.",
+            "description": "Number of months into the next year before carried-forward days expire. Null where carried-forward days do not expire, and on any policy that allows no carry forward at all.",
             "example": 3,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "carryForwardLimit": {
-            "description": "Maximum days that can be carried forward into the next year.",
+            "description": "Maximum days that can be carried forward into the next year. Null where the policy allows no carry forward.",
             "example": 5.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "createdAt": {
             "description": "Time the policy was created.",
@@ -9427,15 +9655,21 @@
             "type": "string"
           },
           "description": {
-            "description": "Description of the leave type and when it applies.",
+            "description": "Description of the leave type and when it applies. Null where the policy was created without one.",
             "example": "Short-notice leave for personal matters, not carried forward beyond the configured limit",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "displayOrder": {
-            "description": "Order this policy is shown in, relative to the organization's other policies.",
+            "description": "Order this policy is shown in, relative to the organization's other policies. Defaults to 0 when the create payload omits the field; the nullable column keeps an explicit null.",
             "example": 1,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "id": {
             "description": "Id of the policy.",
@@ -9449,9 +9683,12 @@
             "type": "boolean"
           },
           "isPaid": {
-            "description": "Whether leave taken under this policy is paid.",
+            "description": "Whether leave taken under this policy is paid. Defaults to true on a create payload that omits the field. The column is nullable, so an explicit null is stored and returned.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "leaveTypeCode": {
             "description": "Short code identifying the leave type.",
@@ -9464,22 +9701,31 @@
             "type": "string"
           },
           "maxDaysPerRequest": {
-            "description": "Largest number of days that can be requested at once.",
+            "description": "Largest number of days that can be requested at once. Null where the policy sets no per-request ceiling.",
             "example": 15.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "minDaysPerRequest": {
-            "description": "Smallest number of days that can be requested at once.",
+            "description": "Smallest number of days that can be requested at once. The create payload defaults it to 0.5 when the field is omitted, but the column is nullable and a null sent explicitly is written through.",
             "example": 0.5,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "minServiceMonths": {
-            "description": "Minimum months of service before an employee becomes eligible.",
+            "description": "Minimum months of service before an employee becomes eligible. Defaults to 0 when the create payload omits the field; the column is nullable, so an explicit null survives to the response.",
             "example": 6,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "multiLevelApprovalEnabled": {
             "description": "Whether leave requests under this policy go through the full multi-level approval chain (the employee's management line). When false, a single approval by the direct approver finalizes the request.",
@@ -9498,9 +9744,12 @@
             "type": "string"
           },
           "requiresAttachment": {
-            "description": "Whether a supporting attachment is required for requests under this policy.",
+            "description": "Whether a supporting attachment is required for requests under this policy. Defaults to false when the field is absent from the create payload, and stays null if the payload sends null, since the column is nullable.",
             "example": false,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "updatedAt": {
             "description": "Time the policy was last updated.",
@@ -9515,9 +9764,12 @@
         "description": "Condensed view of a leave policy, used when embedding it inside a request or balance record.",
         "properties": {
           "allowHalfDay": {
-            "description": "Whether requests under this policy can be for half a day.",
+            "description": "Whether requests under this policy can be for half a day. Defaults to true when the create payload omits the field, and is null where the payload set it to null, which the column allows.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "annualQuota": {
             "description": "Total days granted per year under this policy.",
@@ -9532,9 +9784,12 @@
             "type": "integer"
           },
           "isPaid": {
-            "description": "Whether leave taken under this policy is paid.",
+            "description": "Whether leave taken under this policy is paid. Defaults to true on a create payload that omits the field. The column is nullable, so an explicit null is stored and returned.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "leaveTypeCode": {
             "description": "Short code identifying the leave type.",
@@ -9799,20 +10054,29 @@
             "type": "array"
           },
           "cancellationReason": {
-            "description": "Reason the request was cancelled, if it was.",
+            "description": "Reason the request was cancelled. Null until the request is cancelled, and on a cancellation recorded without a reason.",
             "example": "Wedding postponed to next month",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "cancelledAt": {
-            "description": "Time the request was cancelled, if it was.",
+            "description": "Time the request was cancelled. Null until the request is cancelled.",
             "example": "2026-09-10T11:20:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "contactDuringLeave": {
-            "description": "Contact number or address reachable during the leave.",
+            "description": "Contact number or address reachable during the leave. Null where the requester supplied none.",
             "example": 9847012345,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "createdAt": {
             "description": "Time the request was created.",
@@ -9821,26 +10085,38 @@
             "type": "string"
           },
           "currentApprovalLevel": {
-            "description": "The approval level currently pending action.",
+            "description": "The approval level currently pending action. Set when the approval chain is built at submission, so it is null on a draft and on a request that was finalized immediately because no approver could be resolved for the employee.",
             "example": 1,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "currentApproverId": {
-            "description": "Id of the employee who must act next in the approval chain.",
+            "description": "Id of the employee who must act next in the approval chain. Never set on a draft, and cleared once the request reaches a final state (approved, rejected, cancelled or withdrawn).",
             "example": 5,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "currentApproverName": {
-            "description": "Name of the employee who must act next in the approval chain.",
+            "description": "Name of the employee who must act next in the approval chain. Null whenever currentApproverId is, since it is read from that employee.",
             "example": "Anitha Menon",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "department": {
-            "description": "Department of the employee who raised the request.",
+            "description": "Department of the employee who raised the request. Read from the employee record, which the employee table permits to carry no department.",
             "example": "Civil",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "employeeId": {
             "description": "Id of the employee who raised the request.",
@@ -9860,30 +10136,42 @@
             "type": "string"
           },
           "endHalfDayType": {
-            "description": "Whether the end date is a full day or a half day.",
+            "description": "Whether the end date is a full day or a half day. Null where the requester did not mark the last day as a half day; the column is written only when they did.",
             "enum": [
               "FULL_DAY",
               "FIRST_HALF",
               "SECOND_HALF"
             ],
             "example": "SECOND_HALF",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "handoverNotes": {
-            "description": "Notes for the person receiving the handover.",
+            "description": "Notes for the person receiving the handover. Null where none were written.",
             "example": "Site inspection at Asset Homes Chennai is due on 2026-09-15, please coordinate with the QA team",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "handoverToId": {
-            "description": "Id of the employee handling handover during the leave, if any.",
+            "description": "Id of the employee handling handover during the leave. Null where no handover was arranged.",
             "example": 12,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "handoverToName": {
-            "description": "Name of the employee handling handover during the leave, if any.",
+            "description": "Name of the employee handling handover during the leave. Filled in only by the single-request read; every list response, and every response returned by a create, update or approval action, leaves it null even when handoverToId is set.",
             "example": "Deepak Nair",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Id of the leave request.",
@@ -9896,10 +10184,13 @@
             "description": "Leave policy the request is raised under."
           },
           "maxApprovalLevel": {
-            "description": "The highest approval level configured for this request.",
+            "description": "The highest approval level configured for this request. Written alongside currentApprovalLevel when the chain is built, and null wherever that one is.",
             "example": 2,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "organizationId": {
             "description": "Id of the organization the employee belongs to.",
@@ -9924,14 +10215,17 @@
             "type": "string"
           },
           "startHalfDayType": {
-            "description": "Whether the start date is a full day or a half day.",
+            "description": "Whether the start date is a full day or a half day. Null where the requester did not mark the first day as a half day; the column is written only when they did.",
             "enum": [
               "FULL_DAY",
               "FIRST_HALF",
               "SECOND_HALF"
             ],
             "example": "FULL_DAY",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "Current status of the request.",
@@ -10058,15 +10352,21 @@
             "type": "string"
           },
           "createdById": {
-            "description": "Id of the employee who created the transaction, for manual adjustments.",
+            "description": "Id of the employee who created the transaction. Written only on a manual adjustment, so it is null on the accrual and approval-deduction rows the system posts itself.",
             "example": 2,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "createdByName": {
-            "description": "Name of the employee who created the transaction, for manual adjustments.",
+            "description": "Name of the employee who created the transaction. Always null on this response: the mapper leaves the field unset and nothing else fills it in, so resolve the name from createdById.",
             "example": "Anand Rajan",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "days": {
             "description": "Signed number of days moved by this transaction.",
@@ -10075,9 +10375,12 @@
             "type": "number"
           },
           "description": {
-            "description": "Description of the transaction.",
+            "description": "Description of the transaction. Written on every path the application takes (accrual, approval deduction and manual adjustment), but the column permits null, so a row loaded outside the application can carry none.",
             "example": "Deduction for leave request LR-2026-0241",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "employeeId": {
             "description": "Id of the employee this transaction belongs to.",
@@ -10103,10 +10406,13 @@
             "type": "integer"
           },
           "leaveRequestId": {
-            "description": "Id of the leave request this transaction is linked to, if any.",
+            "description": "Id of the leave request this transaction is linked to. Null for transactions with no originating request, such as a monthly accrual or a manual adjustment.",
             "example": 241,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "leaveTypeName": {
             "description": "Name of the leave type the balance is tracked under.",
@@ -10114,21 +10420,30 @@
             "type": "string"
           },
           "referenceMonth": {
-            "description": "Month the transaction is attributed to, for accrual transactions.",
+            "description": "Month the transaction is attributed to. Written only by the accrual service, so it is null on deductions and manual adjustments.",
             "example": 9,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "referenceYear": {
-            "description": "Year the transaction is attributed to.",
+            "description": "Year the transaction is attributed to. Written only by the accrual service, so it is null on deductions and manual adjustments.",
             "example": 2026,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "requestNumber": {
-            "description": "Request number of the linked leave request, if any.",
+            "description": "Request number of the linked leave request. Null whenever leaveRequestId is, since it is read from that request.",
             "example": "LR-2026-0241",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "transactionDate": {
             "description": "Date the transaction is effective.",
@@ -11357,27 +11672,47 @@
         "description": "A non-conformance report as returned by the API, with its assignment and closure trail.",
         "properties": {
           "closedAt": {
+            "description": "When the report was closed. Null until it is closed, and cleared again when a closed report is reopened.",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "closedById": {
+            "description": "Employee who closed the report. Null until the report is closed, cleared again when a closed report is reopened, and null where the closing user has no employee record in the current organization.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "correctiveActionCompletedAt": {
+            "description": "When the corrective action was marked complete. Null until it is.",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "correctiveActionRemarks": {
-            "type": "string"
+            "description": "What was done to correct the non-conformance. Null until the corrective action is marked complete.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "createdAt": {
             "format": "date-time",
             "type": "string"
           },
           "defectId": {
+            "description": "Inspection defect the report was raised from. Null where the report was raised against the inspection as a whole rather than one defect.",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "description": {
             "type": "string"
@@ -11394,20 +11729,32 @@
             "type": "string"
           },
           "raisedById": {
+            "description": "Employee who raised the report, resolved from the signed-in user's employee record in the current organization. Null where that user has no employee record.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "severity": {
+            "description": "How serious the non-conformance is. Null where none was recorded when the report was raised.",
             "enum": [
               "critical",
               "major",
               "minor"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "siteEngineerId": {
+            "description": "Site engineer the report is assigned to. Null until the report is assigned.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "status": {
             "enum": [
@@ -11422,8 +11769,12 @@
             "type": "string"
           },
           "targetDate": {
+            "description": "Date the corrective action is due. Null until one is set, which normally happens when the report is assigned.",
             "format": "date",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "title": {
             "type": "string"
@@ -11440,15 +11791,27 @@
             "type": "string"
           },
           "verificationRemarks": {
-            "type": "string"
+            "description": "Remarks recorded at re-inspection. Null until the report is verified, rejected or reopened.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "verifiedAt": {
+            "description": "When the corrective work was accepted or refused on re-inspection. Null until re-inspection.",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "verifiedById": {
+            "description": "Employee who accepted or refused the corrective work on re-inspection. Null until re-inspection, and null again where the verifying user has no employee record in the current organization.",
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -11470,9 +11833,12 @@
         "description": "An in-app notification raised by an event in the leave workflow.",
         "properties": {
           "actionUrl": {
-            "description": "URL the client should navigate to when the notification is opened.",
+            "description": "URL the client should navigate to when the notification is opened. Null where the sender supplied none, leaving the notification with nothing to open.",
             "example": "/leave-requests/241",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "createdAt": {
             "description": "Time the notification was created.",
@@ -11481,15 +11847,21 @@
             "type": "string"
           },
           "entityId": {
-            "description": "Id of the entity this notification refers to.",
+            "description": "Id of the entity this notification refers to. Null whenever entityType is, since the two are set together.",
             "example": 241,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "entityType": {
-            "description": "Type of the entity this notification refers to.",
+            "description": "Type of the entity this notification refers to. The leave senders always set it, but a notification raised through the generic delivery seam carries whatever the sender put in the draft, which may be nothing.",
             "example": "LEAVE_REQUEST",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Id of the notification.",
@@ -11524,10 +11896,13 @@
             "type": "string"
           },
           "readAt": {
-            "description": "Time the notification was read, if it has been.",
+            "description": "Time the notification was read. Null until it is marked read.",
             "example": "2026-08-31T09:10:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "recipientId": {
             "description": "Id of the employee the notification is addressed to.",
@@ -16779,7 +17154,11 @@
         "description": "A product-supplied starter checklist for one trade, which an organization adopts to create its own editable template.",
         "properties": {
           "description": {
-            "type": "string"
+            "description": "What the starter checklist covers. Null where the shipped seed row carried none.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "format": "uuid",

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateDto.java
@@ -12,6 +12,9 @@ public record ChecklistTemplateDto(
         UUID id,
         InspectionTrade trade,
         String name,
+        @Schema(description = "What the template covers. Null where none was recorded, including "
+                + "on a template adopted from a starter checklist that carried none.",
+                nullable = true)
         String description,
         boolean active,
         int version,

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateItemDto.java
@@ -9,11 +9,22 @@ public record ChecklistTemplateItemDto(
         UUID id,
         String category,
         String checkPoint,
+        @Schema(description = "Reference specification for the check point. Null where none was "
+                + "recorded.", nullable = true)
         String specification,
+        @Schema(description = "Target value the check point is measured against. Null on "
+                + "qualitative check points.", nullable = true)
         String expectedValue,
+        @Schema(description = "What makes the check point pass. Null where none was recorded.",
+                nullable = true)
         String acceptanceCriterion,
+        @Schema(description = "Permitted band around the expected value. Null where none was "
+                + "recorded.", nullable = true)
         String tolerance,
         boolean photosRequired,
+        @Schema(description = "Priority of the check point. The service substitutes \"medium\" "
+                + "wherever a payload or a starter checklist omits it, but the column permits "
+                + "null, so a row loaded outside the application can carry none.", nullable = true)
         String priority,
         int lineOrder
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/DefectPhotoAnnotationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/DefectPhotoAnnotationDto.java
@@ -17,7 +17,12 @@ public record DefectPhotoAnnotationDto(
         BigDecimal y1,
         BigDecimal x2,
         BigDecimal y2,
+        @Schema(description = "Caption printed against the mark. Null where the mark was drawn "
+                + "without one.", nullable = true)
         String label,
         int lineOrder,
+        @Schema(description = "Employee who drew the mark, resolved from the signed-in user's "
+                + "employee record in the current organization. Null where that user has no "
+                + "employee record.", nullable = true)
         Long createdById
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemDto.java
@@ -12,16 +12,38 @@ public record InspectionCheckItemDto(
         UUID id,
         String category,
         String checkPoint,
+        @Schema(description = "Reference specification for the check point. Null where none was "
+                + "recorded.", nullable = true)
         String specification,
         CheckItemStatus status,
+        @Schema(description = "Free-text remarks recorded against the check point. Null where none "
+                + "were recorded.", nullable = true)
         String remarks,
         boolean photosRequired,
         List<String> photos,
+        @Schema(description = "Measured value recorded on site. Null until a measurement is taken, "
+                + "and on qualitative check points that carry none.", nullable = true)
         String measurement,
+        @Schema(description = "Value expected per specification. Null on check points with no "
+                + "numeric target.", nullable = true)
         String expectedValue,
+        @Schema(description = "What makes the check point pass, copied from the checklist template "
+                + "when the inspection was created. Null where the template carried none.",
+                nullable = true)
         String acceptanceCriterion,
+        @Schema(description = "Permitted band around the expected value, copied from the checklist "
+                + "template. Null where the template carried none.", nullable = true)
         String tolerance,
+        @Schema(description = "Measured value minus the expected one, computed server-side on "
+                + "every save. Null wherever the two do not both parse as a number in the same "
+                + "unit, which is the normal case for a qualitative check point.", nullable = true)
         BigDecimal deviation,
+        @Schema(description = "IFC GlobalId of the BIM element the check point was carried out "
+                + "against. Copied from the payload, which no client fills in until the BIM "
+                + "viewer lands, so it is null on every row today.", nullable = true)
         String bimElementGuid,
+        @Schema(description = "Priority of the check point. The service substitutes \"medium\" "
+                + "wherever a payload omits it, but the column permits null, so a row loaded "
+                + "outside the application can carry none.", nullable = true)
         String priority
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectDto.java
@@ -11,14 +11,29 @@ import java.util.UUID;
 @Schema(description = "A defect identified during an inspection, as returned by the API.")
 public record InspectionDefectDto(
         UUID id,
+        @Schema(description = "Grouping the defect belongs to. Null where none was recorded.",
+                nullable = true)
         String category,
         String description,
+        @Schema(description = "How serious the defect is. Null where none was recorded: the "
+                + "migration that promoted the free-text column to the enum cleared blank values "
+                + "to null rather than guessing a severity.", nullable = true)
         DefectSeverity severity,
+        @Schema(description = "Where on site the defect was found. Null where none was recorded.",
+                nullable = true)
         String location,
         List<String> photos,
         String correctiveAction,
+        @Schema(description = "Who is accountable for putting the defect right. Null where none "
+                + "was recorded.", nullable = true)
         String responsibleParty,
+        @Schema(description = "Date the corrective action is due. Null where none was agreed.",
+                nullable = true)
         LocalDate targetDate,
+        @Schema(description = "Where the defect stands. The service substitutes OPEN wherever a "
+                + "payload omits it, but the column permits null, so a row loaded outside the "
+                + "application can carry none.", nullable = true)
         DefectStatus status,
+        @Schema(description = "Date the defect was resolved. Null until it is.", nullable = true)
         LocalDate resolvedDate
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
@@ -22,33 +22,89 @@ public record InspectionDto(
         String title,
         InspectionType type,
         InspectionCategory category,
+        @Schema(description = "QA/QC stage or trade the inspection covers. Null on safety and "
+                + "compliance inspections, which carry no trade, and null on a QA/QC inspection "
+                + "whose payload omitted it.", nullable = true)
         InspectionTrade trade,
         InspectionStatus status,
+        @Schema(description = "Overall outcome of the inspection. Null until the inspection is "
+                + "concluded and a result is recorded against it.", nullable = true)
         InspectionResult result,
+        @Schema(description = "Project the inspection is against. The column permits null and the "
+                + "create payload does not require the field, so an inspection can be recorded "
+                + "without a project.", nullable = true)
         Long projectId,
+        @Schema(description = "Site or building location of the inspection. Null where none was "
+                + "recorded.", nullable = true)
         String location,
+        @Schema(description = "Specific area inspected within the location. Null where none was "
+                + "recorded.", nullable = true)
         String areaInspected,
+        @Schema(description = "Drawing the inspection was carried out against. Null where none was "
+                + "recorded.", nullable = true)
         String drawingReference,
+        @Schema(description = "Date the inspection is scheduled for. Every payload the API accepts "
+                + "requires one, but AI-generated compliance inspections are written by the "
+                + "generation service without a schedule, so those carry none until a project "
+                + "manager fills it in.", nullable = true)
         LocalDate scheduledDate,
+        @Schema(description = "Scheduled time of day. Null where only a date was given.",
+                nullable = true)
         String scheduledTime,
+        @Schema(description = "When the inspection actually started. Null until it is carried out.",
+                nullable = true)
         LocalDateTime actualStartTime,
+        @Schema(description = "When the inspection actually finished. Null until it is carried out.",
+                nullable = true)
         LocalDateTime actualEndTime,
+        @Schema(description = "Duration of the inspection in minutes, stored as sent on the payload "
+                + "and never derived from the start and end times. Null where the payload carried "
+                + "none.", nullable = true)
         Integer duration,
+        @Schema(description = "Employee performing the inspection. Every payload the API accepts "
+                + "requires one, but AI-generated compliance inspections are written by the "
+                + "generation service without an inspector, so those carry none until a project "
+                + "manager assigns one.", nullable = true)
         Long inspectorId,
+        @Schema(description = "Contractor whose work is being inspected. Null where the inspection "
+                + "is not against a contractor's work.", nullable = true)
         Long contractorId,
+        @Schema(description = "Name of the client's representative present at the inspection. Null "
+                + "where none was recorded.", nullable = true)
         String clientRepresentative,
         List<String> attendees,
+        @Schema(description = "Weather at the time of the inspection. Null where none was "
+                + "recorded.", nullable = true)
         String weatherConditions,
+        @Schema(description = "Ambient temperature at the time of the inspection. Null where none "
+                + "was recorded.", nullable = true)
         String temperature,
         int totalCheckPoints,
         int passedCheckPoints,
         int failedCheckPoints,
         int defectsFound,
         InspectionOrigin origin,
+        @Schema(description = "Project phase the compliance rule applies to. Written only by the "
+                + "compliance generation service, so null on every manually created inspection.",
+                nullable = true)
         CompliancePhase compliancePhase,
+        @Schema(description = "Risk the compliance rule carries, taken from the model's suggestion "
+                + "and falling back to the rule's own default. Written only by the compliance "
+                + "generation service, so null on every manually created inspection, and null "
+                + "again where the rule itself carries no default.", nullable = true)
         ComplianceRiskLevel riskLevel,
+        @Schema(description = "Newline-separated ways of satisfying the compliance rule, taken from "
+                + "the model's suggestion and falling back to the rule's own. Written only by the "
+                + "compliance generation service, so null on every manually created inspection, "
+                + "and null again where the rule itself lists none.", nullable = true)
         String resolutionOptions,
+        @Schema(description = "Code of the compliance rule that produced this inspection. Written "
+                + "only by the compliance generation service, so null on every manually created "
+                + "inspection.", nullable = true)
         String complianceRuleRef,
+        @Schema(description = "The model's reasoning for suggesting this compliance inspection. "
+                + "Written only by the compliance generation service, so null on every manually "
+                + "created inspection.", nullable = true)
         String aiRationale,
         List<InspectionCheckItemDto> checkItems,
         List<InspectionDefectDto> defects,

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/NcrDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/NcrDto.java
@@ -16,20 +16,48 @@ public record NcrDto(
         String ncrNumber,
         NcrType type,
         UUID inspectionId,
+        @Schema(description = "Inspection defect the report was raised from. Null where the report "
+                + "was raised against the inspection as a whole rather than one defect.",
+                nullable = true)
         UUID defectId,
         String title,
         String description,
+        @Schema(description = "How serious the non-conformance is. Null where none was recorded "
+                + "when the report was raised.", nullable = true)
         DefectSeverity severity,
         NcrStatus status,
+        @Schema(description = "Site engineer the report is assigned to. Null until the report is "
+                + "assigned.", nullable = true)
         Long siteEngineerId,
+        @Schema(description = "Date the corrective action is due. Null until one is set, which "
+                + "normally happens when the report is assigned.", nullable = true)
         LocalDate targetDate,
+        @Schema(description = "Employee who raised the report, resolved from the signed-in user's "
+                + "employee record in the current organization. Null where that user has no "
+                + "employee record.", nullable = true)
         Long raisedById,
+        @Schema(description = "Employee who accepted or refused the corrective work on "
+                + "re-inspection. Null until re-inspection, and null again where the verifying "
+                + "user has no employee record in the current organization.", nullable = true)
         Long verifiedById,
+        @Schema(description = "Employee who closed the report. Null until the report is closed, "
+                + "cleared again when a closed report is reopened, and null where the closing user "
+                + "has no employee record in the current organization.", nullable = true)
         Long closedById,
+        @Schema(description = "What was done to correct the non-conformance. Null until the "
+                + "corrective action is marked complete.", nullable = true)
         String correctiveActionRemarks,
+        @Schema(description = "Remarks recorded at re-inspection. Null until the report is "
+                + "verified, rejected or reopened.", nullable = true)
         String verificationRemarks,
+        @Schema(description = "When the corrective action was marked complete. Null until it is.",
+                nullable = true)
         LocalDateTime correctiveActionCompletedAt,
+        @Schema(description = "When the corrective work was accepted or refused on re-inspection. "
+                + "Null until re-inspection.", nullable = true)
         LocalDateTime verifiedAt,
+        @Schema(description = "When the report was closed. Null until it is closed, and cleared "
+                + "again when a closed report is reopened.", nullable = true)
         LocalDateTime closedAt,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/StarterChecklistTemplateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/StarterChecklistTemplateDto.java
@@ -12,6 +12,8 @@ public record StarterChecklistTemplateDto(
         UUID id,
         InspectionTrade trade,
         String name,
+        @Schema(description = "What the starter checklist covers. Null where the shipped seed row "
+                + "carried none.", nullable = true)
         String description,
         List<ChecklistTemplateItemDto> items
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalDto.java
@@ -42,7 +42,7 @@ public class LeaveApprovalDto {
 
     @Schema(nullable = true, description = "Name of the approver this action was delegated from. Always null "
             + "on this response: the mapper leaves the field unset and nothing else fills it in, so resolve the "
-            + "name from delegatedFromId.", example = "Suresh Pillai")
+            + "name from delegatedFromId.")
     private String delegatedFromName;
 
     @Schema(nullable = true, description = "Time the action was taken. Null while the approval is still "

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalDto.java
@@ -21,7 +21,8 @@ public class LeaveApprovalDto {
     @Schema(description = "Name of the employee who took the action.", example = "Anitha Menon")
     private String approverName;
 
-    @Schema(description = "Job title of the employee who took the action.", example = "Site Manager")
+    @Schema(nullable = true, description = "Job title of the employee who took the action. Null where the "
+            + "employee record carries no designation, which the employee table permits.", example = "Site Manager")
     private String approverDesignation;
 
     @Schema(description = "Approval level this action was taken at.", example = "1")
@@ -30,16 +31,22 @@ public class LeaveApprovalDto {
     @Schema(description = "The action taken.", example = "APPROVED")
     private ApprovalAction action;
 
-    @Schema(description = "Comments on the action.", example = "Approved, please plan handover before you leave")
+    @Schema(nullable = true, description = "Comments on the action. Null where the approver recorded none, "
+            + "and on the pending rows written when the approval chain is built, which carry no comment yet.",
+            example = "Approved, please plan handover before you leave")
     private String comments;
 
-    @Schema(description = "Id of the approver this action was delegated from, if any.", example = "3")
+    @Schema(nullable = true, description = "Id of the approver this action was delegated from. Null unless "
+            + "the action reached this approver by delegation.", example = "3")
     private Long delegatedFromId;
 
-    @Schema(description = "Name of the approver this action was delegated from, if any.", example = "Suresh Pillai")
+    @Schema(nullable = true, description = "Name of the approver this action was delegated from. Always null "
+            + "on this response: the mapper leaves the field unset and nothing else fills it in, so resolve the "
+            + "name from delegatedFromId.", example = "Suresh Pillai")
     private String delegatedFromName;
 
-    @Schema(description = "Time the action was taken.", example = "2026-08-31T10:05:00")
+    @Schema(nullable = true, description = "Time the action was taken. Null while the approval is still "
+            + "pending, since the column is written only when the approver acts.", example = "2026-08-31T10:05:00")
     private LocalDateTime actionAt;
 
     @Schema(description = "Time this approval record was created.", example = "2026-08-31T10:05:00")

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveBalanceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveBalanceDto.java
@@ -42,12 +42,17 @@ public class LeaveBalanceDto {
     @Schema(description = "Days that can still be booked, respecting per-request limits.", example = "6.5")
     private Double bookable;
 
-    @Schema(description = "Days carried forward from the previous year.", example = "1.5")
+    @Schema(nullable = true, description = "Days carried forward from the previous year. Written as zero on "
+            + "every balance the application creates, but the column permits null, so a row loaded outside the "
+            + "application can carry none.", example = "1.5")
     private Double carryForwardFromPrevious;
 
-    @Schema(description = "Date the carried-forward days expire, if the policy sets one.", example = "2026-03-31")
+    @Schema(nullable = true, description = "Date the carried-forward days expire. Null where the policy sets "
+            + "no carry-forward expiry, and where nothing was carried forward.", example = "2026-03-31")
     private LocalDate carryForwardExpiryDate;
 
-    @Schema(description = "Time this balance was last recalculated.", example = "2026-08-20T02:00:00")
+    @Schema(nullable = true, description = "Time this balance was last recalculated. Null until the accrual "
+            + "service first runs against the balance, and on the transient zero balance returned for a year "
+            + "before the employee joined.", example = "2026-08-20T02:00:00")
     private LocalDateTime lastCalculatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveCalendarDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveCalendarDto.java
@@ -21,7 +21,8 @@ public class LeaveCalendarDto {
     @Schema(description = "Name of the employee on leave.", example = "Ravi Kumar")
     private String employeeName;
 
-    @Schema(description = "Department of the employee on leave.", example = "Civil")
+    @Schema(nullable = true, description = "Department of the employee on leave. Copied from the employee "
+            + "record when the entry is written, and null where that record carries no department.", example = "Civil")
     private String department;
 
     @Schema(description = "Id of the leave request this entry comes from.", example = "241")

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyDto.java
@@ -23,47 +23,68 @@ public class LeavePolicyDto {
     @Schema(description = "Display name of the leave type.", example = "Casual Leave")
     private String leaveTypeName;
 
-    @Schema(description = "Description of the leave type and when it applies.", example = "Short-notice "
+    @Schema(nullable = true, description = "Description of the leave type and when it applies. Null where "
+            + "the policy was created without one.", example = "Short-notice "
             + "leave for personal matters, not carried forward beyond the configured limit")
     private String description;
 
     @Schema(description = "Total days granted per year under this policy.", example = "12.0")
     private Double annualQuota;
 
-    @Schema(description = "Days accrued per completed month, for policies that accrue monthly.", example = "1.0")
+    @Schema(nullable = true, description = "Days accrued per completed month. Null for policies that grant "
+            + "the full quota upfront instead of accruing monthly.", example = "1.0")
     private Double accrualRatePerMonth;
 
-    @Schema(description = "Maximum days that can be carried forward into the next year.", example = "5.0")
+    @Schema(nullable = true, description = "Maximum days that can be carried forward into the next year. "
+            + "Null where the policy allows no carry forward.", example = "5.0")
     private Double carryForwardLimit;
 
-    @Schema(description = "Number of months into the next year before carried-forward days expire.", example = "3")
+    @Schema(nullable = true, description = "Number of months into the next year before carried-forward days "
+            + "expire. Null where carried-forward days do not expire, and on any policy that allows no carry "
+            + "forward at all.", example = "3")
     private Integer carryForwardExpiryMonths;
 
-    @Schema(description = "Smallest number of days that can be requested at once.", example = "0.5")
+    @Schema(nullable = true, description = "Smallest number of days that can be requested at once. The "
+            + "create payload defaults it to 0.5 when the field is omitted, but the column is nullable and a "
+            + "null sent explicitly is written through.", example = "0.5")
     private Double minDaysPerRequest;
 
-    @Schema(description = "Largest number of days that can be requested at once.", example = "15.0")
+    @Schema(nullable = true, description = "Largest number of days that can be requested at once. Null "
+            + "where the policy sets no per-request ceiling.", example = "15.0")
     private Double maxDaysPerRequest;
 
-    @Schema(description = "Minimum number of days' notice required before the leave starts.", example = "2")
+    @Schema(nullable = true, description = "Minimum number of days' notice required before the leave "
+            + "starts. Defaults to 0 on a create payload that omits the field; a null sent explicitly is "
+            + "stored as null, because the column permits it.", example = "2")
     private Integer advanceNoticeDays;
 
-    @Schema(description = "Whether a supporting attachment is required for requests under this policy.", example = "false")
+    @Schema(nullable = true, description = "Whether a supporting attachment is required for requests under "
+            + "this policy. Defaults to false when the field is absent from the create payload, and stays "
+            + "null if the payload sends null, since the column is nullable.", example = "false")
     private Boolean requiresAttachment;
 
-    @Schema(description = "Number of consecutive days after which an attachment becomes required.", example = "3")
+    @Schema(nullable = true, description = "Number of consecutive days after which an attachment becomes "
+            + "required. Null where the policy sets no such threshold.", example = "3")
     private Integer attachmentRequiredAfterDays;
 
-    @Schema(description = "Genders this policy applies to.", example = "ALL")
+    @Schema(nullable = true, description = "Genders this policy applies to. Defaults to ALL for a create "
+            + "payload that omits the field. The column is nullable, so a policy created with an explicit "
+            + "null carries none.", example = "ALL")
     private String applicableGenders;
 
-    @Schema(description = "Minimum months of service before an employee becomes eligible.", example = "6")
+    @Schema(nullable = true, description = "Minimum months of service before an employee becomes eligible. "
+            + "Defaults to 0 when the create payload omits the field; the column is nullable, so an explicit "
+            + "null survives to the response.", example = "6")
     private Integer minServiceMonths;
 
-    @Schema(description = "Whether requests under this policy can be for half a day.", example = "true")
+    @Schema(nullable = true, description = "Whether requests under this policy can be for half a day. "
+            + "Defaults to true when the create payload omits the field, and is null where the payload set "
+            + "it to null, which the column allows.", example = "true")
     private Boolean allowHalfDay;
 
-    @Schema(description = "Whether leave taken under this policy is paid.", example = "true")
+    @Schema(nullable = true, description = "Whether leave taken under this policy is paid. Defaults to true "
+            + "on a create payload that omits the field. The column is nullable, so an explicit null is "
+            + "stored and returned.", example = "true")
     private Boolean isPaid;
 
     @Schema(description = "Whether the policy is currently active.", example = "true")
@@ -74,7 +95,9 @@ public class LeavePolicyDto {
             + "finalizes the request.", example = "true")
     private Boolean multiLevelApprovalEnabled;
 
-    @Schema(description = "Order this policy is shown in, relative to the organization's other policies.", example = "1")
+    @Schema(nullable = true, description = "Order this policy is shown in, relative to the organization's "
+            + "other policies. Defaults to 0 when the create payload omits the field; the nullable column "
+            + "keeps an explicit null.", example = "1")
     private Integer displayOrder;
 
     @Schema(description = "Time the policy was created.", example = "2026-01-05T10:00:00")

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicySimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicySimpleDto.java
@@ -19,9 +19,13 @@ public class LeavePolicySimpleDto {
     @Schema(description = "Total days granted per year under this policy.", example = "12.0")
     private Double annualQuota;
 
-    @Schema(description = "Whether requests under this policy can be for half a day.", example = "true")
+    @Schema(nullable = true, description = "Whether requests under this policy can be for half a day. "
+            + "Defaults to true when the create payload omits the field, and is null where the payload set "
+            + "it to null, which the column allows.", example = "true")
     private Boolean allowHalfDay;
 
-    @Schema(description = "Whether leave taken under this policy is paid.", example = "true")
+    @Schema(nullable = true, description = "Whether leave taken under this policy is paid. Defaults to true "
+            + "on a create payload that omits the field. The column is nullable, so an explicit null is "
+            + "stored and returned.", example = "true")
     private Boolean isPaid;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestDto.java
@@ -24,7 +24,8 @@ public class LeaveRequestDto {
     @Schema(description = "Name of the employee who raised the request.", example = "Ravi Kumar")
     private String employeeName;
 
-    @Schema(description = "Department of the employee who raised the request.", example = "Civil")
+    @Schema(nullable = true, description = "Department of the employee who raised the request. Read from "
+            + "the employee record, which the employee table permits to carry no department.", example = "Civil")
     private String department;
 
     @Schema(description = "Id of the organization the employee belongs to.", example = "2")
@@ -36,13 +37,17 @@ public class LeaveRequestDto {
     @Schema(description = "First day of leave.", example = "2026-09-14")
     private LocalDate startDate;
 
-    @Schema(description = "Whether the start date is a full day or a half day.", example = "FULL_DAY")
+    @Schema(nullable = true, description = "Whether the start date is a full day or a half day. Null where "
+            + "the requester did not mark the first day as a half day; the column is written only when they "
+            + "did.", example = "FULL_DAY")
     private HalfDayType startHalfDayType;
 
     @Schema(description = "Last day of leave.", example = "2026-09-16")
     private LocalDate endDate;
 
-    @Schema(description = "Whether the end date is a full day or a half day.", example = "SECOND_HALF")
+    @Schema(nullable = true, description = "Whether the end date is a full day or a half day. Null where "
+            + "the requester did not mark the last day as a half day; the column is written only when they "
+            + "did.", example = "SECOND_HALF")
     private HalfDayType endHalfDayType;
 
     @Schema(description = "Total leave days, accounting for any half days.", example = "2.5")
@@ -54,35 +59,51 @@ public class LeaveRequestDto {
     @Schema(description = "Current status of the request.", example = "PENDING_APPROVAL")
     private LeaveStatus status;
 
-    @Schema(description = "Id of the employee who must act next in the approval chain.", example = "5")
+    @Schema(nullable = true, description = "Id of the employee who must act next in the approval chain. "
+            + "Never set on a draft, and cleared once the request reaches a final state (approved, rejected, "
+            + "cancelled or withdrawn).", example = "5")
     private Long currentApproverId;
 
-    @Schema(description = "Name of the employee who must act next in the approval chain.", example = "Anitha Menon")
+    @Schema(nullable = true, description = "Name of the employee who must act next in the approval chain. "
+            + "Null whenever currentApproverId is, since it is read from that employee.", example = "Anitha Menon")
     private String currentApproverName;
 
-    @Schema(description = "The approval level currently pending action.", example = "1")
+    @Schema(nullable = true, description = "The approval level currently pending action. Set when the "
+            + "approval chain is built at submission, so it is null on a draft and on a request that was "
+            + "finalized immediately because no approver could be resolved for the employee.", example = "1")
     private Integer currentApprovalLevel;
 
-    @Schema(description = "The highest approval level configured for this request.", example = "2")
+    @Schema(nullable = true, description = "The highest approval level configured for this request. "
+            + "Written alongside currentApprovalLevel when the chain is built, and null wherever that one "
+            + "is.", example = "2")
     private Integer maxApprovalLevel;
 
-    @Schema(description = "Contact number or address reachable during the leave.", example = "9847012345")
+    @Schema(nullable = true, description = "Contact number or address reachable during the leave. Null "
+            + "where the requester supplied none.", example = "9847012345")
     private String contactDuringLeave;
 
-    @Schema(description = "Id of the employee handling handover during the leave, if any.", example = "12")
+    @Schema(nullable = true, description = "Id of the employee handling handover during the leave. Null "
+            + "where no handover was arranged.", example = "12")
     private Long handoverToId;
 
-    @Schema(description = "Name of the employee handling handover during the leave, if any.", example = "Deepak Nair")
+    @Schema(nullable = true, description = "Name of the employee handling handover during the leave. "
+            + "Filled in only by the single-request read; every list response, and every response returned "
+            + "by a create, update or approval action, leaves it null even when handoverToId is set.",
+            example = "Deepak Nair")
     private String handoverToName;
 
-    @Schema(description = "Notes for the person receiving the handover.", example = "Site inspection at "
+    @Schema(nullable = true, description = "Notes for the person receiving the handover. Null where none "
+            + "were written.", example = "Site inspection at "
             + "Asset Homes Chennai is due on 2026-09-15, please coordinate with the QA team")
     private String handoverNotes;
 
-    @Schema(description = "Time the request was cancelled, if it was.", example = "2026-09-10T11:20:00")
+    @Schema(nullable = true, description = "Time the request was cancelled. Null until the request is "
+            + "cancelled.", example = "2026-09-10T11:20:00")
     private LocalDateTime cancelledAt;
 
-    @Schema(description = "Reason the request was cancelled, if it was.", example = "Wedding postponed to next month")
+    @Schema(nullable = true, description = "Reason the request was cancelled. Null until the request is "
+            + "cancelled, and on a cancellation recorded without a reason.",
+            example = "Wedding postponed to next month")
     private String cancellationReason;
 
     @Schema(description = "Time the request was created.", example = "2026-08-30T09:15:00")

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveTransactionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveTransactionDto.java
@@ -71,7 +71,7 @@ public class LeaveTransactionDto {
 
     @Schema(nullable = true, description = "Name of the employee who created the transaction. Always null "
             + "on this response: the mapper leaves the field unset and nothing else fills it in, so resolve "
-            + "the name from createdById.", example = "Anand Rajan")
+            + "the name from createdById.")
     private String createdByName;
 
     @Schema(description = "Time the transaction was recorded.", example = "2026-09-14T09:30:00")

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveTransactionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveTransactionDto.java
@@ -26,10 +26,13 @@ public class LeaveTransactionDto {
     @Schema(description = "Name of the leave type the balance is tracked under.", example = "Casual Leave")
     private String leaveTypeName;
 
-    @Schema(description = "Id of the leave request this transaction is linked to, if any.", example = "241")
+    @Schema(nullable = true, description = "Id of the leave request this transaction is linked to. Null "
+            + "for transactions with no originating request, such as a monthly accrual or a manual "
+            + "adjustment.", example = "241")
     private Long leaveRequestId;
 
-    @Schema(description = "Request number of the linked leave request, if any.", example = "LR-2026-0241")
+    @Schema(nullable = true, description = "Request number of the linked leave request. Null whenever "
+            + "leaveRequestId is, since it is read from that request.", example = "LR-2026-0241")
     private String requestNumber;
 
     @Schema(description = "Type of the transaction.", example = "DEDUCTION")
@@ -47,19 +50,28 @@ public class LeaveTransactionDto {
     @Schema(description = "Date the transaction is effective.", example = "2026-09-14")
     private LocalDate transactionDate;
 
-    @Schema(description = "Month the transaction is attributed to, for accrual transactions.", example = "9")
+    @Schema(nullable = true, description = "Month the transaction is attributed to. Written only by the "
+            + "accrual service, so it is null on deductions and manual adjustments.", example = "9")
     private Integer referenceMonth;
 
-    @Schema(description = "Year the transaction is attributed to.", example = "2026")
+    @Schema(nullable = true, description = "Year the transaction is attributed to. Written only by the "
+            + "accrual service, so it is null on deductions and manual adjustments.", example = "2026")
     private Integer referenceYear;
 
-    @Schema(description = "Description of the transaction.", example = "Deduction for leave request LR-2026-0241")
+    @Schema(nullable = true, description = "Description of the transaction. Written on every path the "
+            + "application takes (accrual, approval deduction and manual adjustment), but the column permits "
+            + "null, so a row loaded outside the application can carry none.",
+            example = "Deduction for leave request LR-2026-0241")
     private String description;
 
-    @Schema(description = "Id of the employee who created the transaction, for manual adjustments.", example = "2")
+    @Schema(nullable = true, description = "Id of the employee who created the transaction. Written only on "
+            + "a manual adjustment, so it is null on the accrual and approval-deduction rows the system "
+            + "posts itself.", example = "2")
     private Long createdById;
 
-    @Schema(description = "Name of the employee who created the transaction, for manual adjustments.", example = "Anand Rajan")
+    @Schema(nullable = true, description = "Name of the employee who created the transaction. Always null "
+            + "on this response: the mapper leaves the field unset and nothing else fills it in, so resolve "
+            + "the name from createdById.", example = "Anand Rajan")
     private String createdByName;
 
     @Schema(description = "Time the transaction was recorded.", example = "2026-09-14T09:30:00")

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/NotificationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/NotificationDto.java
@@ -25,19 +25,25 @@ public class NotificationDto {
             + "Casual Leave from 2026-09-14 to 2026-09-16")
     private String message;
 
-    @Schema(description = "Type of the entity this notification refers to.", example = "LEAVE_REQUEST")
+    @Schema(nullable = true, description = "Type of the entity this notification refers to. The leave "
+            + "senders always set it, but a notification raised through the generic delivery seam carries "
+            + "whatever the sender put in the draft, which may be nothing.", example = "LEAVE_REQUEST")
     private String entityType;
 
-    @Schema(description = "Id of the entity this notification refers to.", example = "241")
+    @Schema(nullable = true, description = "Id of the entity this notification refers to. Null whenever "
+            + "entityType is, since the two are set together.", example = "241")
     private Long entityId;
 
-    @Schema(description = "URL the client should navigate to when the notification is opened.", example = "/leave-requests/241")
+    @Schema(nullable = true, description = "URL the client should navigate to when the notification is "
+            + "opened. Null where the sender supplied none, leaving the notification with nothing to open.",
+            example = "/leave-requests/241")
     private String actionUrl;
 
     @Schema(description = "Whether the notification has been read.", example = "false")
     private Boolean isRead;
 
-    @Schema(description = "Time the notification was read, if it has been.", example = "2026-08-31T09:10:00")
+    @Schema(nullable = true, description = "Time the notification was read. Null until it is marked read.",
+            example = "2026-08-31T09:10:00")
     private LocalDateTime readAt;
 
     @Schema(description = "Time the notification was created.", example = "2026-08-30T09:16:00")

--- a/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
@@ -22,6 +22,23 @@ import org.tornotron.echno_backend.finance.payment.dtos.PaymentDto;
 import org.tornotron.echno_backend.finance.posting.dtos.PostingAccountMappingDto;
 import org.tornotron.echno_backend.finance.settings.dtos.FinanceSettingsDto;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateDto;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateItemDto;
+import org.tornotron.echno_backend.inspection.dtos.DefectPhotoAnnotationDto;
+import org.tornotron.echno_backend.inspection.dtos.InspectionCheckItemDto;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDefectDto;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+import org.tornotron.echno_backend.inspection.dtos.NcrDto;
+import org.tornotron.echno_backend.inspection.dtos.StarterChecklistTemplateDto;
+import org.tornotron.echno_backend.leave.dto.LeaveApprovalDto;
+import org.tornotron.echno_backend.leave.dto.LeaveBalanceDto;
+import org.tornotron.echno_backend.leave.dto.LeaveBalanceSummaryDto;
+import org.tornotron.echno_backend.leave.dto.LeaveCalendarDto;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyDto;
+import org.tornotron.echno_backend.leave.dto.LeavePolicySimpleDto;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
+import org.tornotron.echno_backend.leave.dto.LeaveTransactionDto;
+import org.tornotron.echno_backend.leave.dto.NotificationDto;
 import org.tornotron.echno_backend.payable.dto.PayableDto;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderDto;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderItemDto;
@@ -289,6 +306,83 @@ final class ReviewedResponseSchemas {
      *       {@code created_at} is {@code NOT NULL} and {@code created_by} is not.
      * </ul>
      *
+     * <p><b>Leave.</b> The seven leave tables are created across {@code v1.2} and {@code v1.3} and
+     * consolidated in the {@code v4.0} baseline. Both paths were read, because a column that is
+     * nullable on one install and not on the other would make the answer depend on how the
+     * database was built; they agree, and every {@code @Column} and {@code @JoinColumn} in the
+     * module matches its changeset. {@code multi_level_approval_enabled} arrives later, in
+     * {@code v4.0/039}, as {@code NOT NULL DEFAULT true}, so it is non-null on every install path.
+     *
+     * <ul>
+     *   <li>{@code LeavePolicyDto} is nullable on 14 of its 24 properties, which is the schema's
+     *       shape rather than an omission. A policy carries one column for each rule an
+     *       organization may choose not to set, and most organizations set few of them.
+     *   <li>{@code LeaveBalanceDto.available} and {@code bookable} are the
+     *       {@code VendorSummaryDto} shape again: {@code @Transient} getters over
+     *       {@code LeaveDays.round} arithmetic on columns that are all {@code NOT NULL}, with no
+     *       column of their own.
+     *   <li>{@code LeaveBalanceSummaryDto} has nothing in its nullable half. It is assembled
+     *       field by field in {@code LeaveBalanceService.getBalanceSummary}, the totals are
+     *       {@code LeaveDays.round} over a stream sum, and the controller defaults {@code year}
+     *       to the current year when the request omits it.
+     *   <li>Three names are null because the mapper ignores them and no service fills them in:
+     *       {@code delegatedFromName} and {@code createdByName} are structurally always null, and
+     *       {@code handoverToName} is resolved on the single-request read alone. They are
+     *       classified as nullable because that is what the server sends, and filed as defects on
+     *       #741 because it is not what the code means.
+     *   <li>{@code currentApproverId}, {@code currentApproverName}, {@code currentApprovalLevel}
+     *       and {@code maxApprovalLevel} are cleared or never written by the workflow rather than
+     *       by a constraint: the first two are nulled on approve, reject, cancel and withdraw,
+     *       and the levels are written only when the approval chain is built at submission.
+     *   <li>{@code carryForwardFromPrevious} and {@code LeaveTransactionDto.description} are the
+     *       standing line held again: the application writes both on every path, the column
+     *       permits null, so they stay nullable with the writing named in the description.
+     *   <li>The module contains no {@code @Builder}, {@code @Embedded} or {@code @Embeddable}, so
+     *       neither the attendance trap nor the {@code CustomerDto.billingAddress} one has an
+     *       analogue here. It does have a setter-shaped equivalent, on #741:
+     *       {@code createPolicy} calls every setter unconditionally, so an explicit null in the
+     *       payload overwrites the entity's own initialiser.
+     * </ul>
+     *
+     * <p><b>Inspection.</b> Two things shape this module and neither is visible from the entity
+     * alone: an inspection row has two producers, a person and the compliance generator, and a
+     * migration relaxed the schema for the second of them.
+     *
+     * <ul>
+     *   <li>{@code scheduledDate} and {@code inspectorId} are nullable even though
+     *       {@code CreateInspectionRequest} and {@code UpdateInspectionRequest} both declare them
+     *       {@code @NotNull}. {@code 035-relax-inspection-not-null-for-ai-rows} dropped the
+     *       constraint precisely so {@code ComplianceGenerationService} can write a row without
+     *       either. The constraint lives on the payload rather than on the row, so no API caller
+     *       can omit them and rows exist that do.
+     *   <li>{@code compliancePhase}, {@code riskLevel}, {@code resolutionOptions},
+     *       {@code complianceRuleRef} and {@code aiRationale} are written only by that same
+     *       service, so they are null on every manually created inspection. The first two also
+     *       fall back to the rule's own default, which can itself be null.
+     *   <li>{@code InspectionCheckItemDto.deviation} is a computation that returns null:
+     *       {@code MeasurementDeviation.of} yields nothing unless the measurement and the
+     *       expected value both parse as numbers in the same unit.
+     *   <li>{@code raisedById}, {@code verifiedById}, {@code closedById} and
+     *       {@code DefectPhotoAnnotationDto.createdById} come from {@code currentEmployeeId()},
+     *       which returns null when the signed-in user has no employee row in the current
+     *       organization. This is the {@code PostingAccountMappingDto} resolver shape with the
+     *       opposite ending: it returns null where the posting resolver throws.
+     *   <li>{@code InspectionDefectDto.severity} is nullable because of a migration rather than a
+     *       design: {@code 054-03} cleared blank values to null rather than guessing a bucket.
+     *   <li>{@code priority} on both check-item schemas and {@code InspectionDefectDto.status}
+     *       are the standing line again. The service substitutes {@code medium} and {@code OPEN}
+     *       on every call site, the columns permit null, so they stay nullable with the
+     *       substitution named.
+     *   <li>Nothing in the module is non-null by aggregate: there is no {@code COALESCE} and no
+     *       normalizer. The seven collection properties are Hibernate-managed collections
+     *       initialised on the entity and copied across by MapStruct, and the four counts are
+     *       primitive {@code int} over {@code NOT NULL} columns.
+     *   <li>Three entities declare a bare {@code @JoinColumn} over a {@code NOT NULL}
+     *       {@code organization_id}. That is the safe direction of the disagreement the
+     *       procurement pass found, so it breaks nothing today; it is on #741 because
+     *       {@code validate} catches neither direction.
+     * </ul>
+     *
      * @return The reviewed schemas.
      */
     static List<ReviewedSchema> schemas() {
@@ -489,6 +583,114 @@ final class ReviewedResponseSchemas {
                 new ReviewedSchema(
                         FinanceSettingsDto.class,
                         Set.of("approvalThreshold"),
-                        Set.of()));
+                        Set.of()),
+                new ReviewedSchema(
+                        LeaveApprovalDto.class,
+                        Set.of("actionAt", "approverDesignation", "comments", "delegatedFromId",
+                                "delegatedFromName"),
+                        Set.of("action", "approvalLevel", "approverId", "approverName", "createdAt",
+                                "id", "leaveRequestId")),
+                new ReviewedSchema(
+                        LeaveBalanceDto.class,
+                        Set.of("carryForwardExpiryDate", "carryForwardFromPrevious",
+                                "lastCalculatedAt"),
+                        Set.of("accrued", "available", "bookable", "employeeId", "employeeName",
+                                "id", "leavePolicy", "openingBalance", "pending", "used", "year")),
+                new ReviewedSchema(
+                        LeaveBalanceSummaryDto.class,
+                        Set.of(),
+                        Set.of("balances", "employeeId", "employeeName", "totalAvailable",
+                                "totalPending", "totalUsed", "year")),
+                new ReviewedSchema(
+                        LeaveCalendarDto.class,
+                        Set.of("department"),
+                        Set.of("dayType", "employeeId", "employeeName", "id", "leaveDate",
+                                "leaveRequestId", "leaveTypeCode", "leaveTypeName",
+                                "organizationId")),
+                new ReviewedSchema(
+                        LeavePolicyDto.class,
+                        Set.of("accrualRatePerMonth", "advanceNoticeDays", "allowHalfDay",
+                                "applicableGenders", "attachmentRequiredAfterDays",
+                                "carryForwardExpiryMonths", "carryForwardLimit", "description",
+                                "displayOrder", "isPaid", "maxDaysPerRequest", "minDaysPerRequest",
+                                "minServiceMonths", "requiresAttachment"),
+                        Set.of("annualQuota", "createdAt", "id", "isActive", "leaveTypeCode",
+                                "leaveTypeName", "multiLevelApprovalEnabled", "organizationId",
+                                "organizationName", "updatedAt")),
+                new ReviewedSchema(
+                        LeavePolicySimpleDto.class,
+                        Set.of("allowHalfDay", "isPaid"),
+                        Set.of("annualQuota", "id", "leaveTypeCode", "leaveTypeName")),
+                new ReviewedSchema(
+                        LeaveRequestDto.class,
+                        Set.of("cancellationReason", "cancelledAt", "contactDuringLeave",
+                                "currentApprovalLevel", "currentApproverId", "currentApproverName",
+                                "department", "endHalfDayType", "handoverNotes", "handoverToId",
+                                "handoverToName", "maxApprovalLevel", "startHalfDayType"),
+                        Set.of("approvals", "createdAt", "employeeId", "employeeName", "endDate",
+                                "id", "leavePolicy", "organizationId", "reason", "requestNumber",
+                                "startDate", "status", "totalDays", "updatedAt")),
+                new ReviewedSchema(
+                        LeaveTransactionDto.class,
+                        Set.of("createdById", "createdByName", "description", "leaveRequestId",
+                                "referenceMonth", "referenceYear", "requestNumber"),
+                        Set.of("balanceAfter", "balanceBefore", "createdAt", "days", "employeeId",
+                                "employeeName", "id", "leaveBalanceId", "leaveTypeName",
+                                "transactionDate", "transactionType")),
+                new ReviewedSchema(
+                        NotificationDto.class,
+                        Set.of("actionUrl", "entityId", "entityType", "readAt"),
+                        Set.of("createdAt", "id", "isRead", "message", "notificationType",
+                                "recipientId", "title")),
+                new ReviewedSchema(
+                        InspectionDto.class,
+                        Set.of("actualEndTime", "actualStartTime", "aiRationale", "areaInspected",
+                                "clientRepresentative", "compliancePhase", "complianceRuleRef",
+                                "contractorId", "drawingReference", "duration", "inspectorId",
+                                "location", "projectId", "resolutionOptions", "result", "riskLevel",
+                                "scheduledDate", "scheduledTime", "temperature", "trade",
+                                "weatherConditions"),
+                        Set.of("attendees", "category", "checkItems", "createdAt", "defects",
+                                "defectsFound", "failedCheckPoints", "id", "inspectionNumber",
+                                "origin", "passedCheckPoints", "status", "title",
+                                "totalCheckPoints", "type", "updatedAt")),
+                new ReviewedSchema(
+                        InspectionCheckItemDto.class,
+                        Set.of("acceptanceCriterion", "bimElementGuid", "deviation",
+                                "expectedValue", "measurement", "priority", "remarks",
+                                "specification", "tolerance"),
+                        Set.of("category", "checkPoint", "id", "photos", "photosRequired", "status")),
+                new ReviewedSchema(
+                        InspectionDefectDto.class,
+                        Set.of("category", "location", "resolvedDate", "responsibleParty",
+                                "severity", "status", "targetDate"),
+                        Set.of("correctiveAction", "description", "id", "photos")),
+                new ReviewedSchema(
+                        NcrDto.class,
+                        Set.of("closedAt", "closedById", "correctiveActionCompletedAt",
+                                "correctiveActionRemarks", "defectId", "raisedById", "severity",
+                                "siteEngineerId", "targetDate", "verificationRemarks", "verifiedAt",
+                                "verifiedById"),
+                        Set.of("createdAt", "description", "id", "inspectionId", "ncrNumber",
+                                "status", "title", "type", "updatedAt")),
+                new ReviewedSchema(
+                        DefectPhotoAnnotationDto.class,
+                        Set.of("createdById", "label"),
+                        Set.of("id", "inspectionId", "lineOrder", "photo", "shape", "x1", "x2",
+                                "y1", "y2")),
+                new ReviewedSchema(
+                        ChecklistTemplateDto.class,
+                        Set.of("description"),
+                        Set.of("active", "createdAt", "id", "items", "name", "trade", "updatedAt",
+                                "version")),
+                new ReviewedSchema(
+                        ChecklistTemplateItemDto.class,
+                        Set.of("acceptanceCriterion", "expectedValue", "priority", "specification",
+                                "tolerance"),
+                        Set.of("category", "checkPoint", "id", "lineOrder", "photosRequired")),
+                new ReviewedSchema(
+                        StarterChecklistTemplateDto.class,
+                        Set.of("description"),
+                        Set.of("id", "items", "name", "trade")));
     }
 }


### PR DESCRIPTION
Sixth module pass on #645, and by the reasoning at the bottom the last one worth taking on its own. Seventeen schemas, 248 published properties, 107 nullable. Leave and inspection were the two largest untouched blocks and both shipped work this week.

| schema | nullable | of |
|---|---|---|
| `LeaveApprovalDto` | 5 | 12 |
| `LeaveBalanceDto` | 3 | 14 |
| `LeaveBalanceSummaryDto` | 0 | 7 |
| `LeaveCalendarDto` | 1 | 10 |
| `LeavePolicyDto` | 14 | 24 |
| `LeavePolicySimpleDto` | 2 | 6 |
| `LeaveRequestDto` | 13 | 27 |
| `LeaveTransactionDto` | 7 | 18 |
| `NotificationDto` | 4 | 11 |
| `InspectionDto` | 21 | 37 |
| `InspectionCheckItemDto` | 9 | 15 |
| `InspectionDefectDto` | 7 | 11 |
| `NcrDto` | 12 | 21 |
| `DefectPhotoAnnotationDto` | 2 | 11 |
| `ChecklistTemplateDto` | 1 | 9 |
| `ChecklistTemplateItemDto` | 5 | 10 |
| `StarterChecklistTemplateDto` | 1 | 5 |

Leave is 49 of 129, inspection 58 of 119. Request bodies and the `Page*` wrappers are out of scope, as before. `LeavePolicySimpleDto` appears in no path and is in scope anyway: it is nested inside `LeaveBalanceDto` and `LeaveRequestDto`.

### The entity-versus-changelog warning

Leave has no disagreement at all. Its tables are created across `v1.2` and `v1.3` and consolidated in the `v4.0` baseline, and both paths were read rather than one, because a column that is nullable on one install and not on the other would make the answer depend on how the database was built. They agree, and every `@Column` and `@JoinColumn` matches its changeset.

Inspection has three, all in the safe direction (the entity permits null where the column does not) and all on the tenant association: `Ncr`, `ChecklistTemplate` and `DefectPhotoAnnotation` each use a bare `@JoinColumn` over a `NOT NULL` `organization_id`. Nothing breaks today. Recorded on #741 because `validate` catches neither direction.

Neither module contains a Lombok `@Builder`, an `@Embedded` or an `@Embeddable`, so the attendance trap and the `CustomerDto.billingAddress` one have no analogue here. Leave does have a setter-shaped equivalent, on #741.

### Where an answer did not come from a column

- **`035-relax-inspection-not-null-for-ai-rows`** is the finding of this pass. `scheduledDate` and `inspectorId` are nullable even though `CreateInspectionRequest` and `UpdateInspectionRequest` both declare them `@NotNull`: the migration dropped the constraint so `ComplianceGenerationService` could write compliance rows without either. The constraint lives on the payload rather than on the row, so no API caller can omit them and rows exist that do. An entity read on its own would have got this backwards in both directions.
- **The five compliance fields** (`compliancePhase`, `riskLevel`, `resolutionOptions`, `complianceRuleRef`, `aiRationale`) are written only by that same service, so they are null on every manually created inspection. Two of them fall back to the rule's own default, which can itself be null.
- **`LeaveBalanceDto.available` and `bookable`** are the `VendorSummaryDto` shape a fourth time: `@Transient` getters over `LeaveDays.round` arithmetic on `NOT NULL` columns, with no column of their own.
- **`InspectionCheckItemDto.deviation`** is a computation that returns null. `MeasurementDeviation.of` yields nothing unless the measurement and the expected value both parse as numbers in the same unit.
- **`currentEmployeeId()`** returns null when the signed-in user has no employee row in the current organization, which is what `raisedById`, `verifiedById`, `closedById` and `createdById` mean by null. This is the `PostingAccountMappingDto` resolver shape with the opposite ending: it returns null where the posting resolver throws.
- **`InspectionDefectDto.severity`** is nullable because of a migration rather than a design. `054-03` cleared blank values to null rather than guessing a bucket.
- **Three names are null because nothing fills them in**: `delegatedFromName` and `createdByName` are structurally always null, and `handoverToName` is resolved on the single-request read alone. Classified as nullable because that is what the server sends, and filed on #741 because it is not what the code means.
- **The standing line held again.** `carryForwardFromPrevious`, `LeaveTransactionDto.description`, `priority` on both check-item schemas and `InspectionDefectDto.status` all sit on nullable columns the application writes on every path, so they stay nullable with the writing named in the description.

There is no `COALESCE` and no normalizer anywhere in either module.

### Document diff

Patched property by property rather than regenerated, then audited semantically: **107 properties changed, 0 added, 0 removed**, `paths` byte-identical, sixteen schemas touched and nothing outside them (`LeaveBalanceSummaryDto` has no nullable property, so it does not appear in the diff). Every changed property is one of the 107. Non-null properties keep the descriptions they had.

A checker held all three representations together before the commit: the `@Schema` description on each field, the manifest, and the description and type union in `docs/openapi.json`. All 107 agree, and no property listed as non-null admits null in the document. `openapi-served` from CI is the check that means anything on a hand patch, per #723.

### Remaining after this

About **1339 response-only properties over 117 schemas**, of which roughly 435 are Spring's own `Page*` wrappers. The reviewed set is now **51 schemas and 657 properties**. Largest untouched: the rest of `attendance` (86), `asset` (72).

Refs #645. Defects on #741.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation across inspection, checklist, defect, non-conformance, leave, approval, and notification endpoints to accurately identify nullable fields.
  - Added descriptions explaining when values may be absent, defaulted, cleared, or populated by specific workflows.
  - Improved Swagger/OpenAPI field guidance without changing endpoint behavior or data structures.

- **Tests**
  - Expanded schema review coverage for nullable fields across inspection and leave-related responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->