### PR TITLE
TEMPORARY: measure the #741 reds

### DIFF
--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionNullabilityRepairIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionNullabilityRepairIT.java
@@ -1,0 +1,151 @@
+package org.tornotron.echno_backend.inspection;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.domain.InspectionDefect;
+import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.DefectPhotoAnnotationMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.NcrMapperImpl;
+import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
+import org.tornotron.echno_backend.inspection.service.DefectAnnotationService;
+import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.inspection.service.NcrService;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The two schema repairs in 094, asserted against a real CockroachDB rather than against the
+ * entity annotations.
+ *
+ * <p>Both have to be measured this way. {@code ddl-auto} is {@code validate} and Hibernate does
+ * not compare nullability, so an entity and its column can disagree in either direction without
+ * the build noticing, and a test that builds a defect the way production does would only observe
+ * the field initialiser it set itself. The insert below names every column except {@code status}
+ * precisely so the database is the thing answering.
+ *
+ * <p>Before 094 the first test reads back {@code open}, the {@code @JsonValue} spelling that
+ * {@code @Enumerated(STRING)} cannot read, and the second fails with an
+ * {@code IllegalArgumentException} on the enum conversion. The third fails on both columns.
+ *
+ * <p>The Spring configuration is deliberately identical to {@link InspectionServiceIT} and
+ * {@link InspectionTaxonomyMigrationIT} so every inspection test class shares one cached
+ * application context rather than starting a second. Keep it in step when that list changes.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({InspectionService.class, InspectionMapperImpl.class,
+        ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
+        NcrService.class, NcrMapperImpl.class,
+        DefectAnnotationService.class, DefectPhotoAnnotationMapperImpl.class,
+        UserContextService.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class})
+class InspectionNullabilityRepairIT extends AbstractIntegrationTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void aDefectWrittenWithoutAStatusTakesTheNameTheEnumPersists() {
+        UUID defectId = insertDefectWithoutStatus(insertInspection(insertOrganization()));
+
+        assertThat(readStatus(defectId)).isEqualTo("OPEN");
+    }
+
+    @Test
+    void thatRowThenLoadsThroughTheEntity() {
+        UUID defectId = insertDefectWithoutStatus(insertInspection(insertOrganization()));
+        entityManager.flush();
+        entityManager.clear();
+
+        InspectionDefect defect = entityManager.find(InspectionDefect.class, defectId);
+
+        assertThat(defect.getStatus()).isEqualTo(DefectStatus.OPEN);
+    }
+
+    @Test
+    void bothColumnsAreConstrainedTheWayTheirSiblingsAre() {
+        // inspections.status, inspection_check_items.status and ncrs.status all carry NOT NULL,
+        // and ncrs, checklist_templates and inspection_defect_annotations all constrain their
+        // organization_id. These two were the exceptions.
+        assertThat(isNullable("inspection_defects", "status")).isEqualTo("NO");
+        assertThat(isNullable("inspections", "organization_id")).isEqualTo("NO");
+    }
+
+    private Long insertOrganization() {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO organization (organization_name, organization_address, "
+                                + "organization_email, organization_phone) "
+                                + "VALUES (:name, :address, :email, :phone) RETURNING id")
+                .setParameter("name", "Nullability repair " + UUID.randomUUID())
+                .setParameter("address", "Chennai")
+                .setParameter("email", "qa@example.test")
+                .setParameter("phone", "9847012345")
+                .getSingleResult()).longValue();
+    }
+
+    private UUID insertInspection(Long organizationId) {
+        UUID id = UUID.randomUUID();
+        entityManager.createNativeQuery(
+                        "INSERT INTO inspections (id, inspection_number, title, type, "
+                                + "scheduled_date, organization_id) "
+                                + "VALUES (CAST(:id AS UUID), :number, :title, :type, "
+                                + ":scheduledDate, :organizationId)")
+                .setParameter("id", id.toString())
+                .setParameter("number", "INSP-" + id.toString().substring(0, 8))
+                .setParameter("title", "Defect status default")
+                .setParameter("type", InspectionType.QUALITY.name())
+                .setParameter("scheduledDate", LocalDate.of(2026, 9, 8))
+                .setParameter("organizationId", organizationId)
+                .executeUpdate();
+        return id;
+    }
+
+    /**
+     * Names every column the row needs except {@code status}, which is the whole point: the
+     * value that ends up there is the one the DEFAULT clause supplies.
+     */
+    private UUID insertDefectWithoutStatus(UUID inspectionId) {
+        UUID id = UUID.randomUUID();
+        entityManager.createNativeQuery(
+                        "INSERT INTO inspection_defects (id, inspection_id, description, "
+                                + "corrective_action, line_order) "
+                                + "VALUES (CAST(:id AS UUID), CAST(:inspectionId AS UUID), "
+                                + ":description, :correctiveAction, :lineOrder)")
+                .setParameter("id", id.toString())
+                .setParameter("inspectionId", inspectionId.toString())
+                .setParameter("description", "Cracked render at the stair core")
+                .setParameter("correctiveAction", "Cut out and make good")
+                .setParameter("lineOrder", 1)
+                .executeUpdate();
+        return id;
+    }
+
+    private String readStatus(UUID defectId) {
+        return (String) entityManager.createNativeQuery(
+                        "SELECT status FROM inspection_defects WHERE id = CAST(:id AS UUID)")
+                .setParameter("id", defectId.toString())
+                .getSingleResult();
+    }
+
+    private String isNullable(String table, String column) {
+        return (String) entityManager.createNativeQuery(
+                        "SELECT is_nullable FROM information_schema.columns "
+                                + "WHERE table_schema = 'public' AND table_name = :table "
+                                + "AND column_name = :column")
+                .setParameter("table", table)
+                .setParameter("column", column)
+                .getSingleResult();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveHandoverNameIsReadInTenantTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveHandoverNameIsReadInTenantTest.java
@@ -1,0 +1,128 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
+import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The handover employee's name is resolved inside the caller's organization, like every other
+ * employee lookup in this service.
+ *
+ * <p>{@code handoverToId} is a plain scalar column and no write path checks it against the
+ * tenant, so it can name an employee of another organization. The read then asked for that row
+ * by primary key, and a primary-key load is the one access Hibernate's {@code orgFilter} never
+ * narrows: the condition is applied to queries, and {@code findById} is not one.
+ *
+ * <p>What kept it from being a leak is {@link org.tornotron.echno_backend.common.multitenancy
+ * .TenantIsolationLoadListener}, which denies a foreign row at the load boundary. Leaning on
+ * that has a cost, because the denial is an exception rather than an empty answer: the whole
+ * request-detail read fails where only one optional name could not be resolved. Asking the
+ * scoped question gives back nothing, which is what an unresolvable name should look like.
+ *
+ * <p>Same shape as #589, #599, #607, #631, #635 and #666: a workflow reaching around the tenant
+ * scope on one call while every neighbouring call observes it. See issue #741.
+ *
+ * <p>Against the old code both tests fail: the first because the scoped lookup is never made, the
+ * second because the unscoped one answers with the other organization's employee.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeaveHandoverNameIsReadInTenantTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long REQUEST_ID = 42L;
+    private static final Long HANDOVER_TO_ID = 12L;
+
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private LeaveRequestSequenceRepository sequenceRepository;
+    @Mock private LeavePolicyRepository policyRepository;
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private LeaveApprovalService approvalService;
+    @Mock private LeaveRequestValidator leaveRequestValidator;
+    @Mock private LeaveRequestMapper leaveRequestMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+
+    private LeaveRequestService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new LeaveRequestService(
+                requestRepository,
+                sequenceRepository,
+                policyRepository,
+                balanceRepository,
+                employeeRepository,
+                approvalService,
+                leaveRequestValidator,
+                leaveRequestMapper,
+                orgSecurity,
+                currentEmployeeService);
+
+        LeaveRequest request = new LeaveRequest();
+        request.setId(REQUEST_ID);
+        request.setHandoverToId(HANDOVER_TO_ID);
+        when(requestRepository.findByIdAndOrganization_Id(REQUEST_ID, ORG_ID))
+                .thenReturn(Optional.of(request));
+        when(leaveRequestMapper.toDto(request)).thenReturn(new LeaveRequestDto());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void aColleagueInTheSameOrganizationIsNamed() {
+        when(employeeRepository.findByIdAndOrganizationId(HANDOVER_TO_ID, ORG_ID))
+                .thenReturn(Optional.of(employeeNamed("Deepak Nair")));
+
+        LeaveRequestDto dto = service.getRequest(REQUEST_ID);
+
+        assertThat(dto.getHandoverToName()).isEqualTo("Deepak Nair");
+        verify(employeeRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void anEmployeeOfAnotherOrganizationIsNotNamed() {
+        // The row exists and an unscoped lookup would find it. The scoped one does not, and the
+        // read carries on with the name unresolved rather than serving it or failing outright.
+        when(employeeRepository.findById(HANDOVER_TO_ID))
+                .thenReturn(Optional.of(employeeNamed("Someone Else")));
+        when(employeeRepository.findByIdAndOrganizationId(HANDOVER_TO_ID, ORG_ID))
+                .thenReturn(Optional.empty());
+
+        LeaveRequestDto dto = service.getRequest(REQUEST_ID);
+
+        assertThat(dto.getHandoverToName()).isNull();
+    }
+
+    private Employee employeeNamed(String name) {
+        Employee employee = new Employee();
+        employee.setId(HANDOVER_TO_ID);
+        employee.setEmployeeName(name);
+        return employee;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDeclaredDefaultsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDeclaredDefaultsTest.java
@@ -1,0 +1,187 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyCreationDto;
+import org.tornotron.echno_backend.leave.mapper.LeavePolicyMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A leave policy created without a value for a field keeps the value the entity declares for it.
+ *
+ * <p>{@code createPolicy} ran every setter with whatever arrived, so a payload carrying an
+ * explicit null overwrote the entity's initialiser and Hibernate wrote NULL. Every one of these
+ * columns is nullable, so nothing refused the row, and the column default never applied either:
+ * a default fills an absent column, and the insert named the column.
+ *
+ * <p>What follows is behaviour rather than cosmetics, because {@code LeaveRequestValidator} is
+ * null-safe throughout. A null {@code allowHalfDay} makes {@code Boolean.TRUE.equals(...)} false
+ * and half-day requests are refused on a policy meant to allow them; a null
+ * {@code minDaysPerRequest} or {@code advanceNoticeDays} makes the {@code != null} guards skip
+ * their checks, so the limits the policy was created with go unenforced. The policy reads as
+ * configured and behaves as though it were not.
+ *
+ * <p>The narrow trigger is worth stating: {@code LeavePolicyCreationDto} carries the same
+ * initialisers, so a body that simply omits the field never reaches this. It takes an explicit
+ * JSON null, which is what a client sends when it serialises a form with the field cleared.
+ *
+ * <p>Against the old code the first two tests fail with null in every field. See issue #741.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeavePolicyDeclaredDefaultsTest {
+
+    private static final long TENANT = 100L;
+    private static final long OTHER_TENANT = 200L;
+    private static final String EMAIL = "hr@example.test";
+
+    @Mock private LeavePolicyRepository policyRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private LeavePolicyMapper leavePolicyMapper;
+
+    private LeavePolicyService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LeavePolicyService(policyRepository, organizationRepository,
+                employeeRepository, userContextService, leavePolicyMapper);
+
+        TenantContext.setCurrentOrgId(TENANT);
+
+        Organization tenant = new Organization();
+        tenant.setId(TENANT);
+        when(userContextService.getCurrentUserEmail()).thenReturn(EMAIL);
+        when(organizationRepository.findByIdAndUserEmail(TENANT, EMAIL))
+                .thenReturn(Optional.of(tenant));
+        when(policyRepository.save(any(LeavePolicy.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void aPayloadOfExplicitNullsLeavesEveryDeclaredDefaultStanding() {
+        service.createPolicy(everyOptionalFieldCleared());
+
+        LeavePolicy written = theSavedPolicy();
+        assertThat(written.getMinDaysPerRequest()).isEqualTo(0.5);
+        assertThat(written.getAdvanceNoticeDays()).isZero();
+        assertThat(written.getRequiresAttachment()).isFalse();
+        assertThat(written.getApplicableGenders()).isEqualTo("ALL");
+        assertThat(written.getMinServiceMonths()).isZero();
+        assertThat(written.getAllowHalfDay()).isTrue();
+        assertThat(written.getIsPaid()).isTrue();
+        assertThat(written.getDisplayOrder()).isZero();
+        assertThat(written.getMultiLevelApprovalEnabled()).isTrue();
+    }
+
+    @Test
+    void aDuplicateDoesNotInheritANullTheSourcePolicyShouldNeverHaveHeld() {
+        // Policies written before the repair can hold these nulls, and copying one forward would
+        // spread a state the policy was never configured into.
+        LeavePolicy source = new LeavePolicy();
+        source.setId(7L);
+        source.setLeaveTypeCode("SICK");
+        source.setLeaveTypeName("Sick leave");
+        source.setAnnualQuota(12.0);
+        source.setMinDaysPerRequest(null);
+        source.setAdvanceNoticeDays(null);
+        source.setRequiresAttachment(null);
+        source.setApplicableGenders(null);
+        source.setMinServiceMonths(null);
+        source.setAllowHalfDay(null);
+        source.setIsPaid(null);
+        source.setDisplayOrder(null);
+        source.setMultiLevelApprovalEnabled(null);
+
+        Organization target = new Organization();
+        target.setId(OTHER_TENANT);
+        when(policyRepository.findByIdAndOrganization_Id(7L, TENANT)).thenReturn(Optional.of(source));
+        when(organizationRepository.findByIdAndUserEmail(OTHER_TENANT, EMAIL))
+                .thenReturn(Optional.of(target));
+        when(policyRepository.countWithLeaveTypeCodeInOrganizationUnfiltered(OTHER_TENANT, "SICK"))
+                .thenReturn(0L);
+
+        service.duplicatePolicy(7L, OTHER_TENANT);
+
+        LeavePolicy written = theSavedPolicy();
+        assertThat(written.getAllowHalfDay()).isTrue();
+        assertThat(written.getMinDaysPerRequest()).isEqualTo(0.5);
+        assertThat(written.getAdvanceNoticeDays()).isZero();
+        assertThat(written.getApplicableGenders()).isEqualTo("ALL");
+    }
+
+    @Test
+    void aValueTheCallerDidSendIsStillTheValueThatIsWritten() {
+        // The guard has to distinguish an absent value from a chosen one, and false is a chosen
+        // one. A repair that fell back to the initialiser whenever the field was falsy would read
+        // as fixed here and quietly refuse to let anyone turn half days off.
+        LeavePolicyCreationDto dto = everyOptionalFieldCleared();
+        dto.setAllowHalfDay(false);
+        dto.setIsPaid(false);
+        dto.setMinDaysPerRequest(1.0);
+        dto.setAdvanceNoticeDays(7);
+        dto.setDisplayOrder(3);
+        dto.setMultiLevelApprovalEnabled(false);
+
+        service.createPolicy(dto);
+
+        LeavePolicy written = theSavedPolicy();
+        assertThat(written.getAllowHalfDay()).isFalse();
+        assertThat(written.getIsPaid()).isFalse();
+        assertThat(written.getMinDaysPerRequest()).isEqualTo(1.0);
+        assertThat(written.getAdvanceNoticeDays()).isEqualTo(7);
+        assertThat(written.getDisplayOrder()).isEqualTo(3);
+        assertThat(written.getMultiLevelApprovalEnabled()).isFalse();
+    }
+
+    /**
+     * The payload a client sends when it serialises a form with every optional field cleared:
+     * the required three, and an explicit null everywhere else.
+     */
+    private LeavePolicyCreationDto everyOptionalFieldCleared() {
+        LeavePolicyCreationDto dto = new LeavePolicyCreationDto();
+        dto.setLeaveTypeCode("CASUAL");
+        dto.setLeaveTypeName("Casual leave");
+        dto.setAnnualQuota(12.0);
+        dto.setMinDaysPerRequest(null);
+        dto.setAdvanceNoticeDays(null);
+        dto.setRequiresAttachment(null);
+        dto.setApplicableGenders(null);
+        dto.setMinServiceMonths(null);
+        dto.setAllowHalfDay(null);
+        dto.setIsPaid(null);
+        dto.setDisplayOrder(null);
+        dto.setMultiLevelApprovalEnabled(null);
+        return dto;
+    }
+
+    private LeavePolicy theSavedPolicy() {
+        ArgumentCaptor<LeavePolicy> captor = ArgumentCaptor.forClass(LeavePolicy.class);
+        verify(policyRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}


### PR DESCRIPTION
Do not merge or review. Opened only to run the #741 tests against unrepaired `development` so the failures can be measured rather than asserted. Closed as soon as the run reports.