### PR TITLE
Repair the leave and inspection nullability defects

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/ChecklistTemplate.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/ChecklistTemplate.java
@@ -70,7 +70,7 @@ public class ChecklistTemplate implements TenantScopedEntity {
     private int version = 1;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "organization_id")
+    @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;
 
     @OneToMany(mappedBy = "template", cascade = CascadeType.ALL, orphanRemoval = true,

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/DefectPhotoAnnotation.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/DefectPhotoAnnotation.java
@@ -128,7 +128,7 @@ public class DefectPhotoAnnotation implements TenantScopedEntity {
     private Long createdById;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "organization_id")
+    @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;
 
     @CreationTimestamp

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
@@ -186,7 +186,7 @@ public class Inspection implements TenantScopedEntity {
     private String aiRationale;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "organization_id")
+    @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;
 
     @OneToMany(mappedBy = "inspection", cascade = CascadeType.ALL, orphanRemoval = true,

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionDefect.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionDefect.java
@@ -64,7 +64,7 @@ public class InspectionDefect {
     private LocalDate targetDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", length = 20)
+    @Column(name = "status", length = 20, nullable = false)
     private DefectStatus status = DefectStatus.OPEN;
 
     @Column(name = "resolved_date")

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/Ncr.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/Ncr.java
@@ -133,7 +133,7 @@ public class Ncr implements TenantScopedEntity {
     private LocalDateTime closedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "organization_id")
+    @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;
 
     @CreationTimestamp

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -23,6 +23,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -107,20 +108,31 @@ public class LeavePolicyService {
         policy.setAccrualRatePerMonth(dto.getAccrualRatePerMonth());
         policy.setCarryForwardLimit(dto.getCarryForwardLimit());
         policy.setCarryForwardExpiryMonths(dto.getCarryForwardExpiryMonths());
-        policy.setMinDaysPerRequest(dto.getMinDaysPerRequest());
         policy.setMaxDaysPerRequest(dto.getMaxDaysPerRequest());
-        policy.setAdvanceNoticeDays(dto.getAdvanceNoticeDays());
-        policy.setRequiresAttachment(dto.getRequiresAttachment());
         policy.setAttachmentRequiredAfterDays(dto.getAttachmentRequiredAfterDays());
-        policy.setApplicableGenders(dto.getApplicableGenders());
-        policy.setMinServiceMonths(dto.getMinServiceMonths());
-        policy.setAllowHalfDay(dto.getAllowHalfDay());
-        policy.setIsPaid(dto.getIsPaid());
         policy.setIsActive(true);
-        policy.setDisplayOrder(dto.getDisplayOrder());
-        if (dto.getMultiLevelApprovalEnabled() != null) {
-            policy.setMultiLevelApprovalEnabled(dto.getMultiLevelApprovalEnabled());
-        }
+
+        // Only the fields the entity leaves to the caller are set unconditionally above. The nine
+        // below carry a declared default, and setting those from an absent payload value is what
+        // this repair is: the setter ran whatever arrived, so a request that omitted the field
+        // overwrote the initialiser with null and Hibernate wrote NULL into a column whose default
+        // then never applied either. multiLevelApprovalEnabled already had this guard, spelled out
+        // as an if; the other eight did not.
+        //
+        // Nothing complained, because LeaveRequestValidator is null-safe by construction. A null
+        // allowHalfDay makes Boolean.TRUE.equals(...) false, so a policy created to allow half days
+        // refuses them; null minDaysPerRequest and null advanceNoticeDays make the != null guards
+        // skip their checks outright, so the limits the policy was created with are not enforced.
+        // The policy reads as configured in the UI and behaves as if it were not. See issue #741.
+        applyIfPresent(dto.getMinDaysPerRequest(), policy::setMinDaysPerRequest);
+        applyIfPresent(dto.getAdvanceNoticeDays(), policy::setAdvanceNoticeDays);
+        applyIfPresent(dto.getRequiresAttachment(), policy::setRequiresAttachment);
+        applyIfPresent(dto.getApplicableGenders(), policy::setApplicableGenders);
+        applyIfPresent(dto.getMinServiceMonths(), policy::setMinServiceMonths);
+        applyIfPresent(dto.getAllowHalfDay(), policy::setAllowHalfDay);
+        applyIfPresent(dto.getIsPaid(), policy::setIsPaid);
+        applyIfPresent(dto.getDisplayOrder(), policy::setDisplayOrder);
+        applyIfPresent(dto.getMultiLevelApprovalEnabled(), policy::setMultiLevelApprovalEnabled);
 
         LeavePolicy saved = policyRepository.save(policy);
         return leavePolicyMapper.toDto(saved);
@@ -396,20 +408,46 @@ public class LeavePolicyService {
         duplicate.setAccrualRatePerMonth(source.getAccrualRatePerMonth());
         duplicate.setCarryForwardLimit(source.getCarryForwardLimit());
         duplicate.setCarryForwardExpiryMonths(source.getCarryForwardExpiryMonths());
-        duplicate.setMinDaysPerRequest(source.getMinDaysPerRequest());
         duplicate.setMaxDaysPerRequest(source.getMaxDaysPerRequest());
-        duplicate.setAdvanceNoticeDays(source.getAdvanceNoticeDays());
-        duplicate.setRequiresAttachment(source.getRequiresAttachment());
         duplicate.setAttachmentRequiredAfterDays(source.getAttachmentRequiredAfterDays());
-        duplicate.setApplicableGenders(source.getApplicableGenders());
-        duplicate.setMinServiceMonths(source.getMinServiceMonths());
-        duplicate.setAllowHalfDay(source.getAllowHalfDay());
-        duplicate.setIsPaid(source.getIsPaid());
         duplicate.setIsActive(true);
-        duplicate.setDisplayOrder(source.getDisplayOrder());
-        duplicate.setMultiLevelApprovalEnabled(source.getMultiLevelApprovalEnabled());
+
+        // The same guard, for a different reason. A policy written before the repair above can
+        // hold null in a field that has a declared default, and copying that null forward spreads
+        // a state the policy was never configured into: the copy would refuse half days and skip
+        // the limit checks exactly as the original does. Falling back to the initialiser makes the
+        // duplicate differ from its source only where the source is already broken, which is the
+        // direction worth choosing.
+        applyIfPresent(source.getMinDaysPerRequest(), duplicate::setMinDaysPerRequest);
+        applyIfPresent(source.getAdvanceNoticeDays(), duplicate::setAdvanceNoticeDays);
+        applyIfPresent(source.getRequiresAttachment(), duplicate::setRequiresAttachment);
+        applyIfPresent(source.getApplicableGenders(), duplicate::setApplicableGenders);
+        applyIfPresent(source.getMinServiceMonths(), duplicate::setMinServiceMonths);
+        applyIfPresent(source.getAllowHalfDay(), duplicate::setAllowHalfDay);
+        applyIfPresent(source.getIsPaid(), duplicate::setIsPaid);
+        applyIfPresent(source.getDisplayOrder(), duplicate::setDisplayOrder);
+        applyIfPresent(source.getMultiLevelApprovalEnabled(), duplicate::setMultiLevelApprovalEnabled);
 
         LeavePolicy saved = policyRepository.save(duplicate);
         return leavePolicyMapper.toDto(saved);
+    }
+
+    /**
+     * Runs the setter only when a value was supplied, leaving the entity's own initialiser in
+     * place when it was not.
+     *
+     * <p>A plain setter cannot express the difference between "the caller chose null" and "the
+     * caller said nothing", and for a field with a declared default the two mean opposite things.
+     * Every column this is used on is nullable in the schema, so nothing rejects the null and the
+     * mistake surfaces later as behaviour instead of as an error.
+     *
+     * @param value The supplied value, or null when the field was not supplied.
+     * @param setter The setter to run when the value is present.
+     * @param <T> The field's type.
+     */
+    private static <T> void applyIfPresent(T value, Consumer<T> setter) {
+        if (value != null) {
+            setter.accept(value);
+        }
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -198,8 +198,17 @@ public class LeaveRequestService {
                         "Leave request with ID " + requestId + " was not found in this organization"));
         approvalService.requireMayReadRequest(request);
         LeaveRequestDto dto = leaveRequestMapper.toDto(request);
+        // Scoped, like every other employee lookup in this service. handoverToId is a plain
+        // scalar that no write path checks against the tenant, so it can name an employee of
+        // another organization; findById asks for that row by primary key, which is the one
+        // access Hibernate's orgFilter never narrows. What stopped it being a leak is
+        // TenantIsolationLoadListener, which denies the foreign row at the load boundary, and
+        // the cost of leaning on that is that the denial is an exception: the whole request
+        // detail read fails rather than the one name going unresolved. Asking the scoped
+        // question instead answers empty, which is what an unresolvable name should look like.
+        // See issue #741.
         if (request.getHandoverToId() != null) {
-            employeeRepository.findById(request.getHandoverToId())
+            employeeRepository.findByIdAndOrganizationId(request.getHandoverToId(), TenantContext.getCurrentOrgId())
                     .ifPresent(emp -> dto.setHandoverToName(emp.getEmployeeName()));
         }
         return dto;

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -415,4 +415,7 @@
     <!-- v4.0 - Inventory: remember that a material was reported low, so the sweep reports a crossing rather than a standing fact -->
     <include file="db/changelog/v4.0/093-material-reorder-alert.xml"/>
 
+    <!-- v4.0 - Inspection: spell the defect status default the way the enum reads it, and stop an inspection losing its tenant -->
+    <include file="db/changelog/v4.0/094-repair-inspection-nullability.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/094-repair-inspection-nullability.xml
+++ b/src/main/resources/db/changelog/v4.0/094-repair-inspection-nullability.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <!--
+      Two schema repairs the #645 nullability pass found in the inspection module.
+
+      The first is a default that writes a row the application cannot read. 027 created
+      inspection_defects.status with DEFAULT 'open', which is the @JsonValue spelling;
+      @Enumerated(STRING) persists and reads the constant name, OPEN. 054-05 uppercased the
+      rows that existed and left the DEFAULT alone, so every insert since that omits the
+      column has written a row that throws IllegalArgumentException the moment its parent
+      inspection is loaded. The column is also the one status in the module with no NOT NULL,
+      while the entity initialises it and no code path means it to be absent.
+
+      The second is inspections.organization_id, left nullable in 025 while ncrs,
+      checklist_templates and inspection_defect_annotations all declare it NOT NULL. A null
+      there is not a benign gap: orgFilter's predicate is unsatisfiable for a null row and
+      TenantIsolationLoadListener denies one outright, so the inspection is unreachable and
+      undeletable through the tenant-scoped API while its NCRs and annotations keep pointing
+      at a real organization.
+
+      Both constraints are added only after the rows are made to satisfy them, and each
+      tightening halts rather than proceeding if a row it cannot repair is still there.
+    -->
+
+    <changeSet id="094-01-normalise-defect-status" author="abhijith">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="inspection_defects"/>
+        </preConditions>
+
+        <comment>
+            Bring every status onto the constant name before the column is constrained. The
+            first statement gives absent and whitespace-only values the OPEN the entity has
+            always applied; the second repeats 054-05's promotion, because the DEFAULT the
+            next changeset replaces has been writing fresh lower-case rows ever since 054 ran.
+            Both are guarded on the value they change, so the pair is idempotent.
+        </comment>
+
+        <sql>
+            UPDATE inspection_defects SET status = 'OPEN'
+            WHERE status IS NULL OR trim(status) = ''
+        </sql>
+
+        <sql>
+            UPDATE inspection_defects
+            SET status = upper(replace(replace(trim(status), '-', '_'), ' ', '_'))
+            WHERE upper(replace(replace(trim(status), '-', '_'), ' ', '_'))
+                  IN ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'VERIFIED')
+              AND status &lt;&gt; upper(replace(replace(trim(status), '-', '_'), ' ', '_'))
+        </sql>
+    </changeSet>
+
+    <changeSet id="094-02-correct-defect-status-default" author="abhijith">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="inspection_defects" columnName="status"/>
+        </preConditions>
+
+        <comment>
+            The repair proper: the DEFAULT now spells the value the enum reads back. Written as
+            the constant name rather than as the wire form, because what the column stores is
+            decided by @Enumerated(STRING) and not by the JSON contract.
+        </comment>
+
+        <addDefaultValue tableName="inspection_defects"
+                         columnName="status"
+                         columnDataType="VARCHAR(20)"
+                         defaultValue="OPEN"/>
+    </changeSet>
+
+    <changeSet id="094-03-defect-status-not-null" author="abhijith">
+        <preConditions onFail="HALT">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM inspection_defects
+                WHERE status IS NULL
+                   OR status NOT IN ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'VERIFIED')
+            </sqlCheck>
+        </preConditions>
+
+        <comment>
+            Constrain the column now that every row satisfies it, matching inspections.status,
+            inspection_check_items.status and ncrs.status. The precondition halts on a value
+            outside DefectStatus rather than guessing a bucket for it, the same way 054-04 and
+            054-05 do; a halt here means a row was written by something that is not this
+            application and wants looking at before the constraint goes on.
+        </comment>
+
+        <addNotNullConstraint tableName="inspection_defects"
+                              columnName="status"
+                              columnDataType="VARCHAR(20)"/>
+    </changeSet>
+
+    <changeSet id="094-04-backfill-inspection-organization" author="abhijith">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="inspections" columnName="organization_id"/>
+        </preConditions>
+
+        <comment>
+            Take the organization from the inspection's own project, which is the value the
+            create path would have written. project_id is a plain scalar on Inspection rather
+            than a relation, so the join is spelled out here. Rows whose project is itself gone
+            or unscoped are left alone and are caught by the next changeset.
+        </comment>
+
+        <sql>
+            UPDATE inspections i
+            SET organization_id = p.organization_id
+            FROM project p
+            WHERE i.project_id = p.id
+              AND i.organization_id IS NULL
+              AND p.organization_id IS NOT NULL
+        </sql>
+    </changeSet>
+
+    <changeSet id="094-05-inspection-organization-not-null" author="abhijith">
+        <preConditions onFail="HALT">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM inspections WHERE organization_id IS NULL
+            </sqlCheck>
+        </preConditions>
+
+        <comment>
+            Bring the column into line with ncrs, checklist_templates and
+            inspection_defect_annotations. The precondition halts rather than deleting what the
+            backfill could not place: an inspection with no recoverable organization is already
+            invisible to the API, so it can only be resolved by someone who can say which tenant
+            it belonged to, and a migration that silently removed it would destroy the evidence
+            needed to answer that.
+        </comment>
+
+        <addNotNullConstraint tableName="inspections"
+                              columnName="organization_id"
+                              columnDataType="BIGINT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
@@ -329,7 +329,14 @@ final class ReviewedResponseSchemas {
      *       {@code delegatedFromName} and {@code createdByName} are structurally always null, and
      *       {@code handoverToName} is resolved on the single-request read alone. They are
      *       classified as nullable because that is what the server sends, and filed as defects on
-     *       #741 because it is not what the code means.
+     *       #741 because it is not what the code means. #741 repaired the part of that which is
+     *       an isolation defect, the unscoped {@code findById} behind {@code handoverToName}, and
+     *       left the three names unpopulated: {@code delegatedFromId}, {@code createdById} and
+     *       {@code handoverToId} are all published beside them and the description of each name
+     *       already directs the client to resolve from the id, so filling them in is a feature
+     *       across fourteen read paths and one nested list, and dropping them from a
+     *       hand-maintained contract breaks web at runtime. Both directions are decisions for the
+     *       contract owners rather than repairs, and the classification stands either way.
      *   <li>{@code currentApproverId}, {@code currentApproverName}, {@code currentApprovalLevel}
      *       and {@code maxApprovalLevel} are cleared or never written by the workflow rather than
      *       by a constraint: the first two are nulled on approve, reject, cancel and withdraw,

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionNullabilityRepairIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionNullabilityRepairIT.java
@@ -1,0 +1,151 @@
+package org.tornotron.echno_backend.inspection;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.domain.InspectionDefect;
+import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.DefectPhotoAnnotationMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.NcrMapperImpl;
+import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
+import org.tornotron.echno_backend.inspection.service.DefectAnnotationService;
+import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.inspection.service.NcrService;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The two schema repairs in 094, asserted against a real CockroachDB rather than against the
+ * entity annotations.
+ *
+ * <p>Both have to be measured this way. {@code ddl-auto} is {@code validate} and Hibernate does
+ * not compare nullability, so an entity and its column can disagree in either direction without
+ * the build noticing, and a test that builds a defect the way production does would only observe
+ * the field initialiser it set itself. The insert below names every column except {@code status}
+ * precisely so the database is the thing answering.
+ *
+ * <p>Before 094 the first test reads back {@code open}, the {@code @JsonValue} spelling that
+ * {@code @Enumerated(STRING)} cannot read, and the second fails with an
+ * {@code IllegalArgumentException} on the enum conversion. The third fails on both columns.
+ *
+ * <p>The Spring configuration is deliberately identical to {@link InspectionServiceIT} and
+ * {@link InspectionTaxonomyMigrationIT} so every inspection test class shares one cached
+ * application context rather than starting a second. Keep it in step when that list changes.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({InspectionService.class, InspectionMapperImpl.class,
+        ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
+        NcrService.class, NcrMapperImpl.class,
+        DefectAnnotationService.class, DefectPhotoAnnotationMapperImpl.class,
+        UserContextService.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class})
+class InspectionNullabilityRepairIT extends AbstractIntegrationTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void aDefectWrittenWithoutAStatusTakesTheNameTheEnumPersists() {
+        UUID defectId = insertDefectWithoutStatus(insertInspection(insertOrganization()));
+
+        assertThat(readStatus(defectId)).isEqualTo("OPEN");
+    }
+
+    @Test
+    void thatRowThenLoadsThroughTheEntity() {
+        UUID defectId = insertDefectWithoutStatus(insertInspection(insertOrganization()));
+        entityManager.flush();
+        entityManager.clear();
+
+        InspectionDefect defect = entityManager.find(InspectionDefect.class, defectId);
+
+        assertThat(defect.getStatus()).isEqualTo(DefectStatus.OPEN);
+    }
+
+    @Test
+    void bothColumnsAreConstrainedTheWayTheirSiblingsAre() {
+        // inspections.status, inspection_check_items.status and ncrs.status all carry NOT NULL,
+        // and ncrs, checklist_templates and inspection_defect_annotations all constrain their
+        // organization_id. These two were the exceptions.
+        assertThat(isNullable("inspection_defects", "status")).isEqualTo("NO");
+        assertThat(isNullable("inspections", "organization_id")).isEqualTo("NO");
+    }
+
+    private Long insertOrganization() {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO organization (organization_name, organization_address, "
+                                + "organization_email, organization_phone) "
+                                + "VALUES (:name, :address, :email, :phone) RETURNING id")
+                .setParameter("name", "Nullability repair " + UUID.randomUUID())
+                .setParameter("address", "Chennai")
+                .setParameter("email", "qa@example.test")
+                .setParameter("phone", "9847012345")
+                .getSingleResult()).longValue();
+    }
+
+    private UUID insertInspection(Long organizationId) {
+        UUID id = UUID.randomUUID();
+        entityManager.createNativeQuery(
+                        "INSERT INTO inspections (id, inspection_number, title, type, "
+                                + "scheduled_date, organization_id) "
+                                + "VALUES (CAST(:id AS UUID), :number, :title, :type, "
+                                + ":scheduledDate, :organizationId)")
+                .setParameter("id", id.toString())
+                .setParameter("number", "INSP-" + id.toString().substring(0, 8))
+                .setParameter("title", "Defect status default")
+                .setParameter("type", InspectionType.QUALITY.name())
+                .setParameter("scheduledDate", LocalDate.of(2026, 9, 8))
+                .setParameter("organizationId", organizationId)
+                .executeUpdate();
+        return id;
+    }
+
+    /**
+     * Names every column the row needs except {@code status}, which is the whole point: the
+     * value that ends up there is the one the DEFAULT clause supplies.
+     */
+    private UUID insertDefectWithoutStatus(UUID inspectionId) {
+        UUID id = UUID.randomUUID();
+        entityManager.createNativeQuery(
+                        "INSERT INTO inspection_defects (id, inspection_id, description, "
+                                + "corrective_action, line_order) "
+                                + "VALUES (CAST(:id AS UUID), CAST(:inspectionId AS UUID), "
+                                + ":description, :correctiveAction, :lineOrder)")
+                .setParameter("id", id.toString())
+                .setParameter("inspectionId", inspectionId.toString())
+                .setParameter("description", "Cracked render at the stair core")
+                .setParameter("correctiveAction", "Cut out and make good")
+                .setParameter("lineOrder", 1)
+                .executeUpdate();
+        return id;
+    }
+
+    private String readStatus(UUID defectId) {
+        return (String) entityManager.createNativeQuery(
+                        "SELECT status FROM inspection_defects WHERE id = CAST(:id AS UUID)")
+                .setParameter("id", defectId.toString())
+                .getSingleResult();
+    }
+
+    private String isNullable(String table, String column) {
+        return (String) entityManager.createNativeQuery(
+                        "SELECT is_nullable FROM information_schema.columns "
+                                + "WHERE table_schema = 'public' AND table_name = :table "
+                                + "AND column_name = :column")
+                .setParameter("table", table)
+                .setParameter("column", column)
+                .getSingleResult();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
@@ -160,7 +160,11 @@ class InspectionTaxonomyMigrationIT extends AbstractIntegrationTest {
         UUID spaced = insertLegacyDefect(inspectionId, 2, "'MINOR'", "'In Progress'");
         UUID underscored = insertLegacyDefect(inspectionId, 3, "'minor'", "'IN_PROGRESS'");
         UUID blank = insertLegacyDefect(inspectionId, 4, "'   '", "'  '");
-        UUID unset = insertLegacyDefect(inspectionId, 5, "NULL", "NULL");
+        // The status half of this row used to be seeded as a literal NULL, which 094 now refuses:
+        // the column carries NOT NULL and a DEFAULT of OPEN. Writing DEFAULT keeps the case the
+        // row was here for, a defect stored without anyone stating a status, and takes it through
+        // the path that produces one today.
+        UUID unset = insertLegacyDefect(inspectionId, 5, "NULL", "DEFAULT");
 
         run(BLANK_DEFECT_FIELDS);
         assertThat(unmappedCount(PROMOTE_SEVERITY)).isZero();

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
@@ -77,6 +77,9 @@ class InspectionTaxonomyMigrationIT extends AbstractIntegrationTest {
     @PersistenceContext
     private EntityManager entityManager;
 
+    /** Lazily created by {@link #organizationId()}, and rolled back with the test. */
+    private Long organizationId;
+
     @BeforeAll
     static void readChangelog() throws Exception {
         statements = new HashMap<>();
@@ -235,15 +238,40 @@ class InspectionTaxonomyMigrationIT extends AbstractIntegrationTest {
     private UUID insertLegacyInspection(InspectionType type) {
         UUID id = UUID.randomUUID();
         entityManager.createNativeQuery(
-                        "INSERT INTO inspections (id, inspection_number, title, type, scheduled_date) "
-                                + "VALUES (CAST(:id AS UUID), :number, :title, :type, :scheduledDate)")
+                        "INSERT INTO inspections (id, inspection_number, title, type, scheduled_date, "
+                                + "organization_id) "
+                                + "VALUES (CAST(:id AS UUID), :number, :title, :type, :scheduledDate, "
+                                + ":organizationId)")
                 .setParameter("id", id.toString())
                 .setParameter("number", "INSP-" + id.toString().substring(0, 8))
                 .setParameter("title", "Legacy " + type.getValue())
                 .setParameter("type", type.name())
                 .setParameter("scheduledDate", LocalDate.of(2026, 8, 20))
+                .setParameter("organizationId", organizationId())
                 .executeUpdate();
         return id;
+    }
+
+    /**
+     * The organization these legacy rows are seeded into, created once per test.
+     *
+     * <p>The seed used to leave organization_id out, which the column allowed until 094
+     * constrained it. What is being exercised here is the taxonomy backfill, and the tenant the
+     * rows sit in makes no difference to it, so any organization will do as long as there is one.
+     */
+    private Long organizationId() {
+        if (organizationId == null) {
+            organizationId = ((Number) entityManager.createNativeQuery(
+                            "INSERT INTO organization (organization_name, organization_address, "
+                                    + "organization_email, organization_phone) "
+                                    + "VALUES (:name, :address, :email, :phone) RETURNING id")
+                    .setParameter("name", "Taxonomy migration " + UUID.randomUUID())
+                    .setParameter("address", "Chennai")
+                    .setParameter("email", "qa@example.test")
+                    .setParameter("phone", "9847012345")
+                    .getSingleResult()).longValue();
+        }
+        return organizationId;
     }
 
     /**

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveHandoverNameIsReadInTenantTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveHandoverNameIsReadInTenantTest.java
@@ -1,0 +1,128 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
+import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The handover employee's name is resolved inside the caller's organization, like every other
+ * employee lookup in this service.
+ *
+ * <p>{@code handoverToId} is a plain scalar column and no write path checks it against the
+ * tenant, so it can name an employee of another organization. The read then asked for that row
+ * by primary key, and a primary-key load is the one access Hibernate's {@code orgFilter} never
+ * narrows: the condition is applied to queries, and {@code findById} is not one.
+ *
+ * <p>What kept it from being a leak is {@link org.tornotron.echno_backend.common.multitenancy
+ * .TenantIsolationLoadListener}, which denies a foreign row at the load boundary. Leaning on
+ * that has a cost, because the denial is an exception rather than an empty answer: the whole
+ * request-detail read fails where only one optional name could not be resolved. Asking the
+ * scoped question gives back nothing, which is what an unresolvable name should look like.
+ *
+ * <p>Same shape as #589, #599, #607, #631, #635 and #666: a workflow reaching around the tenant
+ * scope on one call while every neighbouring call observes it. See issue #741.
+ *
+ * <p>Against the old code both tests fail: the first because the scoped lookup is never made, the
+ * second because the unscoped one answers with the other organization's employee.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeaveHandoverNameIsReadInTenantTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long REQUEST_ID = 42L;
+    private static final Long HANDOVER_TO_ID = 12L;
+
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private LeaveRequestSequenceRepository sequenceRepository;
+    @Mock private LeavePolicyRepository policyRepository;
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private LeaveApprovalService approvalService;
+    @Mock private LeaveRequestValidator leaveRequestValidator;
+    @Mock private LeaveRequestMapper leaveRequestMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+
+    private LeaveRequestService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new LeaveRequestService(
+                requestRepository,
+                sequenceRepository,
+                policyRepository,
+                balanceRepository,
+                employeeRepository,
+                approvalService,
+                leaveRequestValidator,
+                leaveRequestMapper,
+                orgSecurity,
+                currentEmployeeService);
+
+        LeaveRequest request = new LeaveRequest();
+        request.setId(REQUEST_ID);
+        request.setHandoverToId(HANDOVER_TO_ID);
+        when(requestRepository.findByIdAndOrganization_Id(REQUEST_ID, ORG_ID))
+                .thenReturn(Optional.of(request));
+        when(leaveRequestMapper.toDto(request)).thenReturn(new LeaveRequestDto());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void aColleagueInTheSameOrganizationIsNamed() {
+        when(employeeRepository.findByIdAndOrganizationId(HANDOVER_TO_ID, ORG_ID))
+                .thenReturn(Optional.of(employeeNamed("Deepak Nair")));
+
+        LeaveRequestDto dto = service.getRequest(REQUEST_ID);
+
+        assertThat(dto.getHandoverToName()).isEqualTo("Deepak Nair");
+        verify(employeeRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void anEmployeeOfAnotherOrganizationIsNotNamed() {
+        // The row exists and an unscoped lookup would find it. The scoped one does not, and the
+        // read carries on with the name unresolved rather than serving it or failing outright.
+        when(employeeRepository.findById(HANDOVER_TO_ID))
+                .thenReturn(Optional.of(employeeNamed("Someone Else")));
+        when(employeeRepository.findByIdAndOrganizationId(HANDOVER_TO_ID, ORG_ID))
+                .thenReturn(Optional.empty());
+
+        LeaveRequestDto dto = service.getRequest(REQUEST_ID);
+
+        assertThat(dto.getHandoverToName()).isNull();
+    }
+
+    private Employee employeeNamed(String name) {
+        Employee employee = new Employee();
+        employee.setId(HANDOVER_TO_ID);
+        employee.setEmployeeName(name);
+        return employee;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDeclaredDefaultsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyDeclaredDefaultsTest.java
@@ -1,0 +1,187 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyCreationDto;
+import org.tornotron.echno_backend.leave.mapper.LeavePolicyMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A leave policy created without a value for a field keeps the value the entity declares for it.
+ *
+ * <p>{@code createPolicy} ran every setter with whatever arrived, so a payload carrying an
+ * explicit null overwrote the entity's initialiser and Hibernate wrote NULL. Every one of these
+ * columns is nullable, so nothing refused the row, and the column default never applied either:
+ * a default fills an absent column, and the insert named the column.
+ *
+ * <p>What follows is behaviour rather than cosmetics, because {@code LeaveRequestValidator} is
+ * null-safe throughout. A null {@code allowHalfDay} makes {@code Boolean.TRUE.equals(...)} false
+ * and half-day requests are refused on a policy meant to allow them; a null
+ * {@code minDaysPerRequest} or {@code advanceNoticeDays} makes the {@code != null} guards skip
+ * their checks, so the limits the policy was created with go unenforced. The policy reads as
+ * configured and behaves as though it were not.
+ *
+ * <p>The narrow trigger is worth stating: {@code LeavePolicyCreationDto} carries the same
+ * initialisers, so a body that simply omits the field never reaches this. It takes an explicit
+ * JSON null, which is what a client sends when it serialises a form with the field cleared.
+ *
+ * <p>Against the old code the first two tests fail with null in every field. See issue #741.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeavePolicyDeclaredDefaultsTest {
+
+    private static final long TENANT = 100L;
+    private static final long OTHER_TENANT = 200L;
+    private static final String EMAIL = "hr@example.test";
+
+    @Mock private LeavePolicyRepository policyRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private LeavePolicyMapper leavePolicyMapper;
+
+    private LeavePolicyService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LeavePolicyService(policyRepository, organizationRepository,
+                employeeRepository, userContextService, leavePolicyMapper);
+
+        TenantContext.setCurrentOrgId(TENANT);
+
+        Organization tenant = new Organization();
+        tenant.setId(TENANT);
+        when(userContextService.getCurrentUserEmail()).thenReturn(EMAIL);
+        when(organizationRepository.findByIdAndUserEmail(TENANT, EMAIL))
+                .thenReturn(Optional.of(tenant));
+        when(policyRepository.save(any(LeavePolicy.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void aPayloadOfExplicitNullsLeavesEveryDeclaredDefaultStanding() {
+        service.createPolicy(everyOptionalFieldCleared());
+
+        LeavePolicy written = theSavedPolicy();
+        assertThat(written.getMinDaysPerRequest()).isEqualTo(0.5);
+        assertThat(written.getAdvanceNoticeDays()).isZero();
+        assertThat(written.getRequiresAttachment()).isFalse();
+        assertThat(written.getApplicableGenders()).isEqualTo("ALL");
+        assertThat(written.getMinServiceMonths()).isZero();
+        assertThat(written.getAllowHalfDay()).isTrue();
+        assertThat(written.getIsPaid()).isTrue();
+        assertThat(written.getDisplayOrder()).isZero();
+        assertThat(written.getMultiLevelApprovalEnabled()).isTrue();
+    }
+
+    @Test
+    void aDuplicateDoesNotInheritANullTheSourcePolicyShouldNeverHaveHeld() {
+        // Policies written before the repair can hold these nulls, and copying one forward would
+        // spread a state the policy was never configured into.
+        LeavePolicy source = new LeavePolicy();
+        source.setId(7L);
+        source.setLeaveTypeCode("SICK");
+        source.setLeaveTypeName("Sick leave");
+        source.setAnnualQuota(12.0);
+        source.setMinDaysPerRequest(null);
+        source.setAdvanceNoticeDays(null);
+        source.setRequiresAttachment(null);
+        source.setApplicableGenders(null);
+        source.setMinServiceMonths(null);
+        source.setAllowHalfDay(null);
+        source.setIsPaid(null);
+        source.setDisplayOrder(null);
+        source.setMultiLevelApprovalEnabled(null);
+
+        Organization target = new Organization();
+        target.setId(OTHER_TENANT);
+        when(policyRepository.findByIdAndOrganization_Id(7L, TENANT)).thenReturn(Optional.of(source));
+        when(organizationRepository.findByIdAndUserEmail(OTHER_TENANT, EMAIL))
+                .thenReturn(Optional.of(target));
+        when(policyRepository.countWithLeaveTypeCodeInOrganizationUnfiltered(OTHER_TENANT, "SICK"))
+                .thenReturn(0L);
+
+        service.duplicatePolicy(7L, OTHER_TENANT);
+
+        LeavePolicy written = theSavedPolicy();
+        assertThat(written.getAllowHalfDay()).isTrue();
+        assertThat(written.getMinDaysPerRequest()).isEqualTo(0.5);
+        assertThat(written.getAdvanceNoticeDays()).isZero();
+        assertThat(written.getApplicableGenders()).isEqualTo("ALL");
+    }
+
+    @Test
+    void aValueTheCallerDidSendIsStillTheValueThatIsWritten() {
+        // The guard has to distinguish an absent value from a chosen one, and false is a chosen
+        // one. A repair that fell back to the initialiser whenever the field was falsy would read
+        // as fixed here and quietly refuse to let anyone turn half days off.
+        LeavePolicyCreationDto dto = everyOptionalFieldCleared();
+        dto.setAllowHalfDay(false);
+        dto.setIsPaid(false);
+        dto.setMinDaysPerRequest(1.0);
+        dto.setAdvanceNoticeDays(7);
+        dto.setDisplayOrder(3);
+        dto.setMultiLevelApprovalEnabled(false);
+
+        service.createPolicy(dto);
+
+        LeavePolicy written = theSavedPolicy();
+        assertThat(written.getAllowHalfDay()).isFalse();
+        assertThat(written.getIsPaid()).isFalse();
+        assertThat(written.getMinDaysPerRequest()).isEqualTo(1.0);
+        assertThat(written.getAdvanceNoticeDays()).isEqualTo(7);
+        assertThat(written.getDisplayOrder()).isEqualTo(3);
+        assertThat(written.getMultiLevelApprovalEnabled()).isFalse();
+    }
+
+    /**
+     * The payload a client sends when it serialises a form with every optional field cleared:
+     * the required three, and an explicit null everywhere else.
+     */
+    private LeavePolicyCreationDto everyOptionalFieldCleared() {
+        LeavePolicyCreationDto dto = new LeavePolicyCreationDto();
+        dto.setLeaveTypeCode("CASUAL");
+        dto.setLeaveTypeName("Casual leave");
+        dto.setAnnualQuota(12.0);
+        dto.setMinDaysPerRequest(null);
+        dto.setAdvanceNoticeDays(null);
+        dto.setRequiresAttachment(null);
+        dto.setApplicableGenders(null);
+        dto.setMinServiceMonths(null);
+        dto.setAllowHalfDay(null);
+        dto.setIsPaid(null);
+        dto.setDisplayOrder(null);
+        dto.setMultiLevelApprovalEnabled(null);
+        return dto;
+    }
+
+    private LeavePolicy theSavedPolicy() {
+        ArgumentCaptor<LeavePolicy> captor = ArgumentCaptor.forClass(LeavePolicy.class);
+        verify(policyRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}


### PR DESCRIPTION
Closes #741.

Eight items, six repaired and two left as contract decisions. Every claim below about live data was checked against the compose-monolith staging on `.116` with read-only SQL; nothing was written there.

## The two that produce rows the application cannot handle

**`inspection_defects.status` DEFAULT `'open'`.** `@Enumerated(STRING)` persists and reads the constant name, so any insert omitting the column wrote a row that throws `IllegalArgumentException` when its parent inspection loads. `054-05` uppercased the rows that existed and left the DEFAULT alone, so the clause has kept writing unreadable rows since.

*Bad rows on staging: none.* All 2 defect rows hold `OPEN`. The default is still wrong, so this is a latent break rather than a live one, and `054-05` is why: the only rows that could have been written through the default predate it. `094-01` re-runs the promotion anyway, because a row written between `054` and this change would have taken the broken default.

**`inspections.organization_id` nullable.** `orgFilter` cannot satisfy its predicate against a null row and `TenantIsolationLoadListener` denies one outright, so such an inspection is unreachable and undeletable through the tenant-scoped API while its NCRs and annotations still carry a real org id.

*Bad rows on staging: none.* 0 of 15 inspections have a null organization.

`094` sequences both: normalise, then correct the default, then constrain; and backfill `organization_id` from the inspection's own project, then constrain. Each tightening carries a `sqlCheck` precondition that HALTs rather than proceeding, matching how `054-04` and `054-05` guard theirs. Nothing is deleted: an inspection with no recoverable organization can only be placed by someone who knows which tenant it belonged to, and removing it would destroy the evidence needed to answer that.

## The behaviour bug

**`LeavePolicyService.createPolicy` overwrote entity defaults with payload nulls.** Nine fields: `minDaysPerRequest`, `advanceNoticeDays`, `requiresAttachment`, `applicableGenders`, `minServiceMonths`, `allowHalfDay`, `isPaid`, `displayOrder`, and `multiLevelApprovalEnabled` (which already had the guard, spelled as an `if`). The column default never applied either, because a default fills an absent column and the insert named it.

The trigger is narrower than it first reads: `LeavePolicyCreationDto` carries the same initialisers, so a body that omits the field never reaches this. It takes an explicit JSON null, which is what a client sends when it serialises a form with the field cleared.

*Policies affected on staging: none.* All 4 rows are clean in all eight columns.

`duplicatePolicy` takes the same guard, so a policy written before this cannot copy its nulls into another organization.

## The isolation half of the naming defects

`handoverToName` was resolved with `employeeRepository.findById`, the one access `orgFilter` never narrows, while every other employee lookup in the service is scoped. It is **not** a live leak: `TenantIsolationLoadListener` denies the foreign row at the load boundary. The cost of leaning on that is that its denial is an exception, so the whole request-detail read fails where one optional name could not be resolved. Now scoped, and the read carries on with the name unresolved.

## Left alone, deliberately

The three names that are structurally always null (`delegatedFromName`, `createdByName`, `handoverToName`) stay unpopulated. Something else does carry the data: `delegatedFromId`, `createdById` and `handoverToId` are all published beside them, and each name's own `@Schema` description already directs the client to resolve from the id. Populating them means enriching fourteen read paths plus a nested list (`LeaveRequestDto.approvals` carries `LeaveApprovalDto`), which is a feature and an N+1 design decision; removing them from a hand-maintained contract breaks web at runtime rather than at compile time. Both are decisions for the contract owners, so `ReviewedResponseSchemas` records the outcome instead.

The five entities whose `@JoinColumn` permitted a null the column refuses now agree with the schema. Nothing depended on the disagreement and the build catches neither direction of it.

`035-relax-inspection-not-null-for-ai-rows` is untouched. Its constraints sit on the request DTOs, not the rows.

## Tests

Pushed as their own commit ahead of the repair, and run against unrepaired `development` in #743 to measure the failures rather than assert them.

- `InspectionNullabilityRepairIT` inserts a defect naming every column except `status`, so the database answers rather than the field initialiser. Asserts the stored value, that the row then loads through the entity, and that both columns are `NOT NULL` in `information_schema`.
- `LeavePolicyDeclaredDefaultsTest` asserts the entity handed to the repository, for a payload of explicit nulls and for a duplicate of a policy that already holds them. A third case sends `false` and `0`, so a repair that fell back to the default on any falsy value would be caught.
- `LeaveHandoverNameIsReadInTenantTest` asserts the scoped lookup answers, and that the unscoped one is not consulted even when it would answer.

`InspectionTaxonomyMigrationIT` now seeds an organization, since its inspections were written without one.

The OpenAPI document is unchanged: no DTO, controller or `@Schema` was touched.